### PR TITLE
Fix crash which happens when a notification is received in AlarmReceiver.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -15,6 +15,10 @@ import nerd.tuxmobil.fahrplan.congress.extensions.getNotificationManager
 
 internal class NotificationHelper(context: Context) : ContextWrapper(context) {
 
+    private val notificationManager: NotificationManager by lazy {
+        getNotificationManager()
+    }
+
     init {
         createNotificationChannel(EVENT_ALARM_CHANNEL_ID, eventAlarmChannelName, eventAlarmChannelDescription)
         createNotificationChannel(SCHEDULE_UPDATE_CHANNEL_ID, scheduleUpdateChannelName, scheduleUpdateChannelDescription)
@@ -105,10 +109,6 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
 
     private val smallIcon: Int
         get() = R.drawable.ic_notification
-
-    private val notificationManager: NotificationManager by lazy {
-        getNotificationManager()
-    }
 
     companion object {
         private const val EVENT_ALARM_CHANNEL_ID = "EVENT_ALARM_CHANNEL"


### PR DESCRIPTION
+ The "notificationManager" property must be initialized before the "init"
  block is executed. Otherwise, the property is null when being accessed
  later such as in "createNotificationChannel".
+ Tested on:
  - Nexus 5X emulator, Android 9 (API 28)
  - Nexus 5X emulator, Android 8.1.0 (API 27)
  - Nexus 5X emulator, Android 8.0.0 (API 26)
  - Nexus 5X emulator, Android 7.1.1 (API 25)
  - Nexus 5 device, Android 6.0.1 (API 23)

Resolves #71.