### PR TITLE
Limits the app activities to be displayed over lock screen

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
@@ -11,7 +11,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.MenuItem;
-import android.view.WindowManager;
 
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService;
@@ -21,12 +20,6 @@ import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper;
 public abstract class BaseActivity extends AppCompatActivity {
 
     private ConnectivityObserver connectivityObserver;
-
-    @Override
-    public void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
-    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetail.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetail.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.WindowManager;
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.MyApp;
@@ -37,6 +38,12 @@ public class EventDetail extends BaseActivity {
         intent.putExtra(BundleKeys.EVENT_ROOM, lecture.room);
         intent.putExtra(BundleKeys.REQUIRES_SCHEDULE_RELOAD, requiresScheduleReload);
         activity.startActivityForResult(intent, MyApp.EVENTVIEW);
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -23,6 +23,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
@@ -78,6 +79,12 @@ public class MainActivity extends BaseActivity implements
     private boolean shouldScrollToCurrent = true;
     private boolean showUpdateAction = true;
     private static MainActivity instance;
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {


### PR DESCRIPTION
**Description**
 - The objective is to restrict the app features which provide edit access to content like alarms, favourites list, and app settings when the device is locked.
- This change limits the number of screens to be displayed over the lock screen, such that only the read-only content is accessible in the locked state.
- This is done in order to prevent unauthorized access to sensitive app content and settings.

**Before**
- All the screens of the app can be used over the lock screen.

**After**
- Only the screens for **event schedule** and **event details** can be viewed over the lock screen.
- Other screens like for **alarms list**, **favourites list** and **app settings** are not visible over lock screen and require the device to be unlocked to be accessed.

Resolves #127 .
