### PR TITLE
Ensure de/selecting a favorite in details is reflected in the main view.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -403,6 +403,7 @@ public class EventDetailFragment extends Fragment {
                 if (lecture != null) {
                     lecture.highlight = true;
                     appRepository.updateHighlight(lecture);
+                    appRepository.updateLecturesLegacy(lecture);
                 }
                 refreshUI(activity);
                 return true;
@@ -410,6 +411,7 @@ public class EventDetailFragment extends Fragment {
                 if (lecture != null) {
                     lecture.highlight = false;
                     appRepository.updateHighlight(lecture);
+                    appRepository.updateLecturesLegacy(lecture);
                 }
                 refreshUI(activity);
                 return true;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -17,6 +17,7 @@ import info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkR
 import info.metadude.kotlin.library.engelsystem.models.Shift
 import kotlinx.coroutines.Job
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.MyApp
 import nerd.tuxmobil.fahrplan.congress.dataconverters.*
 import nerd.tuxmobil.fahrplan.congress.exceptions.AppExceptionHandler
 import nerd.tuxmobil.fahrplan.congress.logging.Logging
@@ -315,6 +316,20 @@ object AppRepository {
 
     fun readDateInfos() =
             readLecturesOrderedByDateUtc().toDateInfos()
+
+    /**
+     * Updates the legacy static lecture list.
+     * This method should be invoked when the state of a [lecture] is changed
+     * while other parts of the application such as the main screen render
+     * their views based on the [legacy static lecture list][MyApp.lectureList].
+     */
+    @Deprecated("Drop method once MyApp.lectureList is gone.")
+    fun updateLecturesLegacy(lecture: Lecture) {
+        MyApp.lectureList?.firstOrNull { lecture.lectureId == it.lectureId }?.let {
+            it.highlight = lecture.highlight
+            it.hasAlarm = lecture.hasAlarm
+        }
+    }
 
     private fun updateLectures(lectures: List<Lecture>) {
         val lecturesDatabaseModel = lectures.toLecturesDatabaseModel()


### PR DESCRIPTION
+ The main schedule view relies on the correct state of the static lecture list (`MyApp.lectureList`) in order to render the favor state. Therefore, it is required that once a lecture is modified in the details view also the corresponding entry in the static lecture list (if present) is updated.
+ Bug introduced in 8d0107331a4d88dc2626d5095cbf3349d0d66a00.
+ Relates to issue #204, #214.