### PR TITLE
Prevent IllegalStateException when zombie lecture is tapped in favorites.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -274,6 +274,9 @@ public class FahrplanMisc {
             if (!l.highlight) {
                 starredList.remove(l);
             }
+            if (l.changedIsCanceled) {
+                starredList.remove(l);
+            }
             lectureIndex--;
         }
         MyApp.LogDebug(LOG_TAG, starredList.size() + " lectures starred.");


### PR DESCRIPTION
+ Cancelled lectures are still present in the database. Just the "changed_is_cancelled" flag is set to "true".
+ Thanks to @bashtian for the debugging session.

Resolves #103.