### PR TITLE
Customize user agent to let the APIs identify requests made by the app.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CustomHttpClient.java
@@ -15,6 +15,8 @@ public class CustomHttpClient {
 
     public static OkHttpClient createHttpClient() {
         OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+        String userAgent = BuildConfig.APPLICATION_ID + ", " + BuildConfig.VERSION_NAME;
+        clientBuilder.addNetworkInterceptor(new UserAgentInterceptor(userAgent));
         if (BuildConfig.DEBUG) {
             HttpLoggingInterceptor httpLoggingInterceptor = new HttpLoggingInterceptor();
             httpLoggingInterceptor.setLevel(Level.HEADERS);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/UserAgentInterceptor.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/UserAgentInterceptor.kt
@@ -1,0 +1,23 @@
+package nerd.tuxmobil.fahrplan.congress.net
+
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Response
+import java.io.IOException
+
+internal class UserAgentInterceptor(
+
+        private val userAgent: String
+
+) : Interceptor {
+
+    @Throws(IOException::class)
+    override fun intercept(chain: Chain): Response {
+        val originalRequest = chain.request()
+        val requestWithUserAgent = originalRequest.newBuilder()
+                .header("User-Agent", userAgent)
+                .build()
+        return chain.proceed(requestWithUserAgent)
+    }
+
+}


### PR DESCRIPTION
# Description
- This set the value of the `User-Agent` key in each HTTP request to a custom value which can be useful for the API to identify the client app

# Before
- Example: `User-Agent: okhttp/3.12.6`


# After
- Example: `User-Agent: info.metadude.android.cccamp.schedule, 1.40.0-CCCamp-Edition`

---

FYI: :information_source: @saerdnaer @manno @n0emis @msquare @MyIgel