### PR TITLE
Mitigates the effect of a SecurityException which can occur in JobIntentService.

### DIFF
--- a/app/src/main/java/android/support/v4/app/SafeJobIntentService.java
+++ b/app/src/main/java/android/support/v4/app/SafeJobIntentService.java
@@ -1,0 +1,22 @@
+package android.support.v4.app;
+
+import org.ligi.tracedroid.logging.Log;
+
+/**
+ * Mitigates the effect of a SecurityException which can occur in {@link JobIntentService}.
+ * The issue is tracked here: https://issuetracker.google.com/issues/63622293
+ */
+public abstract class SafeJobIntentService extends JobIntentService {
+
+    @Override
+    GenericWorkItem dequeueWork() {
+        try {
+            return super.dequeueWork();
+        } catch (SecurityException ignore) {
+            // There is not much we can do here.
+            Log.e(getClass().getName(), ignore);
+        }
+        return null;
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -7,8 +7,8 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
-import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.SafeJobIntentService;
 import android.text.TextUtils;
 
 import java.util.List;
@@ -32,7 +32,7 @@ import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 import okhttp3.OkHttpClient;
 
-public class UpdateService extends JobIntentService {
+public class UpdateService extends SafeJobIntentService {
 
     private static final int JOB_ID = 2119;
 


### PR DESCRIPTION
+ Addresses the error: "SecurityException: Caller no longer running, last stopped".
+ See: https://issuetracker.google.com/issues/63622293

Resolves #120.