### PR TITLE
Don't use MyApp.lectureList to populate EventDetailFragment

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -158,7 +158,10 @@ public class EventDetailFragment extends Fragment {
 
             locale = getResources().getConfiguration().locale;
 
+            // TODO: Remove this after 36C3. Right now it's only kept to minimize the likelihood of
+            //  unintended behavior changes.
             FahrplanFragment.loadLectureList(appRepository, day, requiresScheduleReload);
+
             lecture = eventIdToLecture(eventId);
 
             // Detailbar
@@ -345,17 +348,7 @@ public class EventDetailFragment extends Fragment {
 
     @NonNull
     private Lecture eventIdToLecture(String eventId) {
-        if (MyApp.lectureList == null) {
-            throw new NullPointerException("Lecture list is null.");
-        }
-        for (Lecture lecture : MyApp.lectureList) {
-            if (lecture.lectureId.equals(eventId)) {
-                return lecture;
-            }
-        }
-        Lecture lecture = appRepository.readLectureByLectureId(eventId);
-        Log.d(LOG_TAG, lecture.lectureId + ": " + lecture.getChangedStateString());
-        throw new IllegalStateException("Lecture list does not contain eventId: " + eventId + ", lecture: " + lecture.getChangedStateString());
+        return appRepository.readLectureByLectureId(eventId);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -279,8 +279,21 @@ object AppRepository {
         highlightsDatabaseRepository.insert(values, lecture.lectureId)
     }
 
-    fun readLectureByLectureId(lectureId: String) =
-            lecturesDatabaseRepository.queryLectureByLectureId(lectureId).first().toLectureAppModel()
+    fun readLectureByLectureId(lectureId: String): Lecture {
+        val lecture = lecturesDatabaseRepository.queryLectureByLectureId(lectureId).toLectureAppModel()
+
+        val highlight = highlightsDatabaseRepository.queryByEventId(lectureId.toInt())
+        if (highlight != null) {
+            lecture.highlight = highlight.isHighlight
+        }
+
+        val alarms = alarmsDatabaseRepository.query(lectureId)
+        if (alarms.isNotEmpty()) {
+            lecture.hasAlarm = true
+        }
+
+        return lecture
+    }
 
     private fun readLecturesForDayIndexOrderedByDateUtc(dayIndex: Int) =
             lecturesDatabaseRepository.queryLecturesForDayIndexOrderedByDateUtc(dayIndex).toLecturesAppModel()

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -56,4 +56,33 @@ class HighlightsDatabaseRepository(
         return highlights.toList()
     }
 
+    fun queryByEventId(eventId: Int): Highlight? {
+        val database = sqLiteOpenHelper.readableDatabase
+        val cursor = try {
+            database.read(
+                tableName = HighlightsTable.NAME,
+                selection = "$EVENT_ID=?",
+                selectionArgs = arrayOf(eventId.toString())
+            )
+        } catch (e: SQLiteException) {
+            database.close()
+            sqLiteOpenHelper.close()
+            return null
+        }
+
+        val highlight = cursor.use {
+            if (cursor.moveToFirst()) {
+                val highlightState = cursor.getInt(HIGHLIGHT)
+                val isHighlighted = highlightState == HIGHLIGHT_STATE_ON
+                Highlight(eventId, isHighlighted)
+            } else {
+                null
+            }
+        }
+
+        database.close()
+        sqLiteOpenHelper.close()
+        return highlight
+    }
+
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
@@ -33,7 +33,7 @@ class LecturesDatabaseRepository(
         read(LecturesTable.NAME,
                 selection = "$EVENT_ID=?",
                 selectionArgs = arrayOf(lectureId))
-    }
+    }.first()
 
     fun queryLecturesForDayIndexOrderedByDateUtc(dayIndex: Int) = query {
         read(LecturesTable.NAME,


### PR DESCRIPTION
### Description
Don't use the outdated `MyApp.lectureList` mechanism to populate `EventDetailFragment`'s UI.

### Before
`MyApp.lectureList` was populated using the `day` argument of `EventDetailFragment`. This lead to the lecture not being found by `eventIdToLecture()` when the event was updated and moved to another day while the change list was displayed.

### After
We fetch the lecture from the database using `AppRepository.readLectureByLectureId()`, bypassing the `MyApp.lectureList` mechanism.
The `MyApp.lectureList` mechanism is populating `Lecture.isHighlight` and `Lecture.hasAlarm`.  `AppRepository.readLectureByLectureId()` was therefore updated to also provide this functionality.

I was able to reproduce #204 using the provided schedule files. This PR fixes that issue.

Resolves #204