### PR TITLE
#195 update notification channels on locale changed event

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,12 @@
         </receiver>
         <receiver android:name="nerd.tuxmobil.fahrplan.congress.system.OnBootReceiver">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <receiver android:name="nerd.tuxmobil.fahrplan.congress.system.OnLocaleChangedReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -20,6 +20,10 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
     }
 
     init {
+        createChannels()
+    }
+
+    fun createChannels(){
         createNotificationChannel(EVENT_ALARM_CHANNEL_ID, eventAlarmChannelName, eventAlarmChannelDescription)
         createNotificationChannel(SCHEDULE_UPDATE_CHANNEL_ID, scheduleUpdateChannelName, scheduleUpdateChannelDescription)
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnLocaleChangedReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnLocaleChangedReceiver.kt
@@ -1,0 +1,24 @@
+package nerd.tuxmobil.fahrplan.congress.system
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+
+/**
+ * Handler for androids [Intent.ACTION_LOCALE_CHANGED] event.
+ * Recreates notification channel settings using [NotificationHelper].
+ */
+class OnLocaleChangedReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action ?: return
+        if (action != Intent.ACTION_LOCALE_CHANGED) {
+            return
+        }
+        Log.d(javaClass.name, "onReceive (locale changed)")
+
+        val notificationHelper = NotificationHelper(context)
+        notificationHelper.createChannels()
+    }
+}


### PR DESCRIPTION
# Description
- Update notification channel title and description as soon as locale is changed in phone settings, see #195 .

# Tested on:
- OnePlus 3T (A3003), Android 9, LineageOS 16.0-20191107-microG
- Emulator: Pixel 3A, Android 9.0
- Emulator: Nexus 5X, Android 9.0

# Before
- Text of channel was not updated, even after restarting the application (probably some classes were not destructed ...)

# After
- Auto updates texts on androids "locale changed" event.

Resolves #195
