### PR TITLE
Fix #63: Could not find common.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         maven { url "https://jitpack.io" }
         maven { url "https://plugins.gradle.org/m2/" }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
Fix #63.

Move `jcenter()` repository to the end of the list as suggested here:
https://github.com/facebook/react-native/issues/19485#issuecomment-395882343