### PR TITLE
Fixed broken time column

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
@@ -1,5 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
+import android.support.annotation.VisibleForTesting
+import nerd.tuxmobil.fahrplan.congress.utils.DateHelper
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
 data class Conference(
@@ -54,20 +56,25 @@ data class Conference(
         }
         if (end > 0) {
             lastEventEndsAt = minutesOfDay(end)
-            if (lastEventEndsBeforeFirstEventStarts()) {
+            if (isDaySwitch(firstEventDateUtc, end)) {
                 forwardLastEventEndsAtByOneDay()
             }
         }
     }
 
-    private fun lastEventEndsBeforeFirstEventStarts() = lastEventEndsAt < firstEventStartsAt
+    private fun isDaySwitch(startUtc: Long, endUtc: Long): Boolean {
+        val startDay = DateHelper.getDayOfMonth(startUtc)
+        val endDay = DateHelper.getDayOfMonth(endUtc)
+        return startDay != endDay
+    }
 
     private fun forwardLastEventEndsAtByOneDay() {
         lastEventEndsAt += ONE_DAY
     }
 
     companion object {
-        private const val ONE_DAY = 24 * 60
+        @VisibleForTesting
+        const val ONE_DAY = 24 * 60
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/DateHelper.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/DateHelper.java
@@ -4,8 +4,10 @@ import android.text.format.Time;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 public class DateHelper {
 
@@ -51,6 +53,12 @@ public class DateHelper {
         Time time = new Time();
         time.set(dateUtc);
         return time.hour * 60 + time.minute;
+    }
+
+    public static int getDayOfMonth(long dateUtc) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.setTimeInMillis(dateUtc);
+        return calendar.get(Calendar.DAY_OF_MONTH);
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -24,7 +24,7 @@ class ConferenceTest {
         with(Conference()) {
             calculateTimeFrame(listOf(opening, closing), ::minutesOfDay)
             assertThat(firstEventStartsAt).isEqualTo(1020) // -> 17:00
-            assertThat(lastEventEndsAt).isEqualTo(1035) // -> 17:15
+            assertThat(lastEventEndsAt).isEqualTo(1035 + Conference.ONE_DAY) // -> 17:15 + day switch
         }
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/DateHelperTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/DateHelperTest.kt
@@ -1,0 +1,22 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
+
+class DateHelperTest {
+
+    @Test
+    fun getDayOfMonthWithLeapYearDay() {
+        // Thursday, February 28, 2019 11:59:59 PM UTC
+        assertThat(DateHelper.getDayOfMonth(1551312000000)).isEqualTo(28)
+    }
+
+    @Test
+    fun getDayOfMonthWithDayAfterLeapYear() {
+        // Friday, March 1, 2019 12:00:00 AM UTC
+        assertThat(DateHelper.getDayOfMonth(1551398400000)).isEqualTo(1)
+    }
+
+}


### PR DESCRIPTION
Fixes Issue #93 

My first guess (wrong timezone) was wrong. The real problem was when to call `forwardLastEventEndsAtByOneDay()`. On day 2 the first time slot starts as `00:00` and the last slot ends at 6:00 on the next day. So the old method thought it's OK because end is bigger than start, it doesn't recognizes that there was a day in between.