### PR TITLE
No need to enable/disable the broadcast receiver as it is registered dynamically.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -58,7 +58,6 @@
         <service
                 android:name=".autoupdate.UpdateService"
                 android:exported="false"/>
-        <receiver android:name=".net.ConnectivityStateReceiver" />
         <activity
             android:name="nerd.tuxmobil.fahrplan.congress.changes.ChangeListActivity"
             android:theme="@style/Theme.Congress.NoActionBar"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -19,7 +19,6 @@ import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.MyApp.TASKS;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
-import nerd.tuxmobil.fahrplan.congress.net.ConnectivityStateReceiver;
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult;
 import nerd.tuxmobil.fahrplan.congress.net.HttpStatus;
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper;
@@ -118,7 +117,6 @@ public class UpdateService extends IntentService {
     protected void onHandleIntent(Intent intent) {
         if (!networkIsAvailable(this)) {
             MyApp.LogDebug(LOG_TAG, "Network is not available");
-            ConnectivityStateReceiver.enableReceiver(this);
             stopSelf();
             return;
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityStateReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityStateReceiver.java
@@ -1,12 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.net;
 
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.preference.PreferenceManager;
 import android.util.Log;
@@ -33,8 +31,6 @@ public class ConnectivityStateReceiver extends BroadcastReceiver {
 
         if (networkIsAvailable(context)) {
             Log.d(getClass().getName(), "Network is available.");
-
-            disableReceiver(context);
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             boolean defaultValue = context.getResources().getBoolean(R.bool.preferences_auto_update_enabled_default_value);
             boolean doAutoUpdates = prefs.getBoolean("auto_update", defaultValue);
@@ -44,32 +40,4 @@ public class ConnectivityStateReceiver extends BroadcastReceiver {
         }
     }
 
-    public static void disableReceiver(Context context) {
-        ComponentName receiver = new ComponentName(context, ConnectivityStateReceiver.class);
-        PackageManager manager = context.getPackageManager();
-        manager.setComponentEnabledSetting(receiver, PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-                PackageManager.DONT_KILL_APP);
-    }
-
-    public static void enableReceiver(Context context) {
-        ComponentName receiver = new ComponentName(context, ConnectivityStateReceiver.class);
-        PackageManager manager = context.getPackageManager();
-        manager.setComponentEnabledSetting(receiver, PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                PackageManager.DONT_KILL_APP);
-    }
-
-    public static boolean isEnabled(Context context) {
-        ComponentName receiver = new ComponentName(context, ConnectivityStateReceiver.class);
-        PackageManager manager = context.getPackageManager();
-        int enabled = manager.getComponentEnabledSetting(receiver);
-        switch (enabled) {
-            case PackageManager.COMPONENT_ENABLED_STATE_DEFAULT:
-            case PackageManager.COMPONENT_ENABLED_STATE_ENABLED:
-                return true;
-            case PackageManager.COMPONENT_ENABLED_STATE_DISABLED:
-            case PackageManager.COMPONENT_ENABLED_STATE_DISABLED_USER:
-            default:
-                return false;
-        }
-    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
@@ -19,7 +19,6 @@ import nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService;
 import nerd.tuxmobil.fahrplan.congress.dataconverters.AlarmExtensions;
 import nerd.tuxmobil.fahrplan.congress.models.Alarm;
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm;
-import nerd.tuxmobil.fahrplan.congress.net.ConnectivityStateReceiver;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 
@@ -60,10 +59,6 @@ public final class OnBootReceiver extends BroadcastReceiver {
                 MyApp.LogDebug(LOG_TAG, "Deleting alarm from database: " + alarm);
                 appRepository.deleteAlarmForAlarmId(alarm.getId());
             }
-        }
-
-        if (ConnectivityStateReceiver.isEnabled(context)) {
-            ConnectivityStateReceiver.disableReceiver(context);
         }
 
         // start auto updates


### PR DESCRIPTION
+ The intention was to be more energy-efficient. Disable the broadcast
  receiver if we're not interested in network change events. Because
  if we don't the app might get started to handle the broadcast
  even though there's no work to do. This is no longer an issue if
  we register the receiver dynamically.
+ Related:
  Register dynamically: f43886e0f21c3a6cbf69090c95021c2d8e018083
  Initial implementation: e5e8c2121eb05a157771c60b6a33cd6820ed81b1