### PR TITLE
Sanitize lectures

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
@@ -190,6 +190,9 @@ fun Lecture.sanitize(): Lecture {
     if (abstractt == description) {
         abstractt = ""
     }
+    if (speakers == subtitle) {
+        subtitle = ""
+    }
     if (description.isEmpty()) {
         description = abstractt
         abstractt = ""

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -201,6 +201,7 @@ object AppRepository {
                 .cropToDayRangesExtent(dayRanges)
                 .also { logging.d(javaClass.name, "Shifts filtered = ${it.size}") }
                 .toLectureAppModels(logging, ENGELSYSTEM_ROOM_NAME, dayRanges)
+                .sanitize()
         val lectures = loadLecturesForAllDays(false) // Drop all shifts before ...
                 .toMutableList()
                 // Shift rooms to make space for the Engelshifts room

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
@@ -117,4 +117,48 @@ class LectureExtensionsTest {
         assertThat(lecture.toHighlightDatabaseModel()).isEqualTo(highlight)
     }
 
+    @Test
+    fun sanitizeWithSameAbstractAndDescription() {
+        val lecture = Lecture("").apply {
+            abstractt = "Lorem ipsum"
+            description = "Lorem ipsum"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            abstractt = ""
+            description = "Lorem ipsum"
+        }
+        // The "abstractt" and "description" fields are not part of Lecture#equals for some reason.
+        assertThat(lecture.abstractt).isEqualTo(expected.abstractt)
+        assertThat(lecture.description).isEqualTo(expected.description)
+    }
+
+    @Test
+    fun sanitizeWithDifferentAbstractAndDescription() {
+        val lecture = Lecture("").apply {
+            abstractt = "Lorem ipsum"
+            description = "Dolor sit amet"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            abstractt = "Lorem ipsum"
+            description = "Dolor sit amet"
+        }
+        // The "abstractt" and "description" fields are not part of Lecture#equals for some reason.
+        assertThat(lecture.abstractt).isEqualTo(expected.abstractt)
+        assertThat(lecture.description).isEqualTo(expected.description)
+    }
+
+    @Test
+    fun sanitizeWithAbstractWithoutDescription() {
+        val lecture = Lecture("").apply {
+            abstractt = "Lorem ipsum"
+            description = ""
+        }.sanitize()
+        val expected = Lecture("").apply {
+            description = "Lorem ipsum"
+        }
+        // The "abstractt" and "description" fields are not part of Lecture#equals for some reason.
+        assertThat(lecture.abstractt).isEqualTo(expected.abstractt)
+        assertThat(lecture.description).isEqualTo(expected.description)
+    }
+
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
@@ -161,4 +161,30 @@ class LectureExtensionsTest {
         assertThat(lecture.description).isEqualTo(expected.description)
     }
 
+    @Test
+    fun sanitizeWithSameSpeakersAndSubtitle() {
+        val lecture = Lecture("").apply {
+            speakers = "Luke Skywalker"
+            subtitle = "Luke Skywalker"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            speakers = "Luke Skywalker"
+            subtitle = ""
+        }
+        assertThat(lecture).isEqualTo(expected)
+    }
+
+    @Test
+    fun sanitizeWithDifferentSpeakersAndAbstract() {
+        val lecture = Lecture("").apply {
+            speakers = "Darth Vader"
+            subtitle = "Lorem ipsum"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            speakers = "Darth Vader"
+            subtitle = "Lorem ipsum"
+        }
+        assertThat(lecture).isEqualTo(expected)
+    }
+
 }


### PR DESCRIPTION
# Description
- Unit test `Lecture#sanitize` extension.
- Lecture: Clear `subtitle` field if it matches the `speakers` names.
- Sanitize lecturized _Engelsystem_ shifts.
- Related commit: 39f9eba1332d428e3ecb2211a9a7feb28786f2d1.
- Related issue: #13.

# Before
- Lecture with speaker name in `subtitle` field.
![Lecture with speaker name in subtitle field](https://user-images.githubusercontent.com/144518/71491020-7b45cc80-282e-11ea-88fc-2f7864956542.png)

# After
- Lecture with speaker name cleared from `subtitle` field.
![Lecture with speaker name cleared from subtitle field](https://user-images.githubusercontent.com/144518/71491025-8993e880-282e-11ea-9bf6-efe8c391b878.png)
