### PR TITLE
Fix crash when EventDetailFragment attempts to be load with an non existing "event_id".

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.java
@@ -21,9 +21,13 @@ public abstract class AbstractListFragment extends ListFragment {
      * fragment to allow an interaction in this fragment to be communicated
      * to the activity and potentially other fragments contained in that
      * activity.
+     *
+     * @param lecture                The lecture which was clicked.
+     * @param requiresScheduleReload Boolean flag to indicate whether the schedule
+     *                               must be reload from the data source or not.
      */
     public interface OnLectureListClick {
-        void onLectureListClick(Lecture lecture);
+        void onLectureListClick(Lecture lecture, boolean requiresScheduleReload);
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.java
@@ -10,6 +10,7 @@ import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment;
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity;
+import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.details.EventDetail;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 
@@ -27,16 +28,26 @@ public class ChangeListActivity extends BaseActivity implements
         int actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(actionBarColor));
 
+        boolean requiresScheduleReload = false;
+        Intent intent = getIntent();
+        if (intent != null) {
+            Bundle extras = intent.getExtras();
+            if (extras != null) {
+                requiresScheduleReload = extras.getBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD, false);
+            }
+        }
+
         if (savedInstanceState == null) {
-            addFragment(R.id.container, new ChangeListFragment(), ChangeListFragment.FRAGMENT_TAG);
+            ChangeListFragment fragment = ChangeListFragment.newInstance(false, requiresScheduleReload);
+            addFragment(R.id.container, fragment, ChangeListFragment.FRAGMENT_TAG);
             MyApp.LogDebug(LOG_TAG, "onCreate fragment created");
         }
     }
 
     @Override
-    public void onLectureListClick(Lecture lecture) {
+    public void onLectureListClick(Lecture lecture, boolean requiresScheduleReload) {
         if (lecture != null) {
-            EventDetail.startForResult(this, lecture, lecture.day);
+            EventDetail.startForResult(this, lecture, lecture.day, requiresScheduleReload);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -37,6 +37,7 @@ public class ChangeListFragment extends AbstractListFragment {
     private OnLectureListClick mListener;
     private List<Lecture> changesList;
     private boolean sidePane = false;
+    private boolean requiresScheduleReload = false;
 
     /**
      * The fragment's ListView/GridView.
@@ -49,10 +50,11 @@ public class ChangeListFragment extends AbstractListFragment {
      */
     private LectureChangesArrayAdapter mAdapter;
 
-    public static ChangeListFragment newInstance(boolean sidePane) {
+    public static ChangeListFragment newInstance(boolean sidePane, boolean requiresScheduleReload) {
         ChangeListFragment fragment = new ChangeListFragment();
         Bundle args = new Bundle();
         args.putBoolean(BundleKeys.SIDEPANE, sidePane);
+        args.putBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD, requiresScheduleReload);
         fragment.setArguments(args);
         return fragment;
     }
@@ -71,6 +73,7 @@ public class ChangeListFragment extends AbstractListFragment {
         Bundle args = getArguments();
         if (args != null) {
             sidePane = args.getBoolean(BundleKeys.SIDEPANE);
+            requiresScheduleReload = args.getBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD);
         }
 
         FragmentActivity activity = getActivity();
@@ -142,7 +145,7 @@ public class ChangeListFragment extends AbstractListFragment {
             position--;
             Lecture clicked = changesList.get(mAdapter.getItemIndex(position));
             if (clicked.changedIsCanceled) return;
-            mListener.onLectureListClick(clicked);
+            mListener.onLectureListClick(clicked, requiresScheduleReload);
         }
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
@@ -31,9 +31,10 @@ public class ChangesDialog extends DialogFragment {
     private int cancelled;
     private int markedAffected;
     private String version;
+    private boolean requiresScheduleReload = false;
 
     public static ChangesDialog newInstance(String version, int changed, int added,
-                                            int cancelled, int marked) {
+                                            int cancelled, int marked, boolean requiresScheduleReload) {
         ChangesDialog dialog = new ChangesDialog();
         Bundle args = new Bundle();
         args.putInt(BundleKeys.CHANGES_DLG_NUM_CHANGED, changed);
@@ -41,6 +42,7 @@ public class ChangesDialog extends DialogFragment {
         args.putInt(BundleKeys.CHANGES_DLG_NUM_CANCELLED, cancelled);
         args.putInt(BundleKeys.CHANGES_DLG_NUM_MARKED, marked);
         args.putString(BundleKeys.CHANGES_DLG_VERSION, version);
+        args.putBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD, requiresScheduleReload);
         dialog.setArguments(args);
         dialog.setCancelable(false);
         return dialog;
@@ -56,6 +58,7 @@ public class ChangesDialog extends DialogFragment {
             cancelled = args.getInt(BundleKeys.CHANGES_DLG_NUM_CANCELLED);
             markedAffected = args.getInt(BundleKeys.CHANGES_DLG_NUM_MARKED);
             version = args.getString(BundleKeys.CHANGES_DLG_VERSION);
+            requiresScheduleReload = args.getBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD);
         }
     }
 
@@ -95,7 +98,7 @@ public class ChangesDialog extends DialogFragment {
         flagChangesAsSeen();
         FragmentActivity activity = getActivity();
         if (activity instanceof MainActivity) {
-            ((MainActivity) activity).openLectureChanges();
+            ((MainActivity) activity).openLectureChanges(requiresScheduleReload);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -38,6 +38,10 @@ public interface BundleKeys {
     String SIDEPANE =
             "nerd.tuxmobil.fahrplan.congress.SIDEPANE";
 
+    // Schedule reload
+    String REQUIRES_SCHEDULE_RELOAD =
+            "nerd.tuxmobil.fahrplan.congress.REQUIRES_SCHEDULE_RELOAD";
+
     // Changes dialog
     String CHANGES_DLG_NUM_CHANGED =
             "nerd.tuxmobil.fahrplan.congress.ChangesDialog.NUM_CHANGES";

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetail.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetail.java
@@ -23,7 +23,8 @@ public class EventDetail extends BaseActivity {
 
     public static void startForResult(@NonNull Activity activity,
                                       @NonNull Lecture lecture,
-                                      int lectureDay) {
+                                      int lectureDay,
+                                      boolean requiresScheduleReload) {
         Intent intent = new Intent(activity, EventDetail.class);
         intent.putExtra(BundleKeys.EVENT_TITLE, lecture.title);
         intent.putExtra(BundleKeys.EVENT_SUBTITLE, lecture.subtitle);
@@ -35,6 +36,7 @@ public class EventDetail extends BaseActivity {
         intent.putExtra(BundleKeys.EVENT_TIME, lecture.startTime);
         intent.putExtra(BundleKeys.EVENT_DAY, lectureDay);
         intent.putExtra(BundleKeys.EVENT_ROOM, lecture.room);
+        intent.putExtra(BundleKeys.REQUIRES_SCHEDULE_RELOAD, requiresScheduleReload);
         activity.startActivityForResult(intent, MyApp.EVENTVIEW);
     }
 
@@ -74,6 +76,8 @@ public class EventDetail extends BaseActivity {
                     intent.getIntExtra(BundleKeys.EVENT_DAY, 0));
             args.putString(BundleKeys.EVENT_ROOM,
                     intent.getStringExtra(BundleKeys.EVENT_ROOM));
+            args.putBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD,
+                    intent.getBooleanExtra(BundleKeys.REQUIRES_SCHEDULE_RELOAD, false));
             eventDetailFragment.setArguments(args);
             replaceFragment(R.id.detail, eventDetailFragment,
                     EventDetailFragment.FRAGMENT_TAG);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.java
@@ -38,9 +38,9 @@ public class StarredListActivity extends BaseActivity implements
     }
 
     @Override
-    public void onLectureListClick(Lecture lecture) {
+    public void onLectureListClick(Lecture lecture, boolean requiresScheduleReload) {
         if (lecture != null) {
-            EventDetail.startForResult(this, lecture, lecture.day);
+            EventDetail.startForResult(this, lecture, lecture.day, requiresScheduleReload);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -190,7 +190,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
             // fragment is attached to one) that an item has been selected.
             position--;
             Lecture clicked = starredList.get(mAdapter.getItemIndex(position));
-            mListener.onLectureListClick(clicked);
+            mListener.onLectureListClick(clicked, false);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -279,7 +279,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             FrameLayout sidePane = getActivity().findViewById(R.id.detail);
             if (sidePane != null) {
                 Lecture lecture = LectureUtils.getLecture(MyApp.lectureList, lecture_id);
-                ((MainActivity) getActivity()).openLectureDetail(lecture, mDay);
+                ((MainActivity) getActivity()).openLectureDetail(lecture, mDay, false);
             }
             intent.removeExtra("lecture_id");   // jump to given lecture_id only once
         }
@@ -777,7 +777,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         MyApp.LogDebug(LOG_TAG, "Click on " + lecture.title);
         MainActivity main = (MainActivity) getActivity();
         if (main != null) {
-            main.openLectureDetail(lecture, mDay);
+            main.openLectureDetail(lecture, mDay, false);
         }
     }
 


### PR DESCRIPTION
+ The crash happens when:
  1. Schedule changes are retrieved
  2. The user browses the list of changes
  3. And taps an item which is new.
+ To communicate that new schedule items might be retrieved the
  `requiresScheduleReload = true` flag is passed from where schedule changes
   are known to be present to the actual rendering screen of the event.
   MainActivity.showChangesDialog() -> ChangesDialog -> EventDetailFragment.

Resolves #81.