### PR TITLE
Use targetSdkVersion 27 (Oreo)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # Note that the tools section appears twice on purpose as it’s required
     # to get the newest Android SDK tools. Source: Travis CI docs.
     - build-tools-28.0.3
-    - android-26
+    - android-27
 
     # The libraries we can't get from Maven Central or similar
     - extra

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.about;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.content.ContextCompat;
@@ -20,9 +21,9 @@ import nerd.tuxmobil.fahrplan.congress.R;
 public class AboutDialog extends DialogFragment {
 
     @Override
-    public View onCreateView(LayoutInflater inflater,
-                             ViewGroup container,
-                             Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.about_dialog, container, false);
     }
 
@@ -33,7 +34,7 @@ public class AboutDialog extends DialogFragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         TextView text = view.findViewById(R.id.eventVersion);
         text.setText(getString(R.string.fahrplan) + " " + MyApp.meta.getVersion());

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java
@@ -41,7 +41,7 @@ public class AlarmTimePickerFragment extends DialogFragment {
                             int requestCode) {
         DialogFragment dialogFragment = new AlarmTimePickerFragment();
         dialogFragment.setTargetFragment(invokingFragment, requestCode);
-        FragmentActivity activity = invokingFragment.getActivity();
+        FragmentActivity activity = invokingFragment.requireActivity();
         FragmentManager fragmentManager = activity.getSupportFragmentManager();
         dialogFragment.show(fragmentManager, FRAGMENT_TAG);
     }
@@ -49,17 +49,17 @@ public class AlarmTimePickerFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Context activity = getActivity();
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(activity);
-        int defaultAlarmTimeIndex = activity.getResources().getInteger(R.integer.default_alarm_time_index);
+        Context context = requireContext();
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        int defaultAlarmTimeIndex = context.getResources().getInteger(R.integer.default_alarm_time_index);
         alarmTimeIndex = prefs.getInt(BundleKeys.PREFS_ALARM_TIME_INDEX, defaultAlarmTimeIndex);
-        LayoutInflater inflater = Contexts.getLayoutInflater(activity);
+        LayoutInflater inflater = Contexts.getLayoutInflater(context);
         @SuppressLint("InflateParams")
         View layout = inflater.inflate(R.layout.reminder_dialog, null, false);
         // https://possiblemobile.com/2013/05/layout-inflation-as-intended/
         initializeSpinner(layout);
 
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(activity);
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
         dialogBuilder
                 .setView(layout)
                 .setTitle(R.string.choose_alarm_time)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.changes;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.v4.app.FragmentActivity;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -77,11 +76,11 @@ public class ChangeListFragment extends AbstractListFragment {
             requiresScheduleReload = args.getBoolean(BundleKeys.REQUIRES_SCHEDULE_RELOAD);
         }
 
-        FragmentActivity activity = getActivity();
-        AppRepository appRepository = AppRepository.Companion.getInstance(activity);
+        Context context = requireContext();
+        AppRepository appRepository = AppRepository.Companion.getInstance(context);
         changesList = FahrplanMisc.readChanges(appRepository);
         Meta meta = appRepository.readMeta();
-        mAdapter = new LectureChangesArrayAdapter(activity, changesList, meta.getNumDays());
+        mAdapter = new LectureChangesArrayAdapter(context, changesList, meta.getNumDays());
         MyApp.LogDebug(LOG_TAG, "onCreate, " + changesList.size() + " changes");
     }
 
@@ -89,7 +88,7 @@ public class ChangeListFragment extends AbstractListFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
-        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(),
+        final Context contextThemeWrapper = new ContextThemeWrapper(requireContext(),
                 R.style.Theme_AppCompat_Light);
 
         LayoutInflater localInflater = inflater.cloneInContext(contextThemeWrapper);
@@ -130,7 +129,7 @@ public class ChangeListFragment extends AbstractListFragment {
     }
 
     public void onRefresh() {
-        AppRepository appRepository = AppRepository.Companion.getInstance(getActivity());
+        AppRepository appRepository = AppRepository.Companion.getInstance(requireContext());
         List<Lecture> updatedChanges = FahrplanMisc.readChanges(appRepository);
         if (changesList != null) {
             changesList.clear();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
@@ -9,7 +9,6 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.text.Spannable;
@@ -66,7 +65,7 @@ public class ChangesDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        Activity activity = getActivity();
+        Activity activity = requireActivity();
         AlertDialog.Builder builder = new AlertDialog.Builder(activity)
                 .setTitle(getString(R.string.schedule_changes_dialog_title))
                 .setPositiveButton(R.string.schedule_changes_dialog_browse, (dialog, which) -> onBrowse())
@@ -97,7 +96,7 @@ public class ChangesDialog extends DialogFragment {
 
     private void onBrowse() {
         flagChangesAsSeen();
-        FragmentActivity activity = getActivity();
+        Activity activity = requireActivity();
         if (activity instanceof MainActivity) {
             ((MainActivity) activity).openLectureChanges(requiresScheduleReload);
         }
@@ -108,7 +107,7 @@ public class ChangesDialog extends DialogFragment {
     }
 
     private void flagChangesAsSeen() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
         SharedPreferences.Editor edit = prefs.edit();
         edit.putBoolean(BundleKeys.PREFS_CHANGES_SEEN, true);
         edit.commit();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -108,9 +108,9 @@ public class EventDetailFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater,
-                             ViewGroup container,
-                             Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         if (sidePane) {
             return inflater.inflate(R.layout.detail_narrow, container, false);
         } else {
@@ -136,7 +136,7 @@ public class EventDetailFragment extends Fragment {
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         FragmentActivity activity = getActivity();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -1,6 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.details;
 
-import android.content.Context;
+import android.app.Activity;
 import android.content.Intent;
 import android.content.res.AssetManager;
 import android.graphics.Typeface;
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.TextUtils;
@@ -139,7 +138,7 @@ public class EventDetailFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        FragmentActivity activity = getActivity();
+        Activity activity = requireActivity();
         if (hasArguments) {
             AssetManager assetManager = activity.getAssets();
             boldCondensed = Typeface.createFromAsset(assetManager, "Roboto-BoldCondensed.ttf");
@@ -245,7 +244,7 @@ public class EventDetailFragment extends Fragment {
 
             activity.invalidateOptionsMenu();
         }
-        activity.setResult(FragmentActivity.RESULT_CANCELED);
+        activity.setResult(Activity.RESULT_CANCELED);
     }
 
     private void setUpTextView(@NonNull TextView textView,
@@ -319,7 +318,7 @@ public class EventDetailFragment extends Fragment {
 
     @NonNull
     private String getRoomConvertedForC3Nav() {
-        String currentRoom = getActivity().getIntent().getStringExtra(BundleKeys.EVENT_ROOM);
+        String currentRoom = requireActivity().getIntent().getStringExtra(BundleKeys.EVENT_ROOM);
         if (currentRoom == null) {
             currentRoom = room;
         }
@@ -336,7 +335,7 @@ public class EventDetailFragment extends Fragment {
                 return lecture;
             }
         }
-        Lecture lecture = AppRepository.Companion.getInstance(getActivity()).readLectureByLectureId(eventId);
+        Lecture lecture = AppRepository.Companion.getInstance(requireContext()).readLectureByLectureId(eventId);
         Log.d(LOG_TAG, lecture.lecture_id + ": " + lecture.getChangedStateString());
         throw new IllegalStateException("Lecture list does not contain eventId: " + eventId + ", lecture: " + lecture.getChangedStateString());
     }
@@ -357,7 +356,7 @@ public class EventDetailFragment extends Fragment {
     }
 
     private void onAlarmTimesIndexPicked(int alarmTimesIndex) {
-        FragmentActivity activity = getActivity();
+        Activity activity = requireActivity();
         if (lecture != null) {
             FahrplanMisc.addAlarm(activity, lecture, alarmTimesIndex);
         } else {
@@ -368,7 +367,7 @@ public class EventDetailFragment extends Fragment {
 
     public boolean onOptionsItemSelected(MenuItem item) {
         Lecture l;
-        FragmentActivity activity = getActivity();
+        Activity activity = requireActivity();
         switch (item.getItemId()) {
             case R.id.menu_item_feedback: {
                 l = eventIdToLecture(event_id);
@@ -381,9 +380,8 @@ public class EventDetailFragment extends Fragment {
             case R.id.menu_item_share_event:
                 l = eventIdToLecture(event_id);
                 String formattedLecture = SimpleLectureFormat.format(l);
-                Context context = getContext();
-                if (!LectureSharer.shareSimple(context, formattedLecture)) {
-                    Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show();
+                if (!LectureSharer.shareSimple(activity, formattedLecture)) {
+                    Toast.makeText(activity, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show();
                 }
                 return true;
             case R.id.menu_item_add_to_calendar:
@@ -393,14 +391,14 @@ public class EventDetailFragment extends Fragment {
             case R.id.menu_item_flag_as_favorite:
                 if (lecture != null) {
                     lecture.highlight = true;
-                    AppRepository.Companion.getInstance(getActivity()).updateHighlight(lecture);
+                    AppRepository.Companion.getInstance(activity).updateHighlight(lecture);
                 }
                 refreshUI(activity);
                 return true;
             case R.id.menu_item_unflag_as_favorite:
                 if (lecture != null) {
                     lecture.highlight = false;
-                    AppRepository.Companion.getInstance(getActivity()).updateHighlight(lecture);
+                    AppRepository.Companion.getInstance(activity).updateHighlight(lecture);
                 }
                 refreshUI(activity);
                 return true;
@@ -414,7 +412,7 @@ public class EventDetailFragment extends Fragment {
                 refreshUI(activity);
                 return true;
             case R.id.menu_item_close_event_details:
-                closeFragment(FRAGMENT_TAG);
+                closeFragment(activity, FRAGMENT_TAG);
                 return true;
             case R.id.menu_item_navigate:
                 final Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -426,16 +424,15 @@ public class EventDetailFragment extends Fragment {
         return super.onOptionsItemSelected(item);
     }
 
-    private void refreshUI(@NonNull FragmentActivity activity) {
+    private void refreshUI(@NonNull Activity activity) {
         activity.invalidateOptionsMenu();
-        activity.setResult(FragmentActivity.RESULT_OK);
+        activity.setResult(Activity.RESULT_OK);
         if (activity instanceof FahrplanFragment.OnRefreshEventMarkers) {
             ((FahrplanFragment.OnRefreshEventMarkers) activity).refreshEventMarkers();
         }
     }
 
-    private void closeFragment(@NonNull String fragmentTag) {
-        FragmentActivity activity = getActivity();
+    private void closeFragment(@NonNull Activity activity, @NonNull String fragmentTag) {
         if (activity instanceof OnSidePaneCloseListener) {
             ((OnSidePaneCloseListener) activity).onSidePaneClose(fragmentTag);
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.text.format.Time;
@@ -248,7 +247,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
             case R.id.menu_item_delete_favorite:
                 deleteItems(mListView.getCheckedItemPositions());
                 Activity activity = requireActivity();
-                ActivityCompat.invalidateOptionsMenu(activity);
+                activity.invalidateOptionsMenu();
                 refreshViews(activity);
                 mode.finish();
                 return true;
@@ -314,7 +313,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
             deleteItem(0);
         }
         Activity activity = requireActivity();
-        ActivityCompat.invalidateOptionsMenu(activity);
+        activity.invalidateOptionsMenu();
         refreshViews(activity);
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CertificateDialogFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CertificateDialogFragment.java
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.net;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
@@ -110,13 +111,14 @@ public class CertificateDialogFragment extends DialogFragment {
             chainInfo.append("SHA1 Fingerprint: " + getFingerPrint(chain[i])).append("\n");
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+        Activity activity = requireActivity();
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity)
                 .setTitle(getString(R.string.dlg_invalid_certificate_title))
                 .setCancelable(true)
                 .setPositiveButton(getString(android.R.string.yes), (dialog, which) -> onConfirm())
                 .setNegativeButton(getString(android.R.string.no), null);
 
-        LayoutInflater inflater = getActivity().getLayoutInflater();
+        LayoutInflater inflater = activity.getLayoutInflater();
         View msgView = inflater.inflate(R.layout.cert_dialog, null);
         TextView messageView = msgView.findViewById(R.id.cert);
         String message = getString(R.string.dlg_certificate_message_fmt, exceptionMessage);
@@ -137,7 +139,7 @@ public class CertificateDialogFragment extends DialogFragment {
         } catch (CertificateException e) {
             String messageArguments = e.getMessage() == null ? "" : e.getMessage();
             AlertDialogHelper.showErrorDialog(
-                    getActivity(),
+                    requireContext(),
                     R.string.dlg_invalid_certificate_could_not_apply,
                     R.string.dlg_certificate_message_fmt,
                     messageArguments);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -175,14 +175,14 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater,
-                             ViewGroup container,
-                             Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater,
+                             @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.schedule, container, false);
     }
 
     @Override
-    public void onViewCreated(View view, Bundle savedInstanceState) {
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
         Context context = view.getContext();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.schedule;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -69,8 +70,6 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
 
         void refreshEventMarkers();
     }
-
-    private MyApp global;
 
     private static String LOG_TAG = "Fahrplan";
 
@@ -152,11 +151,11 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
+        context = requireContext();
         boldCondensed = Typeface.createFromAsset(
-                getActivity().getAssets(), "Roboto-BoldCondensed.ttf");
+                context.getAssets(), "Roboto-BoldCondensed.ttf");
         light = Typeface.createFromAsset(
-                getActivity().getAssets(), "Roboto-Light.ttf");
-        context = getActivity();
+                context.getAssets(), "Roboto-Light.ttf");
         Resources resources = getResources();
         eventDrawableInsetTop = resources.getDimensionPixelSize(
                 R.dimen.event_drawable_inset_top);
@@ -169,9 +168,9 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         eventDrawableStrokeWidth = resources.getDimensionPixelSize(
                 R.dimen.event_drawable_selection_stroke_width);
         eventDrawableStrokeColor = ContextCompat.getColor(
-                context, R.color.event_drawable_selection_stroke);
+                FahrplanFragment.context, R.color.event_drawable_selection_stroke);
         eventDrawableRippleColor = ContextCompat.getColor(
-                context, R.color.event_drawable_ripple);
+                FahrplanFragment.context, R.color.event_drawable_ripple);
     }
 
     @Override
@@ -186,7 +185,6 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         super.onViewCreated(view, savedInstanceState);
 
         Context context = view.getContext();
-        global = (MyApp) getActivity().getApplicationContext();
         scale = getResources().getDisplayMetrics().density;
         screenWidth = getResources().getDisplayMetrics().widthPixels;
         MyApp.LogDebug(LOG_TAG, "screen width = " + screenWidth);
@@ -216,7 +214,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
 
         inflater = Contexts.getLayoutInflater(context);
 
-        Intent intent = getActivity().getIntent();
+        Intent intent = requireActivity().getIntent();
         lecture_id = intent.getStringExtra("lecture_id");
 
         if (lecture_id != null) {
@@ -231,7 +229,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     }
 
     private void saveCurrentDay(int day) {
-        SharedPreferences settings = getActivity().getSharedPreferences(PREFS_NAME, 0);
+        SharedPreferences settings = requireContext().getSharedPreferences(PREFS_NAME, 0);
         SharedPreferences.Editor editor = settings.edit();
         editor.putInt("displayDay", day);
         editor.apply();
@@ -250,9 +248,10 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             }
         }
         super.onResume();
-        getActivity().invalidateOptionsMenu();
+        Activity activity = requireActivity();
+        activity.invalidateOptionsMenu();
 
-        Intent intent = getActivity().getIntent();
+        Intent intent = activity.getIntent();
 
         Log.d(LOG_TAG, "lecture_id = " + lecture_id);
         lecture_id = intent.getStringExtra("lecture_id");
@@ -286,10 +285,10 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
 
         if (lecture_id != null) {
             scrollTo(lecture_id);
-            FrameLayout sidePane = getActivity().findViewById(R.id.detail);
+            FrameLayout sidePane = activity.findViewById(R.id.detail);
             if (sidePane != null) {
                 Lecture lecture = LectureUtils.getLecture(MyApp.lectureList, lecture_id);
-                ((MainActivity) getActivity()).openLectureDetail(lecture, mDay, false);
+                ((MainActivity) activity).openLectureDetail(lecture, mDay, false);
             }
             intent.removeExtra("lecture_id");   // jump to given lecture_id only once
         }
@@ -299,7 +298,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     private void viewDay(boolean reload) {
         Log.d(LOG_TAG, "viewDay(" + reload + ")");
 
-        loadLectureList(getActivity(), mDay, reload);
+        loadLectureList(requireContext(), mDay, reload);
         List<Lecture> lectures = MyApp.lectureList;
         if (lectures != null && !lectures.isEmpty()) {
             conference.calculateTimeFrame(lectures, DateHelper::getMinutesOfDay);
@@ -331,7 +330,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     }
 
     private void updateNavigationMenuSelection() {
-        AppCompatActivity activity = (AppCompatActivity) getActivity();
+        AppCompatActivity activity = (AppCompatActivity) requireActivity();
         ActionBar actionbar = activity.getSupportActionBar();
         Log.d(LOG_TAG, "MyApp.meta = " + MyApp.meta);
         if (actionbar != null && MyApp.meta.getNumDays() > 1) {
@@ -554,7 +553,8 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     }
 
     private void setLectureBackground(Lecture event, View eventView) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
+        Context context = eventView.getContext();
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean defaultValue = getResources().getBoolean(R.bool.preferences_alternative_highlight_enabled_default_value);
         boolean alternativeHighlightingIsEnabled = prefs.getBoolean(
                 BundleKeys.PREFS_ALTERNATIVE_HIGHLIGHT, defaultValue);
@@ -567,7 +567,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             Integer colorResId = trackNameBackgroundColorDefaultPairs.get(event.track);
             backgroundColorResId = colorResId == null ? R.color.event_border_default : colorResId;
         }
-        @ColorInt int backgroundColor = ContextCompat.getColor(getContext(), backgroundColorResId);
+        @ColorInt int backgroundColor = ContextCompat.getColor(context, backgroundColorResId);
         EventDrawable eventDrawable;
         if (eventIsFavored && alternativeHighlightingIsEnabled) {
             eventDrawable = new EventDrawable(
@@ -780,9 +780,9 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     public void onClick(View v) {
         Lecture lecture = (Lecture) v.getTag();
         MyApp.LogDebug(LOG_TAG, "Click on " + lecture.title);
-        MainActivity main = (MainActivity) getActivity();
-        if (main != null) {
-            main.openLectureDetail(lecture, mDay, false);
+        MainActivity mainActivity = (MainActivity) requireActivity();
+        if (mainActivity != null) {
+            mainActivity.openLectureDetail(lecture, mDay, false);
         }
     }
 
@@ -796,7 +796,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
                 getString(R.string.day),
                 getString(R.string.today)
         );
-        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        ActionBar actionBar = ((AppCompatActivity) requireActivity()).getSupportActionBar();
         actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
         ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(
                 actionBar.getThemedContext(),
@@ -807,15 +807,16 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     }
 
     public void onParseDone(Boolean result, String version) {
+        Activity activity = requireActivity();
         if (result) {
             if (MyApp.meta.getNumDays() == 0 || !version.equals(MyApp.meta.getVersion())) {
-                AppRepository appRepository = AppRepository.Companion.getInstance(context);
+                AppRepository appRepository = AppRepository.Companion.getInstance(activity);
                 MyApp.meta = appRepository.readMeta();
-                FahrplanMisc.loadDays(getActivity());
+                FahrplanMisc.loadDays(activity);
                 if (MyApp.meta.getNumDays() > 1) {
                     buildNavigationMenu();
                 }
-                SharedPreferences prefs = getActivity().getSharedPreferences(PREFS_NAME, 0);
+                SharedPreferences prefs = activity.getSharedPreferences(PREFS_NAME, 0);
                 mDay = prefs.getInt("displayDay", 1);
                 if (mDay > MyApp.meta.getNumDays()) {
                     mDay = 1;
@@ -827,11 +828,11 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             }
         } else {
             Toast.makeText(
-                    global.getApplicationContext(),
+                    activity,
                     getParsingErrorMessage(version),
                     Toast.LENGTH_LONG).show();
         }
-        getActivity().invalidateOptionsMenu();
+        activity.invalidateOptionsMenu();
     }
 
     private String getParsingErrorMessage(final String version) {
@@ -862,7 +863,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
             Log.e(getClass().getName(), "onAlarmTimesIndexPicked: lecture: null. alarmTimesIndex: " + alarmTimesIndex);
             throw new NullPointerException("Lecture is null.");
         }
-        FahrplanMisc.addAlarm(getActivity(), lastSelectedLecture, alarmTimesIndex);
+        FahrplanMisc.addAlarm(requireContext(), lastSelectedLecture, alarmTimesIndex);
         setBell(lastSelectedLecture);
         updateMenuItems();
     }
@@ -875,32 +876,29 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
 
         MyApp.LogDebug(LOG_TAG, "clicked on " + ((Lecture) contextMenuView.getTag()).lecture_id);
 
+        Context context = requireContext();
         switch (menuItemIndex) {
             case CONTEXT_MENU_ITEM_ID_FAVORITES:
                 lecture.highlight = !lecture.highlight;
                 AppRepository.Companion.getInstance(context).updateHighlight(lecture);
                 setLectureBackground(lecture, contextMenuView);
                 setLectureTextColor(lecture, contextMenuView);
-                MainActivity main = (MainActivity) getActivity();
-                if (main != null) {
-                    main.refreshFavoriteList();
-                }
+                ((MainActivity) context).refreshFavoriteList();
                 updateMenuItems();
                 break;
             case CONTEXT_MENU_ITEM_ID_SET_ALARM:
                 showAlarmTimePicker();
                 break;
             case CONTEXT_MENU_ITEM_ID_DELETE_ALARM:
-                FahrplanMisc.deleteAlarm(getActivity(), lecture);
+                FahrplanMisc.deleteAlarm(context, lecture);
                 setBell(lecture);
                 updateMenuItems();
                 break;
             case CONTEXT_MENU_ITEM_ID_ADD_TO_CALENDAR:
-                CalendarSharing.addToCalendar(lecture, getActivity());
+                CalendarSharing.addToCalendar(lecture, context);
                 break;
             case CONTEXT_MENU_ITEM_ID_SHARE:
                 String formattedLecture = SimpleLectureFormat.format(lecture);
-                Context context = getContext();
                 if (!LectureSharer.shareSimple(context, formattedLecture)) {
                     Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show();
                 }
@@ -912,7 +910,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
     private void updateMenuItems() {
         // Toggles the icon for "add/delete favorite" or "add/delete alarm".
         // Triggers EventDetailFragment.onPrepareOptionsMenu to be called
-        getActivity().invalidateOptionsMenu();
+        requireActivity().invalidateOptionsMenu();
     }
 
     public void onCreateContextMenu(ContextMenu menu, View view, ContextMenuInfo menuInfo) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -12,7 +12,6 @@ import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -474,7 +473,7 @@ public class MainActivity extends BaseActivity implements
         if (fragment != null) {
             ((StarredListFragment) fragment).onRefresh(this);
         }
-        ActivityCompat.invalidateOptionsMenu(this);
+        invalidateOptionsMenu();
     }
 
     private void openFavorites() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -170,13 +170,13 @@ public class MainActivity extends BaseActivity implements
             CustomHttpClient.showHttpError(this, status, fetchScheduleResult.getHostName());
             progressBar.setVisibility(View.INVISIBLE);
             showUpdateAction = true;
-            supportInvalidateOptionsMenu();
+            invalidateOptionsMenu();
             return;
         }
         MyApp.LogDebug(LOG_TAG, "yehhahh");
         progressBar.setVisibility(View.INVISIBLE);
         showUpdateAction = true;
-        supportInvalidateOptionsMenu();
+        invalidateOptionsMenu();
 
         MyApp.fahrplan_xml = fetchScheduleResult.getScheduleXml();
         MyApp.meta.setETag(fetchScheduleResult.getETag());
@@ -196,7 +196,7 @@ public class MainActivity extends BaseActivity implements
         }
         progressBar.setVisibility(View.INVISIBLE);
         showUpdateAction = true;
-        supportInvalidateOptionsMenu();
+        invalidateOptionsMenu();
         Fragment fragment = findFragment(FahrplanFragment.FRAGMENT_TAG);
         if (fragment != null) {
             ((FahrplanFragment) fragment).onParseDone(result, version);
@@ -221,7 +221,7 @@ public class MainActivity extends BaseActivity implements
             MyApp.LogDebug(LOG_TAG, "show fetch status");
             progressBar.setVisibility(View.VISIBLE);
             showUpdateAction = false;
-            supportInvalidateOptionsMenu();
+            invalidateOptionsMenu();
         }
     }
 
@@ -233,7 +233,7 @@ public class MainActivity extends BaseActivity implements
             MyApp.LogDebug(LOG_TAG, "show parse status");
             progressBar.setVisibility(View.VISIBLE);
             showUpdateAction = false;
-            supportInvalidateOptionsMenu();
+            invalidateOptionsMenu();
         }
     }
 
@@ -441,7 +441,7 @@ public class MainActivity extends BaseActivity implements
         FragmentManager manager = getSupportFragmentManager();
         int detailView = R.id.detail;
         toggleSidePaneVisibility(manager, detailView);
-        supportInvalidateOptionsMenu();
+        invalidateOptionsMenu();
     }
 
     private void showProgressDialog(@StringRes int message) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConfirmationDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConfirmationDialog.java
@@ -50,7 +50,7 @@ public class ConfirmationDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
+        AlertDialog.Builder builder = new AlertDialog.Builder(requireContext())
                 .setTitle(dlgTitle)
                 .setPositiveButton(R.string.dlg_delete_all_favorites_delete_all, (dialog, which) -> {
                     if (listener != null) {

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -15,7 +15,7 @@ object Versions {
     val okhttp = "3.12.1"
     val snackengage = "0.18"
     val sonarQubeGradle = "2.7"
-    val supportLibrary = "26.1.0"
+    val supportLibrary = "27.1.1"
     val testRules = "1.0.2"
     val threeTenBp = "1.3.8"
     val tracedroid = "1.4"
@@ -23,9 +23,9 @@ object Versions {
 
 object Android {
     val buildToolsVersion = "28.0.3"
-    val compileSdkVersion = 26
+    val compileSdkVersion = 27
     val minSdkVersion = 14
-    val targetSdkVersion = 26
+    val targetSdkVersion = 27
 }
 
 object GradlePlugins {


### PR DESCRIPTION
# Description
- Use targetSdkVersion 27 (Oreo).
- Add new override annotations.
- Avoid passing nullable context or activity around.
- Replace deprecated "invalidateOptionsMenu()" method.
- Replace deprecated support "supportInvalidateOptionsMenu()" method.

# Successfully tested on
- Google Pixel 2, Android 9
- HTC Nexus 9, Android 7.1.1
- LG Nexus 5, Android 6.0.1

Resolves #137 