### PR TITLE
Automatically reload schedule if Engelsystem shifts URL is configured.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -61,6 +61,8 @@ public interface BundleKeys {
             "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT";
     String PREFS_SCHEDULE_URL =
             "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_URL";
+    String BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED =
+            "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_URL_UPDATED";
     String PREFS_ENGELSYSTEM_SHIFTS_URL =
             "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_URL";
     String PREFS_ENGELSYSTEM_SHIFTS_HASH =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -460,12 +460,16 @@ public class MainActivity extends BaseActivity implements
                 break;
             case MyApp.SETTINGS:
                 if (resultCode == Activity.RESULT_OK) {
-                    boolean defaultValue = getResources().getBoolean(R.bool.preferences_alternative_highlight_enabled_default_value);
-                    if (intent.getBooleanExtra(BundleKeys.PREFS_ALTERNATIVE_HIGHLIGHT, defaultValue)) {
+                    boolean isAlternativeHighlightEnabled = getResources().getBoolean(R.bool.preferences_alternative_highlight_enabled_default_value);
+                    if (intent.getBooleanExtra(BundleKeys.PREFS_ALTERNATIVE_HIGHLIGHT, isAlternativeHighlightEnabled)) {
                         if (findViewById(R.id.schedule) != null && findFragment(FahrplanFragment.FRAGMENT_TAG) == null) {
                             replaceFragment(R.id.schedule, new FahrplanFragment(),
                                     FahrplanFragment.FRAGMENT_TAG);
                         }
+                    }
+                    boolean isEngelsystemShiftsUrlUpdated = getResources().getBoolean(R.bool.bundle_key_engelsystem_shifts_url_updated_default_value);
+                    if (intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED, isEngelsystemShiftsUrlUpdated)) {
+                        fetchFahrplan();
                     }
                 }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -137,6 +137,9 @@ public class SettingsActivity extends BaseActivity {
                 urlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     String url = (String) newValue;
                     appRepository.updateEngelsystemShiftsUrl(url);
+                    Intent redrawIntent = new Intent();
+                    redrawIntent.putExtra(BundleKeys.BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED, true);
+                    getActivity().setResult(Activity.RESULT_OK, redrawIntent);
                     return true;
                 });
             } else {

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -11,7 +11,7 @@
         <![CDATA[Damit deine Schichten angezeigt werden, gib hier bitte deine <u>persönliche</u> URL ein.<br/><br/>
         1. Melde dich beim Engelsystem an.<br/>
         2. Kopiere die URL hinter der <u>JSON Export</u>-Schaltfläche auf deiner Profilseite.<br/>
-        3. Füge die URL hier ein.<br/>4. Lade die Daten, indem du den <u>Aktualisieren</u>-Eintrag in der Menüleiste antippst.<br/><br/>
+        3. Füge die URL hier ein.<br/><br/>
         Schichten vor und nach den offiziellen Konferenztagen werden <u>nicht</u> dargestellt.]]>
     </string>
 

--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <bool name="bundle_key_engelsystem_shifts_url_updated_default_value">false</bool>
     <bool name="preferences_alternative_highlight_enabled_default_value">true</bool>
     <bool name="preferences_auto_update_enabled_default_value">true</bool>
     <bool name="preferences_insistent_alarm_enabled_default_value">false</bool>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -28,7 +28,7 @@
         <![CDATA[In order to see your shifts please enter your <u>personal</u> URL here.<br/><br/>
         1. Login to your Engelsystem account.<br/>
         2. Copy the URL behind the <u>JSON Export</u> button at your profile page.<br/>
-        3. Paste the URL here.<br/>4. Reload the data by tapping the <u>refresh</u> button in the overflow menu.<br/><br/>
+        3. Paste the URL here.<br/><br/>
         Shifts before and after the main conference days are <u>not</u> displayed.]]>
     </string>
     <string name="preference_engelsystem_json_export_url_title" translatable="false">JSON Export URL</string>


### PR DESCRIPTION
# Description
- This change releases users from invoking the `Refresh` menu after configuring the _Engelsystem_ shifts URL in the app settings. The app now **automatically** loads the shifts once configured.
- The related sentence in the setting description is removed.
- Related commit: 7bb735c7bcc2b0ec29b9e93c7116c6801005d9a4.

# Before
- Settings with update instructions to reload.
![Settings with update instructions to reload](https://user-images.githubusercontent.com/144518/71489598-a2000500-2826-11ea-8ee5-6fa3eefb0bed.png)

# After
- Settings without update instructions to reload.
![Settings without update instructions to reload](https://user-images.githubusercontent.com/144518/71489600-a6c4b900-2826-11ea-8eef-700ec0163ef3.png)

