### PR TITLE
Use targetSdkVersion 28 (Pie)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
@@ -5,15 +5,15 @@ package nerd.tuxmobil.fahrplan.congress.extensions
 import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
-import android.content.Context.*
 import android.content.Intent
+import android.support.v4.content.ContextCompat
 import android.view.LayoutInflater
 
-fun Context.getAlarmManager() = getSystemService(ALARM_SERVICE) as AlarmManager
+fun Context.getAlarmManager() = ContextCompat.getSystemService(this, AlarmManager::class.java)!!
 
-fun Context.getLayoutInflater() = getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
+fun Context.getLayoutInflater() = ContextCompat.getSystemService(this, LayoutInflater::class.java)!!
 
-fun Context.getNotificationManager() = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+fun Context.getNotificationManager() = ContextCompat.getSystemService(this, NotificationManager::class.java)!!
 
 fun Context.startActivity(intent: Intent, onActivityNotFound: () -> Unit) {
     if (intent.resolveActivity(packageManager) == null) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityObserver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityObserver.kt
@@ -9,6 +9,7 @@ import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.net.Network
 import android.os.Build
+import android.support.v4.content.ContextCompat
 
 /**
  * Observes network connectivity by consulting the [ConnectivityManager].
@@ -24,7 +25,7 @@ class ConnectivityObserver @JvmOverloads constructor(
 ) {
 
     private val connectivityManager
-        get() = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        get() = ContextCompat.getSystemService(context, ConnectivityManager::class.java)!!
 
     @Suppress("DEPRECATION")
     private val intentFilter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -36,7 +36,7 @@ object Libs {
         const val mockito = "2.28.0"
         const val mockitoKotlin = "2.2.0"
         const val okhttp = "3.12.4"
-        const val snackengage = "0.19"
+        const val snackengage = "0.22"
         const val supportLibrary = "28.0.0"
         const val testRules = "1.0.2"
         const val threeTenBp = "1.4.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -6,7 +6,7 @@ object Android {
     const val buildToolsVersion = "29.0.1"
     const val compileSdkVersion = 28
     const val minSdkVersion = 14
-    const val targetSdkVersion = 27
+    const val targetSdkVersion = 28
 }
 
 private const val kotlinVersion = "1.3.50"
@@ -37,7 +37,7 @@ object Libs {
         const val mockitoKotlin = "2.2.0"
         const val okhttp = "3.12.4"
         const val snackengage = "0.19"
-        const val supportLibrary = "27.1.1"
+        const val supportLibrary = "28.0.0"
         const val testRules = "1.0.2"
         const val threeTenBp = "1.4.0"
         const val tracedroid = "1.4"


### PR DESCRIPTION
# Description
- Use targetSdkVersion 28 (Pie).
- Use [Support Library 28.0.0](https://developer.android.com/topic/libraries/support-library/revisions#28-0-0).
- Use `ContextCompat#getSystemService`.
- Use [SnackEngage v.0.22](https://github.com/ligi/SnackEngage).

# Successfully tested on
- Google Pixel 2, Android 10
- HTC Nexus 9, Android 7.1.1
- LG Nexus 5, Android 6.0.1

Resolves #138
