### PR TITLE
Fix schedule feedback URL for Pretalx events.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -44,6 +44,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleLectureFormat;
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener;
 import nerd.tuxmobil.fahrplan.congress.utils.EventUrlComposer;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
+import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer;
 import nerd.tuxmobil.fahrplan.congress.utils.StringUtils;
 import nerd.tuxmobil.fahrplan.congress.wiki.WikiEventUtils;
 
@@ -367,7 +368,9 @@ public class EventDetailFragment extends Fragment {
         FragmentActivity activity = getActivity();
         switch (item.getItemId()) {
             case R.id.menu_item_feedback: {
-                Uri uri = Uri.parse(String.format(SCHEDULE_FEEDBACK_URL, event_id));
+                l = eventIdToLecture(event_id);
+                String feedbackUrl = new FeedbackUrlComposer(l, SCHEDULE_FEEDBACK_URL).getFeedbackUrl();
+                Uri uri = Uri.parse(feedbackUrl);
                 Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                 startActivity(intent);
                 return true;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
@@ -1,0 +1,6 @@
+package nerd.tuxmobil.fahrplan.congress.extensions
+
+import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
+
+val Event.originatesFromPretalx
+    get() = !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.endsWith(slug)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -14,13 +14,13 @@ class EventUrlComposer @JvmOverloads constructor(
 
     fun getEventUrl(): String = when (serverBackEndType) {
         PENTABARF.name -> getComposedEventUrl(event.slug)
-        FRAB.name -> event.eventUrl()
+        FRAB.name -> event.eventUrl
         PRETALX.name -> event.url
         else -> throw NotImplementedError("Unknown server backend type: '$serverBackEndType'")
     }
 
-    private fun Event.eventUrl() =
-            if (originatesFromPretalx()) url else getComposedEventUrl(lecture_id)
+    private val Event.eventUrl
+        get() = if (originatesFromPretalx()) url else getComposedEventUrl(lecture_id)
 
     private fun getComposedEventUrl(eventIdentifier: String) =
             String.format(eventUrlTemplate, eventIdentifier)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.extensions.originatesFromPretalx
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.*
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
@@ -20,12 +21,9 @@ class EventUrlComposer @JvmOverloads constructor(
     }
 
     private val Event.eventUrl
-        get() = if (originatesFromPretalx()) url else getComposedEventUrl(lecture_id)
+        get() = if (originatesFromPretalx) url else getComposedEventUrl(lecture_id)
 
     private fun getComposedEventUrl(eventIdentifier: String) =
             String.format(eventUrlTemplate, eventIdentifier)
-
-    private fun Event.originatesFromPretalx() =
-            !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.endsWith(slug)
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -1,0 +1,43 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.extensions.originatesFromPretalx
+import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
+
+class FeedbackUrlComposer(
+
+        private val event: Event,
+        private val frabScheduleFeedbackUrlFormatString: String = BuildConfig.SCHEDULE_FEEDBACK_URL
+
+) {
+
+    /**
+     * Returns the feedback URL for the [event] if it can be composed
+     * otherwise an empty string.
+     *
+     * The [Frab schedule feedback URL][frabScheduleFeedbackUrl] is
+     * composed from the event id. Currently, events extracted from
+     * the wiki of the Chaos Communication Congress cannot be
+     * distinguished from regular Frab events. Therefore, visiting the
+     * resulting schedule feedback URL results in an HTTP 404 error.
+     */
+    fun getFeedbackUrl() = if (event.originatesFromPretalx) {
+        event.pretalxScheduleFeedbackUrl
+    } else {
+        event.frabScheduleFeedbackUrl
+    }
+
+    private val Event.frabScheduleFeedbackUrl
+        get() =
+            if (frabScheduleFeedbackUrlFormatString.isEmpty()) NO_URL
+            else String.format(frabScheduleFeedbackUrlFormatString, lecture_id)
+
+    private val Event.pretalxScheduleFeedbackUrl
+        get() = "$url$PRETALX_SCHEDULE_FEEDBACK_URL_SUFFIX"
+
+    companion object {
+        private const val NO_URL = ""
+        private const val PRETALX_SCHEDULE_FEEDBACK_URL_SUFFIX = "/feedback/"
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -1,0 +1,43 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
+
+class FeedbackUrlComposerTest {
+
+    companion object {
+
+        private const val FRAB_SCHEDULE_FEEDBACK_URL = "https://frab.cccv.de/en/35C3/public/events/%s/feedback/new"
+
+        private val FRAB_EVENT = Event("9985").apply {
+            url = "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html"
+            slug = "35c3-9985-opening_ceremony"
+        }
+
+        private val PRETALX_EVENT = Event("32").apply {
+            url = "https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB"
+            slug = "KDYQEB"
+        }
+
+    }
+
+    @Test
+    fun getFeedbackUrlWithFrabEventWithoutScheduleFeedbackUrl() {
+        assertThat(FeedbackUrlComposer(FRAB_EVENT, "")
+                .getFeedbackUrl()).isEmpty()
+    }
+
+    @Test
+    fun getFeedbackUrlWithFrabEventWithFrabScheduleFeedbackUrl() {
+        assertThat(FeedbackUrlComposer(FRAB_EVENT, FRAB_SCHEDULE_FEEDBACK_URL)
+                .getFeedbackUrl()).isEqualTo("https://frab.cccv.de/en/35C3/public/events/9985/feedback/new")
+    }
+
+    @Test
+    fun getFeedbackUrlWithPretalxEventWithFrabScheduleFeedbackUrl() {
+        assertThat(FeedbackUrlComposer(PRETALX_EVENT, FRAB_SCHEDULE_FEEDBACK_URL)
+                .getFeedbackUrl()).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB/feedback/")
+    }
+
+}


### PR DESCRIPTION
+ Please note that for events extracted from the wiki of the CCC still an invalid URL is generated. The schedule file needs to provide additional attributes to distinguish wiki events from generic events. This needs to be discussed with the @voc up-front.

@saerdnaer, @raphaelm, @rixx FYI