### PR TITLE
Let users visually distinguish between past and upcoming favorites.

### DIFF
--- a/app/src/ccc35c3/res/values/colors.xml
+++ b/app/src/ccc35c3/res/values/colors.xml
@@ -25,7 +25,4 @@
     <!-- About -->
     <color name="about_horizontal_line">#4d4d4c</color>
 
-    <!-- Favorites -->
-    <color name="favorites_past_event_text">#4d4d4c</color>
-
 </resources>


### PR DESCRIPTION
+ The default value for "favorites_past_event_text" has a higher contrast
  in relation to the default text color which is used for upcoming favorites.

# Favorites with bad (left) and improved (right) contrast

![favorites-before](https://user-images.githubusercontent.com/144518/50564537-e648ea00-0d25-11e9-8507-3eb73574a0e5.png) ![favorites-after](https://user-images.githubusercontent.com/144518/50564542-ea750780-0d25-11e9-8c40-12f92843a6a9.png)



