### PR TITLE
Revise architecture around AppRepository

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
@@ -25,6 +25,7 @@ import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.base.ActionBarListActivity;
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm;
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment;
 
 public class AlarmList extends ActionBarListActivity {
@@ -36,6 +37,8 @@ public class AlarmList extends ActionBarListActivity {
     private SQLiteDatabase db;
 
     private CursorAdapter mAdapter;
+
+    private AppRepository appRepository;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -88,7 +91,7 @@ public class AlarmList extends ActionBarListActivity {
             case CONTEXT_MENU_ITEM_ID_DELETE:
                 deleteAlarm(info.position);
                 setResult(RESULT_OK);
-                FahrplanFragment.loadAlarms(this);
+                FahrplanFragment.loadAlarms(appRepository);
                 break;
         }
         return true;
@@ -132,7 +135,7 @@ public class AlarmList extends ActionBarListActivity {
         switch (item.getItemId()) {
             case R.id.menu_item_delete_all_alarms:
                 deleteAllAlarms();
-                FahrplanFragment.loadAlarms(this);
+                FahrplanFragment.loadAlarms(appRepository);
                 setResult(RESULT_OK);
                 return true;
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -4,14 +4,12 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.text.TextUtils;
-import android.text.format.Time;
 
 import java.util.List;
 
@@ -75,13 +73,7 @@ public class UpdateService extends JobIntentService {
         HttpStatus status = fetchScheduleResult.getHttpStatus();
         MyApp.task_running = TASKS.NONE;
         if (status == HttpStatus.HTTP_OK || status == HttpStatus.HTTP_NOT_MODIFIED) {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-            Time now = new Time();
-            now.setToNow();
-            long millis = now.toMillis(true);
-            Editor edit = prefs.edit();
-            edit.putLong("last_fetch", millis);
-            edit.commit();
+            appRepository.updateScheduleLastFetchingTime();
         }
         if (status != HttpStatus.HTTP_OK) {
             MyApp.LogDebug(LOG_TAG, "Background schedule update failed. HTTP status code: " + status);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -33,11 +33,12 @@ public class UpdateService extends JobIntentService {
 
     private static final String LOG_TAG = "UpdateService";
 
+    private AppRepository appRepository;
+
     public void onParseDone(Boolean result, String version) {
         MyApp.LogDebug(LOG_TAG, "parseDone: " + result + " , numDays=" + MyApp.meta.getNumDays());
         MyApp.task_running = TASKS.NONE;
         MyApp.fahrplan_xml = null;
-        AppRepository appRepository = AppRepository.Companion.getInstance(this);
         List<Lecture> changesList = FahrplanMisc.readChanges(appRepository);
         if (!changesList.isEmpty()) {
             showScheduleUpdateNotification(version, changesList.size());
@@ -97,7 +98,6 @@ public class UpdateService extends JobIntentService {
     private void fetchFahrplan() {
         if (MyApp.task_running == TASKS.NONE) {
             MyApp.task_running = TASKS.FETCH;
-            AppRepository appRepository = AppRepository.Companion.getInstance(this);
             String url = appRepository.readScheduleUrl();
             appRepository.loadSchedule(url, MyApp.meta.getETag(), fetchScheduleResult -> {
                 onGotResponse(fetchScheduleResult);
@@ -122,11 +122,11 @@ public class UpdateService extends JobIntentService {
             stopSelf();
             return null;
         }, true);
+        appRepository = AppRepository.Companion.getInstance(this);
         connectivityObserver.start();
     }
 
     private void fetchSchedule() {
-        AppRepository appRepository = AppRepository.Companion.getInstance(getApplicationContext());
         MyApp.meta = appRepository.readMeta(); // to load eTag
         MyApp.LogDebug(LOG_TAG, "Fetching schedule ...");
         FahrplanMisc.setUpdateAlarm(this, false);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.java
@@ -1,9 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.base;
 
+import android.content.Context;
 import android.support.v4.app.ListFragment;
 
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
-
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 
 /**
  * A fragment representing a list of Items.
@@ -29,6 +30,14 @@ public abstract class AbstractListFragment extends ListFragment {
          *                               must be reload from the data source or not.
          */
         void onLectureListClick(Lecture lecture, boolean requiresScheduleReload);
+    }
+
+    protected AppRepository appRepository;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        appRepository = AppRepository.Companion.getInstance(context);
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -17,7 +17,6 @@ import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.models.Meta;
-import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 
 
@@ -77,7 +76,6 @@ public class ChangeListFragment extends AbstractListFragment {
         }
 
         Context context = requireContext();
-        AppRepository appRepository = AppRepository.Companion.getInstance(context);
         changesList = FahrplanMisc.readChanges(appRepository);
         Meta meta = appRepository.readMeta();
         mAdapter = new LectureChangesArrayAdapter(context, changesList, meta.getNumDays());
@@ -130,7 +128,6 @@ public class ChangeListFragment extends AbstractListFragment {
     }
 
     public void onRefresh() {
-        AppRepository appRepository = AppRepository.Companion.getInstance(requireContext());
         List<Lecture> updatedChanges = FahrplanMisc.readChanges(appRepository);
         if (changesList != null) {
             changesList.clear();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
@@ -2,10 +2,8 @@ package nerd.tuxmobil.fahrplan.congress.changes;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
@@ -20,6 +18,7 @@ import android.widget.TextView;
 
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity;
 
 public class ChangesDialog extends DialogFragment {
@@ -107,10 +106,7 @@ public class ChangesDialog extends DialogFragment {
     }
 
     private void flagChangesAsSeen() {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(requireContext());
-        SharedPreferences.Editor edit = prefs.edit();
-        edit.putBoolean(BundleKeys.PREFS_CHANGES_SEEN, true);
-        edit.commit();
+        AppRepository.Companion.getInstance(requireContext()).updateScheduleChangesSeen(true);
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -57,6 +57,8 @@ public interface BundleKeys {
     // Shared Preferences
     String PREFS_CHANGES_SEEN =
             "nerd.tuxmobil.fahrplan.congress.Prefs.CHANGES_SEEN";
+    String PREFS_SCHEDULE_LAST_FETCHED_AT =
+            "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT";
     String PREFS_SCHEDULE_URL =
             "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_URL";
     String PREFS_ALTERNATIVE_HIGHLIGHT =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.details;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.res.AssetManager;
 import android.graphics.Typeface;
@@ -61,6 +62,8 @@ public class EventDetailFragment extends Fragment {
 
     private static final boolean SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL);
 
+    private AppRepository appRepository;
+
     private String eventId;
 
     private String title;
@@ -98,6 +101,12 @@ public class EventDetailFragment extends Fragment {
     private boolean requiresScheduleReload = false;
 
     private boolean hasArguments = false;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        appRepository = AppRepository.Companion.getInstance(context);
+    }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -149,7 +158,7 @@ public class EventDetailFragment extends Fragment {
 
             locale = getResources().getConfiguration().locale;
 
-            FahrplanFragment.loadLectureList(activity, day, requiresScheduleReload);
+            FahrplanFragment.loadLectureList(appRepository, day, requiresScheduleReload);
             lecture = eventIdToLecture(eventId);
 
             // Detailbar
@@ -337,7 +346,7 @@ public class EventDetailFragment extends Fragment {
                 return lecture;
             }
         }
-        Lecture lecture = AppRepository.Companion.getInstance(requireContext()).readLectureByLectureId(eventId);
+        Lecture lecture = appRepository.readLectureByLectureId(eventId);
         Log.d(LOG_TAG, lecture.lectureId + ": " + lecture.getChangedStateString());
         throw new IllegalStateException("Lecture list does not contain eventId: " + eventId + ", lecture: " + lecture.getChangedStateString());
     }
@@ -360,7 +369,7 @@ public class EventDetailFragment extends Fragment {
     private void onAlarmTimesIndexPicked(int alarmTimesIndex) {
         Activity activity = requireActivity();
         if (lecture != null) {
-            FahrplanMisc.addAlarm(activity, lecture, alarmTimesIndex);
+            FahrplanMisc.addAlarm(activity, appRepository, lecture, alarmTimesIndex);
         } else {
             Log.e(getClass().getName(), "onAlarmTimesIndexPicked: lecture: null. alarmTimesIndex: " + alarmTimesIndex);
         }
@@ -393,14 +402,14 @@ public class EventDetailFragment extends Fragment {
             case R.id.menu_item_flag_as_favorite:
                 if (lecture != null) {
                     lecture.highlight = true;
-                    AppRepository.Companion.getInstance(activity).updateHighlight(lecture);
+                    appRepository.updateHighlight(lecture);
                 }
                 refreshUI(activity);
                 return true;
             case R.id.menu_item_unflag_as_favorite:
                 if (lecture != null) {
                     lecture.highlight = false;
-                    AppRepository.Companion.getInstance(activity).updateHighlight(lecture);
+                    appRepository.updateHighlight(lecture);
                 }
                 refreshUI(activity);
                 return true;
@@ -409,7 +418,7 @@ public class EventDetailFragment extends Fragment {
                 return true;
             case R.id.menu_item_delete_alarm:
                 if (lecture != null) {
-                    FahrplanMisc.deleteAlarm(activity, lecture);
+                    FahrplanMisc.deleteAlarm(activity, appRepository, lecture);
                 }
                 refreshUI(activity);
                 return true;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -29,7 +29,6 @@ import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.models.Meta;
-import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity;
 import nerd.tuxmobil.fahrplan.congress.sharing.LectureSharer;
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleLectureFormat;
@@ -129,7 +128,6 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
 
     private void initStarredList() {
         Context context = requireContext();
-        AppRepository appRepository = AppRepository.Companion.getInstance(context);
         starredList = FahrplanMisc.getStarredLectures(appRepository);
         Meta meta = appRepository.readMeta();
         mAdapter = new LectureArrayAdapter(context, starredList, meta.getNumDays());
@@ -175,7 +173,6 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
     }
 
     public void onRefresh(@NonNull Context context) {
-        AppRepository appRepository = AppRepository.Companion.getInstance(context);
         List<Lecture> starred = FahrplanMisc.getStarredLectures(appRepository);
         if (starredList != null) {
             starredList.clear();
@@ -260,7 +257,7 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
     private void deleteItem(int index) {
         Lecture l = starredList.get(index);
         l.highlight = false;
-        AppRepository.Companion.getInstance(requireContext()).updateHighlight(l);
+        appRepository.updateHighlight(l);
         if (MyApp.lectureList != null) {
             for (int j = 0; j < MyApp.lectureList.size(); j++) {
                 Lecture lecture = MyApp.lectureList.get(j);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/ConsoleLogger.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/ConsoleLogger.kt
@@ -1,0 +1,11 @@
+package nerd.tuxmobil.fahrplan.congress.logging
+
+import nerd.tuxmobil.fahrplan.congress.MyApp
+
+object ConsoleLogger : Logging {
+
+    override fun d(tag: String, message: String) {
+        MyApp.LogDebug(tag, message)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/Logging.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/Logging.kt
@@ -1,0 +1,17 @@
+package nerd.tuxmobil.fahrplan.congress.logging
+
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
+
+interface Logging {
+
+    fun d(tag: String, message: String)
+
+    companion object {
+
+        fun get(): Logging {
+            return if (BuildConfig.DEBUG) ConsoleLogger else NoLogging
+        }
+
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/NoLogging.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/logging/NoLogging.kt
@@ -1,0 +1,7 @@
+package nerd.tuxmobil.fahrplan.congress.logging
+
+object NoLogging : Logging {
+
+    override fun d(tag: String, message: String) = Unit
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
@@ -1,6 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.net;
 
 import android.app.Activity;
+import android.net.Uri;
+import android.support.annotation.NonNull;
 import android.widget.Toast;
 
 import java.security.KeyManagementException;
@@ -18,6 +20,15 @@ import okhttp3.logging.HttpLoggingInterceptor.Level;
 
 
 public class CustomHttpClient {
+
+    @NonNull
+    public static String getHostName(@NonNull String url) {
+        String hostName = Uri.parse(url).getHost();
+        if (hostName == null) {
+            throw new NullPointerException("Host not present for URL: " + url);
+        }
+        return hostName;
+    }
 
     public static OkHttpClient createHttpClient(String host)
             throws KeyManagementException, NoSuchAlgorithmException {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
@@ -8,4 +8,9 @@ data class FetchScheduleResult(
         val hostName: String,
         val exceptionMessage: String = ""
 
-)
+) {
+
+    val isSuccessful
+        get() = HttpStatus.HTTP_OK == httpStatus
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
@@ -13,4 +13,12 @@ data class FetchScheduleResult(
     val isSuccessful
         get() = HttpStatus.HTTP_OK == httpStatus
 
+    companion object {
+
+        @JvmStatic
+        fun createError(httpStatus: HttpStatus, hostName: String) =
+                FetchScheduleResult(httpStatus = httpStatus, hostName = hostName)
+
+    }
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ParseScheduleResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ParseScheduleResult.kt
@@ -1,0 +1,8 @@
+package nerd.tuxmobil.fahrplan.congress.net
+
+data class ParseScheduleResult(
+
+        val isSuccess: Boolean,
+        val version: String
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -18,6 +18,9 @@ class SharedPreferencesRepository(val context: Context) {
         apply()
     }
 
+    fun getChangesSeen() =
+            preferences.getBoolean(BundleKeys.PREFS_CHANGES_SEEN, true)
+
     fun setChangesSeen(changesSeen: Boolean) = with(preferences.edit()) {
         putBoolean(BundleKeys.PREFS_CHANGES_SEEN, changesSeen)
         apply()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -10,6 +10,14 @@ class SharedPreferencesRepository(val context: Context) {
 
     private val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
 
+    fun getScheduleLastFetchedAt() =
+            preferences.getLong(BundleKeys.PREFS_SCHEDULE_LAST_FETCHED_AT, 0)
+
+    fun setScheduleLastFetchedAt(fetchedAt: Long) = with(preferences.edit()) {
+        putLong(BundleKeys.PREFS_SCHEDULE_LAST_FETCHED_AT, fetchedAt)
+        apply()
+    }
+
     fun setChangesSeen(changesSeen: Boolean) = with(preferences.edit()) {
         putBoolean(BundleKeys.PREFS_CHANGES_SEEN, changesSeen)
         apply()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import android.content.Context
 import android.net.Uri
+import android.text.format.Time
 import info.metadude.android.eventfahrplan.database.extensions.toContentValues
 import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseRepository
 import info.metadude.android.eventfahrplan.database.repositories.HighlightsDatabaseRepository
@@ -193,6 +194,14 @@ class AppRepository private constructor(val context: Context) {
         } else {
             alternateScheduleUrl
         }
+    }
+
+    fun readScheduleLastFetchingTime() =
+            sharedPreferencesRepository.getScheduleLastFetchedAt()
+
+    fun updateScheduleLastFetchingTime() = with(Time()) {
+        setToNow()
+        sharedPreferencesRepository.setScheduleLastFetchedAt(toMillis(true))
     }
 
     private fun resetChangesSeenFlag() =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -75,11 +75,12 @@ class AppRepository private constructor(val context: Context) {
 
         // Fetching
         scheduleNetworkRepository.fetchSchedule(okHttpClient, url, eTag) { fetchScheduleResult ->
-            onFetchingDone.invoke(fetchScheduleResult.toAppFetchScheduleResult())
+            val fetchResult = fetchScheduleResult.toAppFetchScheduleResult()
+            onFetchingDone.invoke(fetchResult)
 
-            if (fetchScheduleResult.isSuccessful()) {
+            if (fetchResult.isSuccessful) {
                 // Parsing
-                scheduleNetworkRepository.parseSchedule(fetchScheduleResult.scheduleXml, fetchScheduleResult.eTag,
+                scheduleNetworkRepository.parseSchedule(fetchResult.scheduleXml, fetchResult.eTag,
                         onUpdateLectures = { lectures ->
                             val oldLectures = loadLecturesForAllDays()
                             val newLectures = lectures.toLecturesAppModel2().sanitize()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -74,12 +74,14 @@ class AppRepository private constructor(val context: Context) {
             return
         }
 
+        check(onFetchingDone != {}) { "Nobody registered to receive FetchScheduleResult." }
         // Fetching
         scheduleNetworkRepository.fetchSchedule(okHttpClient, url, eTag) { fetchScheduleResult ->
             val fetchResult = fetchScheduleResult.toAppFetchScheduleResult()
             onFetchingDone.invoke(fetchResult)
 
             if (fetchResult.isSuccessful) {
+                check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
                 // Parsing
                 scheduleNetworkRepository.parseSchedule(fetchResult.scheduleXml, fetchResult.eTag,
                         onUpdateLectures = { lectures ->

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -204,7 +204,13 @@ class AppRepository private constructor(val context: Context) {
         sharedPreferencesRepository.setScheduleLastFetchedAt(toMillis(true))
     }
 
+    fun sawScheduleChanges() =
+            sharedPreferencesRepository.getChangesSeen()
+
+    fun updateScheduleChangesSeen(changesSeen: Boolean) =
+            sharedPreferencesRepository.setChangesSeen(changesSeen)
+
     private fun resetChangesSeenFlag() =
-            sharedPreferencesRepository.setChangesSeen(false)
+            updateScheduleChangesSeen(false)
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -22,6 +22,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.net.CustomHttpClient
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult
 import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
+import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
 import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges
 import okhttp3.OkHttpClient
@@ -57,7 +58,7 @@ class AppRepository private constructor(val context: Context) {
     fun loadSchedule(url: String,
                      eTag: String,
                      onFetchingDone: (fetchScheduleResult: FetchScheduleResult) -> Unit,
-                     onParsingDone: (result: Boolean, version: String) -> Unit
+                     onParsingDone: (parseScheduleResult: ParseScheduleResult) -> Unit
     ) {
 
         val scheduleUrl = readScheduleUrl()
@@ -94,7 +95,7 @@ class AppRepository private constructor(val context: Context) {
                             updateMeta(meta.toMetaAppModel())
                         },
                         onParsingDone = { result: Boolean, version: String ->
-                            onParsingDone(result, version)
+                            onParsingDone(ParseScheduleResult(result, version))
                         })
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -83,24 +83,30 @@ class AppRepository private constructor(val context: Context) {
             if (fetchResult.isSuccessful) {
                 check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
                 // Parsing
-                scheduleNetworkRepository.parseSchedule(fetchResult.scheduleXml, fetchResult.eTag,
-                        onUpdateLectures = { lectures ->
-                            val oldLectures = loadLecturesForAllDays()
-                            val newLectures = lectures.toLecturesAppModel2().sanitize()
-                            val hasChanged = ScheduleChanges.hasScheduleChanged(newLectures, oldLectures)
-                            if (hasChanged) {
-                                resetChangesSeenFlag()
-                            }
-                            updateLectures(newLectures)
-                        },
-                        onUpdateMeta = { meta ->
-                            updateMeta(meta.toMetaAppModel())
-                        },
-                        onParsingDone = { result: Boolean, version: String ->
-                            onParsingDone(ParseScheduleResult(result, version))
-                        })
+                parseSchedule(fetchResult.scheduleXml, fetchResult.eTag, onParsingDone)
             }
         }
+    }
+
+    private fun parseSchedule(scheduleXml: String,
+                              eTag: String,
+                              onParsingDone: (parseScheduleResult: ParseScheduleResult) -> Unit) {
+        scheduleNetworkRepository.parseSchedule(scheduleXml, eTag,
+                onUpdateLectures = { lectures ->
+                    val oldLectures = loadLecturesForAllDays()
+                    val newLectures = lectures.toLecturesAppModel2().sanitize()
+                    val hasChanged = ScheduleChanges.hasScheduleChanged(newLectures, oldLectures)
+                    if (hasChanged) {
+                        resetChangesSeenFlag()
+                    }
+                    updateLectures(newLectures)
+                },
+                onUpdateMeta = { meta ->
+                    updateMeta(meta.toMetaAppModel())
+                },
+                onParsingDone = { result: Boolean, version: String ->
+                    onParsingDone(ParseScheduleResult(result, version))
+                })
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.repositories
 
 import android.content.Context
-import android.net.Uri
 import android.text.format.Time
 import info.metadude.android.eventfahrplan.database.extensions.toContentValues
 import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseRepository
@@ -19,15 +18,11 @@ import nerd.tuxmobil.fahrplan.congress.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.Lecture
 import nerd.tuxmobil.fahrplan.congress.models.Meta
-import nerd.tuxmobil.fahrplan.congress.net.CustomHttpClient
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult
-import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
 import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
 import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges
 import okhttp3.OkHttpClient
-import java.security.KeyManagementException
-import java.security.NoSuchAlgorithmException
 
 class AppRepository private constructor(val context: Context) {
 
@@ -57,23 +52,10 @@ class AppRepository private constructor(val context: Context) {
 
     fun loadSchedule(url: String,
                      eTag: String,
+                     okHttpClient: OkHttpClient,
                      onFetchingDone: (fetchScheduleResult: FetchScheduleResult) -> Unit,
                      onParsingDone: (parseScheduleResult: ParseScheduleResult) -> Unit
     ) {
-
-        val scheduleUrl = readScheduleUrl()
-        val hostName = Uri.parse(scheduleUrl).host ?: throw NullPointerException("Host not present for URL: $scheduleUrl")
-        val okHttpClient: OkHttpClient?
-        try {
-            okHttpClient = CustomHttpClient.createHttpClient(hostName)
-        } catch (e: KeyManagementException) {
-            onFetchingDone(FetchScheduleResult(httpStatus = HttpStatus.HTTP_SSL_SETUP_FAILURE, hostName = hostName))
-            return
-        } catch (e: NoSuchAlgorithmException) {
-            onFetchingDone(FetchScheduleResult(httpStatus = HttpStatus.HTTP_SSL_SETUP_FAILURE, hostName = hostName))
-            return
-        }
-
         check(onFetchingDone != {}) { "Nobody registered to receive FetchScheduleResult." }
         // Fetching
         scheduleNetworkRepository.fetchSchedule(okHttpClient, url, eTag) { fetchScheduleResult ->

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -55,6 +55,7 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.Alarm;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
+import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.sharing.LectureSharer;
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleLectureFormat;
@@ -814,10 +815,10 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         actionBar.setListNavigationCallbacks(arrayAdapter, new OnDaySelectedListener());
     }
 
-    public void onParseDone(Boolean result, String version) {
+    public void onParseDone(@NonNull ParseScheduleResult result) {
         Activity activity = requireActivity();
-        if (result) {
-            if (MyApp.meta.getNumDays() == 0 || !version.equals(MyApp.meta.getVersion())) {
+        if (result.isSuccess()) {
+            if (MyApp.meta.getNumDays() == 0 || !result.getVersion().equals(MyApp.meta.getVersion())) {
                 MyApp.meta = appRepository.readMeta();
                 FahrplanMisc.loadDays(appRepository);
                 if (MyApp.meta.getNumDays() > 1) {
@@ -836,7 +837,7 @@ public class FahrplanFragment extends Fragment implements OnClickListener {
         } else {
             Toast.makeText(
                     activity,
-                    getParsingErrorMessage(version),
+                    getParsingErrorMessage(result.getVersion()),
                     Toast.LENGTH_LONG).show();
         }
         activity.invalidateOptionsMenu();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -4,11 +4,9 @@ import android.app.Activity;
 import android.app.KeyguardManager;
 import android.app.ProgressDialog;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -214,8 +212,7 @@ public class MainActivity extends BaseActivity implements
             ((ChangeListFragment) fragment).onRefresh();
         }
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        if (!prefs.getBoolean(BundleKeys.PREFS_CHANGES_SEEN, true)) {
+        if (!appRepository.sawScheduleChanges()) {
             showChangesDialog();
         }
     }
@@ -280,8 +277,7 @@ public class MainActivity extends BaseActivity implements
             sidePane.setVisibility(isScreenLocked ? View.GONE : View.VISIBLE);
         }
 
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        if (prefs.getBoolean(BundleKeys.PREFS_CHANGES_SEEN, true) == false) {
+        if (!appRepository.sawScheduleChanges()) {
             showChangesDialog();
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -168,13 +168,7 @@ public class MainActivity extends BaseActivity implements
             appRepository.updateScheduleLastFetchingTime();
         }
         if (status != HttpStatus.HTTP_OK) {
-            switch (status) {
-                case HTTP_LOGIN_FAIL_UNTRUSTED_CERTIFICATE:
-                    CertificateDialogFragment dialogFragment = CertificateDialogFragment.newInstance(fetchScheduleResult.getExceptionMessage());
-                    dialogFragment.show(getSupportFragmentManager(), CertificateDialogFragment.FRAGMENT_TAG);
-                    break;
-            }
-            CustomHttpClient.showHttpError(this, status, fetchScheduleResult.getHostName());
+            showErrorDialog(fetchScheduleResult.getExceptionMessage(), fetchScheduleResult.getHostName(), status);
             progressBar.setVisibility(View.INVISIBLE);
             showUpdateAction = true;
             invalidateOptionsMenu();
@@ -191,6 +185,16 @@ public class MainActivity extends BaseActivity implements
         // Parser is automatically invoked when response has been received.
         showParsingStatus();
         MyApp.task_running = TASKS.PARSE;
+    }
+
+    private void showErrorDialog(@NonNull String exceptionMessage, @NonNull String hostName, HttpStatus status) {
+        if (HttpStatus.HTTP_LOGIN_FAIL_UNTRUSTED_CERTIFICATE == status) {
+            CertificateDialogFragment.newInstance(exceptionMessage).show(
+                    getSupportFragmentManager(),
+                    CertificateDialogFragment.FRAGMENT_TAG
+            );
+        }
+        CustomHttpClient.showHttpError(this, status, hostName);
     }
 
     public void onParseDone(@NonNull ParseScheduleResult result) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -5,7 +5,6 @@ import android.app.KeyguardManager;
 import android.app.ProgressDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
@@ -20,7 +19,6 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
-import android.text.format.Time;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -168,13 +166,7 @@ public class MainActivity extends BaseActivity implements
             hideProgressDialog();
         }
         if (status == HttpStatus.HTTP_OK || status == HttpStatus.HTTP_NOT_MODIFIED) {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-            Time now = new Time();
-            now.setToNow();
-            long millis = now.toMillis(true);
-            Editor edit = prefs.edit();
-            edit.putLong("last_fetch", millis);
-            edit.commit();
+            appRepository.updateScheduleLastFetchingTime();
         }
         if (status != HttpStatus.HTTP_OK) {
             switch (status) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -78,6 +78,8 @@ public class MainActivity extends BaseActivity implements
 
     private KeyguardManager keyguardManager = null;
 
+    protected AppRepository appRepository;
+
     private ProgressBar progressBar = null;
     private boolean requiresScheduleReload = false;
     private boolean shouldScrollToCurrent = true;
@@ -100,6 +102,7 @@ public class MainActivity extends BaseActivity implements
 
         MyApp.LogDebug(LOG_TAG, "onCreate");
         setContentView(R.layout.main_layout);
+        appRepository = AppRepository.Companion.getInstance(this);
         keyguardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
         Toolbar toolbar = findViewById(R.id.toolbar);
         progressBar = findViewById(R.id.progress);
@@ -115,9 +118,8 @@ public class MainActivity extends BaseActivity implements
 
         resetProgressDialog();
 
-        AppRepository appRepository = AppRepository.Companion.getInstance(this);
         MyApp.meta = appRepository.readMeta();
-        FahrplanMisc.loadDays(this);
+        FahrplanMisc.loadDays(appRepository);
 
         MyApp.LogDebug(LOG_TAG, "task_running:" + MyApp.task_running);
         switch (MyApp.task_running) {
@@ -255,7 +257,6 @@ public class MainActivity extends BaseActivity implements
         if (MyApp.task_running == TASKS.NONE) {
             MyApp.task_running = TASKS.FETCH;
             showFetchingStatus();
-            AppRepository appRepository = AppRepository.Companion.getInstance(this);
             String url = appRepository.readScheduleUrl();
             appRepository.loadSchedule(url, MyApp.meta.getETag(), fetchScheduleResult -> {
                 onGotResponse(fetchScheduleResult);
@@ -309,7 +310,6 @@ public class MainActivity extends BaseActivity implements
         Fragment fragment = findFragment(ChangesDialog.FRAGMENT_TAG);
         if (fragment == null) {
             requiresScheduleReload = true;
-            AppRepository appRepository = AppRepository.Companion.getInstance(this);
             List<Lecture> changedLectures = FahrplanMisc.readChanges(appRepository);
             Meta meta = appRepository.readMeta();
             String scheduleVersion = meta.getVersion();
@@ -408,7 +408,7 @@ public class MainActivity extends BaseActivity implements
     public void reloadAlarms() {
         Fragment fragment = findFragment(FahrplanFragment.FRAGMENT_TAG);
         if (fragment != null) {
-            ((FahrplanFragment) fragment).loadAlarms(this);
+            ((FahrplanFragment) fragment).loadAlarms(appRepository);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
@@ -66,15 +66,15 @@ public final class OnBootReceiver extends BroadcastReceiver {
         boolean defaultValue = context.getResources().getBoolean(R.bool.preferences_auto_update_enabled_default_value);
         boolean doAutoUpdates = prefs.getBoolean("auto_update", defaultValue);
         if (doAutoUpdates) {
-            long lastFetch = prefs.getLong("last_fetch", 0);
+            long lastFetchedAt = appRepository.readScheduleLastFetchingTime();
             long nowMillis;
             now.setToNow();
             nowMillis = now.toMillis(true);
 
             long interval = FahrplanMisc.setUpdateAlarm(context, true);
 
-            MyApp.LogDebug(LOG_TAG, "now: " + nowMillis + ", last_fetch: " + lastFetch);
-            if (interval > 0 && nowMillis - lastFetch >= interval) {
+            MyApp.LogDebug(LOG_TAG, "now: " + nowMillis + ", lastFetchedAt: " + lastFetchedAt);
+            if (interval > 0 && nowMillis - lastFetchedAt >= interval) {
                 UpdateService.start(context);
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -41,9 +41,9 @@ public class FahrplanMisc {
     private static final DateFormat TIME_TEXT_DATE_FORMAT =
             SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.SHORT, SimpleDateFormat.SHORT);
 
-    public static void loadDays(Context context) {
+    public static void loadDays(@NonNull AppRepository appRepository) {
         MyApp.dateInfos = new DateInfos();
-        List<DateInfo> dateInfos = AppRepository.Companion.getInstance(context).readDateInfos();
+        List<DateInfo> dateInfos = appRepository.readDateInfos();
         for (DateInfo dateInfo : dateInfos) {
             if (!MyApp.dateInfos.contains(dateInfo)) {
                 MyApp.dateInfos.add(dateInfo);
@@ -65,8 +65,7 @@ public class FahrplanMisc {
         return when;
     }
 
-    public static void deleteAlarm(@NonNull Context context, @NonNull Lecture lecture) {
-        AppRepository appRepository = AppRepository.Companion.getInstance(context);
+    public static void deleteAlarm(@NonNull Context context, @NonNull AppRepository appRepository, @NonNull Lecture lecture) {
         String eventId = lecture.lectureId;
         List<Alarm> alarms = appRepository.readAlarms(eventId);
         if (!alarms.isEmpty()) {
@@ -80,6 +79,7 @@ public class FahrplanMisc {
     }
 
     public static void addAlarm(@NonNull Context context,
+                                @NonNull AppRepository appRepository,
                                 @NonNull Lecture lecture,
                                 int alarmTimesIndex) {
         Log.d(FahrplanMisc.class.getName(), "Add alarm for lecture: " + lecture.lectureId +
@@ -123,7 +123,7 @@ public class FahrplanMisc {
         Alarm alarm = new Alarm(alarmTimeInMin, day, startTime, eventId, eventTitle, when, timeText);
         SchedulableAlarm schedulableAlarm = AlarmExtensions.toSchedulableAlarm(alarm);
         AlarmServices.scheduleEventAlarm(context, schedulableAlarm, true);
-        AppRepository.Companion.getInstance(context).updateAlarm(alarm);
+        appRepository.updateAlarm(alarm);
         lecture.hasAlarm = true;
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -27,7 +27,6 @@ import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.Alarm;
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo;
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos;
-import nerd.tuxmobil.fahrplan.congress.models.Highlight;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
@@ -39,8 +38,6 @@ import static kotlin.collections.CollectionsKt.filterNot;
 public class FahrplanMisc {
 
     private static final String LOG_TAG = "FahrplanMisc";
-    @VisibleForTesting
-    public static final int ALL_DAYS = -1;
     private static final DateFormat TIME_TEXT_DATE_FORMAT =
             SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.SHORT, SimpleDateFormat.SHORT);
 
@@ -169,42 +166,6 @@ public class FahrplanMisc {
         return alarmUpdater.calculateInterval(now, initial);
     }
 
-    @NonNull
-    public static List<Lecture> loadLecturesForAllDays(@NonNull AppRepository appRepository) {
-        return loadLecturesForDayIndex(appRepository, ALL_DAYS);
-    }
-
-    /**
-     * Load all Lectures from the DB on the day specified
-     *
-     * @param appRepository The application repository to retrieve lectures from.
-     * @param day           The day to load lectures for (0..), or -1 for all days
-     * @return ArrayList of Lecture objects
-     */
-    @NonNull
-    public static List<Lecture> loadLecturesForDayIndex(@NonNull AppRepository appRepository, int day) {
-        List<Lecture> lectures;
-        if (day == ALL_DAYS) {
-            MyApp.LogDebug(LOG_TAG, "Loading lectures for all days.");
-            lectures = appRepository.readLecturesOrderedByDateUtc();
-        } else {
-            MyApp.LogDebug(LOG_TAG, "Loading lectures for day " + day + ".");
-            lectures = appRepository.readLecturesForDayIndexOrderedByDateUtc(day);
-        }
-        MyApp.LogDebug(LOG_TAG, "Got " + lectures.size() + " rows.");
-
-        List<Highlight> highlights = appRepository.readHighlights();
-        for (Highlight highlight : highlights) {
-            MyApp.LogDebug(LOG_TAG, highlight.toString());
-            for (Lecture lecture : lectures) {
-                if (lecture.lectureId.equals("" + highlight.getEventId())) {
-                    lecture.highlight = highlight.isHighlight();
-                }
-            }
-        }
-        return lectures;
-    }
-
     public static int getChangedLectureCount(@NonNull final List<Lecture> list, boolean favsOnly) {
         int count = count(list, event -> event.isChanged() && (!favsOnly || event.highlight));
         MyApp.LogDebug(LOG_TAG, count + " changed lectures, favsOnly = " + favsOnly);
@@ -226,7 +187,7 @@ public class FahrplanMisc {
     @NonNull
     public static List<Lecture> readChanges(@NonNull AppRepository appRepository) {
         MyApp.LogDebug(LOG_TAG, "readChanges");
-        List<Lecture> changesList = loadLecturesForAllDays(appRepository);
+        List<Lecture> changesList = appRepository.loadLecturesForAllDays();
         if (changesList.isEmpty()) {
             return changesList;
         }
@@ -237,7 +198,7 @@ public class FahrplanMisc {
 
     @NonNull
     public static List<Lecture> getStarredLectures(@NonNull AppRepository appRepository) {
-        List<Lecture> starredList = loadLecturesForAllDays(appRepository);
+        List<Lecture> starredList = appRepository.loadLecturesForAllDays();
         if (starredList.isEmpty()) {
             return starredList;
         }
@@ -248,7 +209,7 @@ public class FahrplanMisc {
 
     @NonNull
     public static List<Lecture> getUncanceledLectures(@NonNull AppRepository appRepository, int dayIndex) {
-        List<Lecture> lectures = FahrplanMisc.loadLecturesForDayIndex(appRepository, dayIndex);
+        List<Lecture> lectures = appRepository.loadLecturesForDayIndex(dayIndex);
         return filterNot(lectures, event -> event.changedIsCanceled);
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockitokotlin2.mock
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
 class FahrplanMiscTest {
@@ -134,7 +135,7 @@ class FahrplanMiscTest {
     @Test
     fun getStarredLecturesWithEmptyList() {
         val appRepository = mock<AppRepository> {
-            on { readLecturesOrderedByDateUtc() } doReturn emptyList()
+            on { loadLecturesForAllDays() } doReturn emptyList()
         }
         assertThat(FahrplanMisc.getStarredLectures(appRepository)).isEmpty()
     }
@@ -143,7 +144,7 @@ class FahrplanMiscTest {
     fun getStarredLecturesWithAllEvents() {
         val appRepository = mock<AppRepository> {
             val events = mutableListOf(EVENT_1001, EVENT_1002, EVENT_1003, EVENT_1004)
-            on { readLecturesOrderedByDateUtc() } doReturn events
+            on { loadLecturesForAllDays() } doReturn events
         }
         val starredEvents = FahrplanMisc.getStarredLectures(appRepository)
         assertThat(starredEvents).isNotEmpty()
@@ -155,7 +156,7 @@ class FahrplanMiscTest {
     @Test
     fun readChangesWithEmptyList() {
         val appRepository = mock<AppRepository> {
-            on { readLecturesOrderedByDateUtc() } doReturn emptyList()
+            on { loadLecturesForAllDays() } doReturn emptyList()
         }
         assertThat(FahrplanMisc.readChanges(appRepository)).isEmpty()
     }
@@ -164,7 +165,7 @@ class FahrplanMiscTest {
     fun readChangesWithAllEvents() {
         val appRepository = mock<AppRepository> {
             val events = mutableListOf(EVENT_2001, EVENT_2002, EVENT_2003, EVENT_2004, EVENT_2005)
-            on { readLecturesOrderedByDateUtc() } doReturn events
+            on { loadLecturesForAllDays() } doReturn events
         }
         val changedEvents = FahrplanMisc.readChanges(appRepository)
         assertThat(changedEvents).isNotEmpty()
@@ -176,17 +177,17 @@ class FahrplanMiscTest {
     @Test
     fun getUpcomingLecturesWithEmptyList() {
         val appRepository = mock<AppRepository> {
-            on { readLecturesOrderedByDateUtc() } doReturn emptyList()
+            on { loadLecturesForDayIndex(anyInt()) } doReturn emptyList()
         }
-        assertThat(FahrplanMisc.getUncanceledLectures(appRepository, FahrplanMisc.ALL_DAYS)).isEmpty()
+        assertThat(FahrplanMisc.getUncanceledLectures(appRepository, AppRepository.ALL_DAYS)).isEmpty()
     }
 
     @Test
     fun getUpcomingLecturesWithAllEvents() {
         val appRepository = mock<AppRepository> {
-            on { readLecturesOrderedByDateUtc() } doReturn mutableListOf(EVENT_3001, EVENT_3002)
+            on { loadLecturesForDayIndex(anyInt()) } doReturn mutableListOf(EVENT_3001, EVENT_3002)
         }
-        val upcomingEvents = FahrplanMisc.getUncanceledLectures(appRepository, FahrplanMisc.ALL_DAYS)
+        val upcomingEvents = FahrplanMisc.getUncanceledLectures(appRepository, AppRepository.ALL_DAYS)
         assertThat(upcomingEvents).isNotEmpty()
         assertThat(upcomingEvents.size).isEqualTo(1)
         assertThat(upcomingEvents).contains(EVENT_3001)

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchScheduleResult.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchScheduleResult.kt
@@ -8,8 +8,4 @@ data class FetchScheduleResult(
         val hostName: String,
         val exceptionMessage: String = ""
 
-) {
-
-    fun isSuccessful() = httpStatus == HttpStatus.HTTP_OK
-
-}
+)


### PR DESCRIPTION
# Description
This rewrite aims at improving the architecture as follows:
- Minimizing the app/repository interface & strengthen the layer separation by encapsulating data transformation and aggregation routines within `AppRepository`.
- Ease testing by "injecting" `AppRepository`.
- Accessing `SharedPreferences` values through `AppRepository`.
- Harmonize the `AppRepository#loadSchedule` interface by introducing `ParseScheduleResult` analog to the existing `FetchScheduleResult`.
- Create and manage `OkHttpClient` outside of `AppRepository`.

# Motivation
- This is a preparation for the integration of a second data source as planned in #181.