### PR TITLE
Provide notifications settings shortcut in app settings.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -1,13 +1,19 @@
 package nerd.tuxmobil.fahrplan.congress.settings;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
 import android.os.Bundle;
+import android.preference.Preference;
+import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 
@@ -62,6 +68,16 @@ public class SettingsActivity extends BaseActivity {
                         return true;
                     });
 
+            Preference appNotificationSettingsPreference = findPreference(getString(R.string.preference_key_app_notification_settings));
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                PreferenceCategory categoryGeneral = (PreferenceCategory) findPreference(getString(R.string.preference_key_category_general));
+                categoryGeneral.removePreference(appNotificationSettingsPreference);
+            } else {
+                appNotificationSettingsPreference.setOnPreferenceClickListener(preference -> {
+                    launchAppNotificationSettings(preference.getContext());
+                    return true;
+                });
+            }
 
             findPreference("schedule_url")
                     .setOnPreferenceChangeListener((preference, newValue) -> {
@@ -118,5 +134,13 @@ public class SettingsActivity extends BaseActivity {
             }
             return defaultAlarmTimeValue;
         }
+
+        @TargetApi(Build.VERSION_CODES.O)
+        private void launchAppNotificationSettings(Context context) {
+            Intent intent = new Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.getPackageName());
+            startActivity(intent);
+        }
+
     }
 }

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- App notification settings -->
+    <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen &#8230;</string>
+
+</resources>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Category general -->
+    <string name="preference_key_category_general" translatable="false">preference_key_category_general</string>
+
+    <!-- App notification settings -->
+    <string name="preference_key_app_notification_settings" translatable="false">app_notification_settings</string>
+    <string name="preference_title_app_notification_settings">Customize notifications &#8230;</string>
+
+</resources>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory android:title="@string/general_settings">
+    <PreferenceCategory
+        android:key="@string/preference_key_category_general"
+        android:title="@string/general_settings">
 
         <CheckBoxPreference
             android:defaultValue="@bool/preferences_auto_update_enabled_default_value"
             android:key="auto_update"
             android:title="@string/pref_auto_download" />
+
+        <Preference
+            android:key="@string/preference_key_app_notification_settings"
+            android:title="@string/preference_title_app_notification_settings" />
 
         <EditTextPreference
             android:defaultValue="@string/preferences_schedule_url_default_value"


### PR DESCRIPTION
# Before
- Users need to find the notification settings for the app in the system settings.
- There is no shortcut in the app settings.
  ![settings-without-shortcut](https://user-images.githubusercontent.com/144518/51022199-eba6ff80-1583-11e9-93ff-c73496a21142.png)

# After
- Users with devices running Android Oreo (8.0), API 26 or higher can use a shortcut in the app settings to quickly reach the notification settings for the app in the system settings.
- There is a `Customize notifications ...` shortcut in the app settings.
  ![settings-with-shortcut](https://user-images.githubusercontent.com/144518/51022215-f792c180-1583-11e9-8b83-60a844a97bea.png)

Resolves #121.
Relates to #104 and #106.