### PR TITLE
Protect users from reading identical texts twice.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
@@ -178,3 +178,10 @@ fun LectureNetworkModel.toLectureAppModel(): Lecture {
 
     return lecture
 }
+
+fun Lecture.sanitize(): Lecture {
+    if (abstractt == description) {
+        abstractt = ""
+    }
+    return this
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LecturesExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LecturesExtensions.kt
@@ -12,3 +12,5 @@ fun List<Lecture>.toLecturesDatabaseModel() = map(Lecture::toLectureDatabaseMode
 fun List<LectureNetworkModel>.toLecturesAppModel2(): List<Lecture> = map(LectureNetworkModel::toLectureAppModel)
 
 fun List<LectureDatabaseModel>.toLecturesAppModel() = map(LectureDatabaseModel::toLectureAppModel)
+
+fun List<Lecture>.sanitize() = map(Lecture::sanitize)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -75,7 +75,7 @@ class AppRepository private constructor(val context: Context) {
                 scheduleNetworkRepository.parseSchedule(fetchScheduleResult.scheduleXml, fetchScheduleResult.eTag,
                         onUpdateLectures = { lectures ->
                             val oldLectures = FahrplanMisc.loadLecturesForAllDays(this)
-                            val newLectures = lectures.toLecturesAppModel2()
+                            val newLectures = lectures.toLecturesAppModel2().sanitize()
                             val hasChanged = ScheduleChanges.hasScheduleChanged(newLectures, oldLectures)
                             if (hasChanged) {
                                 resetChangesSeenFlag()


### PR DESCRIPTION
# Description
- Remove `abstract` text if it matches the `description` text.

# Before
- The details screen of a lecture shows an `abstract` and `description` text. Both texts are identical.

  ![before](https://user-images.githubusercontent.com/144518/54218903-b91b7380-44ee-11e9-8dee-d918ecde2f9a.png)

# After
- The details screen of a lecture shows only the `description` text. The `abstract` text is no longer displayed.

  ![after](https://user-images.githubusercontent.com/144518/54218917-bf115480-44ee-11e9-81fe-e01c4c4e84f4.png)

Resolves #13.
