### PR TITLE
Let TalkBack read out language abbreviations as full words.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/LectureChangesArrayAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/LectureChangesArrayAdapter.kt
@@ -55,6 +55,7 @@ class LectureChangesArrayAdapter internal constructor(
             subtitle.textOrHide = lecture.subtitle
             speakers.textOrHide = lecture.formattedSpeakers
             lang.textOrHide = lecture.lang
+            lang.contentDescription = lecture.getLanguageContentDescription(context)
             val dayText = DateHelper.getFormattedDate(lecture.dateUTC)
             day.textOrHide = dayText
             val timeText = DateHelper.getFormattedTime(lecture.dateUTC)
@@ -107,6 +108,7 @@ class LectureChangesArrayAdapter internal constructor(
                     lang.setTextStyleChanged()
                     if (lecture.lang.isEmpty()) {
                         lang.text = context.getText(R.string.dash)
+                        lang.contentDescription = context.getText(R.string.lecture_list_item_language_removed_content_description)
                     }
                 }
                 if (lecture.changedDay) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/LectureArrayAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/LectureArrayAdapter.kt
@@ -57,6 +57,7 @@ class LectureArrayAdapter internal constructor(
             subtitle.textOrHide = lecture.subtitle
             speakers.textOrHide = lecture.formattedSpeakers
             lang.textOrHide = lecture.lang
+            lang.contentDescription = lecture.getLanguageContentDescription(context)
             day.visibility = View.GONE
             val timeText = DateHelper.getFormattedTime(lecture.dateUTC)
             time.textOrHide = timeText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Lecture.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Lecture.java
@@ -1,8 +1,11 @@
 package nerd.tuxmobil.fahrplan.congress.models;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.text.format.Time;
+
+import nerd.tuxmobil.fahrplan.congress.R;
 
 public class Lecture {
 
@@ -228,6 +231,30 @@ public class Lecture {
             builder.append(" [").append(lang).append("]");
         }
         return builder.toString();
+    }
+
+    @NonNull
+    public String getFormattedTrackContentDescription(@NonNull Context context) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(track);
+        if (!TextUtils.isEmpty(lang)) {
+            builder.append("; ").append(getLanguageContentDescription(context));
+        }
+        return builder.toString();
+    }
+
+    @NonNull
+    public String getLanguageContentDescription(@NonNull Context context) {
+        if (TextUtils.isEmpty(lang)) {
+            return context.getString(R.string.lecture_list_item_language_unknown_content_description);
+        }
+        if ("en".equals(lang)) {
+            return context.getString(R.string.lecture_list_item_language_english_content_description);
+        }
+        if ("de".equals(lang)) {
+            return context.getString(R.string.lecture_list_item_language_german_content_description);
+        }
+        return context.getString(R.string.lecture_list_item_language_undefined_content_description, lang);
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -680,6 +680,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         title.setText(lecture.getFormattedSpeakers());
         title = eventView.findViewById(R.id.event_track);
         title.setText(lecture.getFormattedTrackText());
+        title.setContentDescription(lecture.getFormattedTrackContentDescription(eventView.getContext()));
         View recordingOptOut = eventView.findViewById(R.id.novideo);
         if (recordingOptOut != null) {
             recordingOptOut.setVisibility(lecture.recordingOptOut ? View.VISIBLE : View.GONE);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -200,6 +200,11 @@
     <string name="alarm_time_title_60_minutes_before">60 Minuten vorher</string>
 
     <!-- Lecture list item -->
+    <string name="lecture_list_item_language_german_content_description">Deutsch</string>
+    <string name="lecture_list_item_language_english_content_description">Englisch</string>
+    <string name="lecture_list_item_language_unknown_content_description">Sprache unbekannt</string>
+    <string name="lecture_list_item_language_undefined_content_description">Sprache: <xliff:g id="language_abbreviation" example="es">%s</xliff:g></string>
+    <string name="lecture_list_item_language_removed_content_description">Sprachinformation wurde entfernt</string>
     <string name="lecture_list_item_no_video_content_description">Ohne Videoaufzeichnung</string>
     <string name="lecture_list_item_video_content_description">Mit Videoaufzeichnung</string>
     <string name="lecture_list_item_without_video_content_description">Ohne Videoaufzeichnung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,11 @@
     <string name="alarm_time_title_60_minutes_before">60 minutes before</string>
 
     <!-- Lecture list item -->
+    <string name="lecture_list_item_language_german_content_description">German</string>
+    <string name="lecture_list_item_language_english_content_description">English</string>
+    <string name="lecture_list_item_language_unknown_content_description">Language unknown</string>
+    <string name="lecture_list_item_language_undefined_content_description">Language: <xliff:g id="language_abbreviation" example="es">%s</xliff:g></string>
+    <string name="lecture_list_item_language_removed_content_description">Language information has been removed</string>
     <string name="lecture_list_item_no_video_content_description">Without video recording</string>
     <string name="lecture_list_item_video_content_description">With video recording</string>
     <string name="lecture_list_item_without_video_content_description">Without video recording</string>


### PR DESCRIPTION
# Description
- The schedule, favorites and schedule changes screens display the language of a session as an abbreviation, such as `en` or `de` as indicated in the screenshot. A screen reader like [TalkBack](https://support.google.com/accessibility/android/answer/6283677) reads out the abbreviation which can be hard to hear.

  ![Favorites screen with arrows pointing at the language abbreviations](https://user-images.githubusercontent.com/144518/65831849-e3335800-e2bd-11e9-96af-baf56c939999.png)

- This pull request adjusts the content description of these views in order to let screen readers like [TalkBack](https://support.google.com/accessibility/android/answer/6283677) read out the language as a full word, e.g. `English` or `German`.
- Successfully tested with Pixel 2, Android 10, TalkBack.