### PR TITLE
Include duration in event detail view

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -171,7 +171,11 @@ public class EventDetailFragment extends Fragment {
             if (lecture != null && lecture.dateUTC > 0) {
                 DateFormat df = SimpleDateFormat
                         .getDateTimeInstance(SimpleDateFormat.SHORT, SimpleDateFormat.SHORT);
-                t.setText(df.format(new Date(lecture.dateUTC)));
+                String date = df.format(new Date(lecture.dateUTC));
+                if (lecture.duration > 0) {
+                    date += "/" + lecture.duration + " min";
+                }
+                t.setText(date);
             } else {
                 t.setText("");
             }


### PR DESCRIPTION
# Description
Includes the event duration after the start time in the detail view's top bar

# Before
No duration was shown

# After
The duration (e.g. "60 min") is shown after the start time.

# Related
- [Issue #231: Show end time of Fahrplan events](https://github.com/EventFahrplan/EventFahrplan/issues/231)
