### PR TITLE
Fix Pretalx feedback URL.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
@@ -2,5 +2,11 @@ package nerd.tuxmobil.fahrplan.congress.extensions
 
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
+/**
+ * Heuristic to detect whether the event originates from Pretalx.
+ * url: https://domain/<slug>/talk/<alphanumeric identifier>
+ * subtitle: not supported, therefore empty
+ * See: https://github.com/EventFahrplan/EventFahrplan/pull/157
+ */
 val Event.originatesFromPretalx
-    get() = !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.endsWith(slug)
+    get() = !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.contains("/talk/") && subtitle.isNullOrEmpty()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -37,7 +37,7 @@ class FeedbackUrlComposer(
 
     companion object {
         private const val NO_URL = ""
-        private const val PRETALX_SCHEDULE_FEEDBACK_URL_SUFFIX = "/feedback/"
+        private const val PRETALX_SCHEDULE_FEEDBACK_URL_SUFFIX = "feedback/"
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -15,9 +15,9 @@ class FeedbackUrlComposerTest {
             slug = "35c3-9985-opening_ceremony"
         }
 
-        private val PRETALX_EVENT = Event("32").apply {
-            url = "https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB"
-            slug = "KDYQEB"
+        private val PRETALX_EVENT = Event("202").apply {
+            url = "https://talks.mrmcd.net/2019/talk/9XL7SP/"
+            slug = "2019-202-board-games-of-medieval-europe"
         }
 
     }
@@ -37,7 +37,7 @@ class FeedbackUrlComposerTest {
     @Test
     fun getFeedbackUrlWithPretalxEventWithFrabScheduleFeedbackUrl() {
         assertThat(FeedbackUrlComposer(PRETALX_EVENT, FRAB_SCHEDULE_FEEDBACK_URL)
-                .getFeedbackUrl()).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB/feedback/")
+                .getFeedbackUrl()).isEqualTo("https://talks.mrmcd.net/2019/talk/9XL7SP/feedback/")
     }
 
 }


### PR DESCRIPTION
# Description
+ The pattern how the `slug` of an event is composed in Pretalx has been changed. This broke the detection whether the event originates from Pretalx. As a result the feedback URL for Pretalx could not be assembled.
+ @rixx, it would be great if you could verify my changes in the pull request and point me to the Pretalx issue or commit which relates to the actual change of the `slug` pattern.
+ @saerdnaer for your interest.