### PR TITLE
Add missing content description for about dialog logo.

### DIFF
--- a/app/src/camp2015/res/values-de/strings.xml
+++ b/app/src/camp2015/res/values-de/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[<a href="https://events.ccc.de/camp/2015/wiki/Static:Design">cccamp15 Artwork</a>]]>
     </string>
+    <string name="about_logo_content_description">
+        Camp 2015 Logo, dass ein Zelt von oben zeigt, in weiß
+    </string>
 </resources>

--- a/app/src/camp2015/res/values/strings.xml
+++ b/app/src/camp2015/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[<a href="https://events.ccc.de/camp/2015/wiki/Static:Design">cccamp15 artwork</a>]]>
     </string>
+    <string name="about_logo_content_description">
+        Camp 2015 logo which shows a tent from above, all white
+    </string>
 </resources>

--- a/app/src/ccc35c3/res/values-de/strings.xml
+++ b/app/src/ccc35c3/res/values-de/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[35C3: Refreshing Memories Design von Stella Schiffczyk]]>
     </string>
+    <string name="about_logo_content_description">
+        35C3 refreshing memories logo, Farbverlauf von blau nach grün
+    </string>
 </resources>

--- a/app/src/ccc35c3/res/values/strings.xml
+++ b/app/src/ccc35c3/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[35C3: Refreshing Memories design by Stella Schiffczyk]]>
     </string>
+    <string name="about_logo_content_description">
+        35C3 refreshing memories logo, gradient from blue to green
+    </string>
 </resources>

--- a/app/src/cccamp2019/res/values-de/strings.xml
+++ b/app/src/cccamp2019/res/values-de/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[Design von <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>
+    <string name="about_logo_content_description">
+        Chaos Communication Camp Logo, mit drei unterschiedlichen Raketen, in blau, gelb und grün
+    </string>
 </resources>

--- a/app/src/cccamp2019/res/values/strings.xml
+++ b/app/src/cccamp2019/res/values/strings.xml
@@ -14,4 +14,7 @@
     <string name="copyright_logo">
         <![CDATA[Design by <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>
+    <string name="about_logo_content_description">
+        Chaos Communication Camp logo, with three different rockets, in blue, yellow and green
+    </string>
 </resources>

--- a/app/src/main/res/layout-port/about_dialog.xml
+++ b/app/src/main/res/layout-port/about_dialog.xml
@@ -22,6 +22,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginTop="16dp"
+                android:contentDescription="@string/about_logo_content_description"
                 android:paddingBottom="15dp"
                 android:src="@drawable/dialog_logo">
         </ImageView>

--- a/app/src/main/res/layout/about_dialog_land.xml
+++ b/app/src/main/res/layout/about_dialog_land.xml
@@ -22,6 +22,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_marginTop="16dp"
+                android:contentDescription="@string/about_logo_content_description"
                 android:paddingBottom="15dp"
                 android:src="@drawable/dialog_logo">
         </ImageView>


### PR DESCRIPTION
- This adds localized content description texts (German, English) to the logo in the about dialog in order to let people with visual impairments still find out via _TalkBack_ what kind of image is shown.
