### PR TITLE
Issue 42 - Stay at current scroll position when going back from details

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -262,11 +262,6 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             saveCurrentDay(mDay);
         }
 
-        if (MyApp.meta.getNumDays() != 0) {
-            // auf jeden Fall reload, wenn mit Lecture ID gestartet
-            viewDay(lecture_id != null);
-        }
-
         Log.d(LOG_TAG, "MyApp.task_running = " + MyApp.task_running);
         switch (MyApp.task_running) {
             case FETCH:
@@ -326,7 +321,10 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             int roomIndex = MyApp.roomList.get(i);
             fillRoom(roomView, roomIndex, MyApp.lectureList, boxHeight);
         }
-        scrollToCurrent(mDay, boxHeight);
+        MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
+            scrollToCurrent(mDay, boxHeight);
+            return null;
+        });
         updateNavigationMenuSelection();
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -30,6 +30,8 @@ import org.ligi.tracedroid.logging.Log;
 
 import java.util.List;
 
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
 import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.MyApp.TASKS;
 import nerd.tuxmobil.fahrplan.congress.R;
@@ -73,6 +75,7 @@ public class MainActivity extends BaseActivity implements
 
     private ProgressBar progressBar = null;
     private boolean requiresScheduleReload = false;
+    private boolean shouldScrollToCurrent = true;
     private boolean showUpdateAction = true;
     private static MainActivity instance;
 
@@ -397,6 +400,10 @@ public class MainActivity extends BaseActivity implements
         switch (requestCode) {
             case MyApp.ALARMLIST:
             case MyApp.EVENTVIEW:
+                if (resultCode == Activity.RESULT_CANCELED) {
+                    shouldScrollToCurrent = false;
+                }
+                break;
             case MyApp.CHANGELOG:
             case MyApp.STARRED:
                 if (resultCode == Activity.RESULT_OK) {
@@ -508,6 +515,13 @@ public class MainActivity extends BaseActivity implements
 
     @Override
     public void onDenied(int dlgRequestCode) {
+    }
+
+    public void shouldScheduleScrollToCurrentTimeSlot(Function0<Unit> scrollToInstructions) {
+        if (shouldScrollToCurrent) {
+            scrollToInstructions.invoke();
+        }
+        shouldScrollToCurrent = true;
     }
 
     public static MainActivity getInstance() {


### PR DESCRIPTION
These changes will fix the back navigation issue. I've tested it on several devices and emulator images and it worked well. 
I couldn't find a reason for the duplication of 
``` java
if (MyApp.meta.getNumDays() != 0) {
   // auf jeden Fall reload, wenn mit Lecture ID gestartet
   viewDay(lecture_id != null);
}
```
in `onResume()` in `FahrplanFragment` so I removed one call, as the dupication made it hard to reliably check if we want to scroll to the current time frame or not. Feel free to suggest adjustments.

Resolves #42.