### PR TITLE
Show app at the lock screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
@@ -8,6 +8,7 @@ import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 import nerd.tuxmobil.fahrplan.congress.net.ConnectivityStateReceiver;
 import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper;
@@ -15,6 +16,12 @@ import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper;
 public abstract class BaseActivity extends AppCompatActivity {
 
     private ConnectivityStateReceiver connectivityStateReceiver;
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {


### PR DESCRIPTION
- When the app is foreground and the device is locked users can still use the app.