### PR TITLE
Enhance visual layout of event details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
@@ -183,5 +183,9 @@ fun Lecture.sanitize(): Lecture {
     if (abstractt == description) {
         abstractt = ""
     }
+    if (description.isEmpty()) {
+        description = abstractt
+        abstractt = ""
+    }
     return this
 }


### PR DESCRIPTION
# Description
- Move `abstract` text into `description` text whenever the latter has not been given. As a result the major text block is presented in **normal** font weight instead of in **bold** font weight which did clutter the screen.

# Before
- Event details with bold `abstract` text
![Event details with bold abstract text](https://user-images.githubusercontent.com/144518/64411617-e4da7900-d08d-11e9-85ab-f66a90bb4ef7.png)

# After
- Event details with normal `description` text
![Event details with normal description text](https://user-images.githubusercontent.com/144518/64411647-fb80d000-d08d-11e9-91ce-bc3eabbf5a08.png)