### PR TITLE
Preferences alternative schedule url

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ android {
         buildConfigField "String", "BUILD_TIME", "\"${buildTime()}\""
         buildConfigField "String", "GIT_SHA", "\"${gitSha()}\""
         buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
+        buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "false"
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -59,6 +59,8 @@ public interface BundleKeys {
             "nerd.tuxmobil.fahrplan.congress.Prefs.CHANGES_SEEN";
     String PREFS_SCHEDULE_LAST_FETCHED_AT =
             "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT";
+    String BUNDLE_KEY_SCHEDULE_URL_UPDATED =
+            "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_URL_UPDATED";
     String PREFS_SCHEDULE_URL =
             "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_URL";
     String BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -27,7 +27,7 @@ class SharedPreferencesRepository(val context: Context) {
     }
 
     fun getScheduleUrl(): String {
-        val defaultScheduleUrl = context.getString(R.string.preferences_schedule_url_default_value)
+        val defaultScheduleUrl = context.getString(R.string.preference_schedule_url_default_value)
         return preferences.getString(BundleKeys.PREFS_SCHEDULE_URL, defaultScheduleUrl)!!
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -31,6 +31,11 @@ class SharedPreferencesRepository(val context: Context) {
         return preferences.getString(BundleKeys.PREFS_SCHEDULE_URL, defaultScheduleUrl)!!
     }
 
+    fun setScheduleUrl(url: String) = with(preferences.edit()) {
+        putString(BundleKeys.PREFS_SCHEDULE_URL, url)
+        apply()
+    }
+
     fun getEngelsystemShiftsUrl(): String {
         val defaultShiftsUrl = context.getString(R.string.preference_engelsystem_json_export_url_default_value)
         return preferences.getString(BundleKeys.PREFS_ENGELSYSTEM_SHIFTS_URL, defaultShiftsUrl)!!

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -355,6 +355,8 @@ object AppRepository {
         }
     }
 
+    fun updateScheduleUrl(url: String) = sharedPreferencesRepository.setScheduleUrl(url)
+
     private fun readEngelsystemShiftsUrl() =
             sharedPreferencesRepository.getEngelsystemShiftsUrl()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -467,8 +467,16 @@ public class MainActivity extends BaseActivity implements
                                     FahrplanFragment.FRAGMENT_TAG);
                         }
                     }
+                    boolean shouldFetchFahrplan = false;
+                    boolean isScheduleUrlUpdated = getResources().getBoolean(R.bool.bundle_key_schedule_url_updated_default_value);
+                    if (intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_SCHEDULE_URL_UPDATED, isScheduleUrlUpdated)) {
+                        shouldFetchFahrplan = true;
+                    }
                     boolean isEngelsystemShiftsUrlUpdated = getResources().getBoolean(R.bool.bundle_key_engelsystem_shifts_url_updated_default_value);
                     if (intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED, isEngelsystemShiftsUrlUpdated)) {
+                        shouldFetchFahrplan = true;
+                    }
+                    if (shouldFetchFahrplan) {
                         fetchFahrplan();
                     }
                 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -85,7 +85,7 @@ public class SettingsActivity extends BaseActivity {
                 });
             }
 
-            findPreference("schedule_url")
+            findPreference(getString(R.string.preference_schedule_url_key))
                     .setOnPreferenceChangeListener((preference, newValue) -> {
                         SharedPreferences prefs = PreferenceManager
                                 .getDefaultSharedPreferences(getActivity());

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -87,12 +87,8 @@ public class SettingsActivity extends BaseActivity {
 
             findPreference(getString(R.string.preference_schedule_url_key))
                     .setOnPreferenceChangeListener((preference, newValue) -> {
-                        SharedPreferences prefs = PreferenceManager
-                                .getDefaultSharedPreferences(getActivity());
-
-                        SharedPreferences.Editor edit = prefs.edit();
-                        edit.putString(BundleKeys.PREFS_SCHEDULE_URL, (String) newValue);
-                        edit.commit();
+                        String url = (String) newValue;
+                        appRepository.updateScheduleUrl(url);
                         return true;
                     });
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -56,6 +56,7 @@ public class SettingsActivity extends BaseActivity {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.prefs);
             AppRepository appRepository = AppRepository.INSTANCE;
+            PreferenceCategory categoryGeneral = (PreferenceCategory) findPreference(getString(R.string.preference_key_category_general));
 
             findPreference("auto_update")
                     .setOnPreferenceChangeListener((preference, newValue) -> {
@@ -76,7 +77,6 @@ public class SettingsActivity extends BaseActivity {
 
             Preference appNotificationSettingsPreference = findPreference(getString(R.string.preference_key_app_notification_settings));
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                PreferenceCategory categoryGeneral = (PreferenceCategory) findPreference(getString(R.string.preference_key_category_general));
                 categoryGeneral.removePreference(appNotificationSettingsPreference);
             } else {
                 appNotificationSettingsPreference.setOnPreferenceClickListener(preference -> {
@@ -85,15 +85,20 @@ public class SettingsActivity extends BaseActivity {
                 });
             }
 
-            findPreference(getString(R.string.preference_schedule_url_key))
-                    .setOnPreferenceChangeListener((preference, newValue) -> {
-                        String url = (String) newValue;
-                        appRepository.updateScheduleUrl(url);
-                        Intent redrawIntent = new Intent();
-                        redrawIntent.putExtra(BundleKeys.BUNDLE_KEY_SCHEDULE_URL_UPDATED, true);
-                        getActivity().setResult(Activity.RESULT_OK, redrawIntent);
-                        return true;
-                    });
+            Preference scheduleUrlPreference = findPreference(getString(R.string.preference_schedule_url_key));
+            if (BuildConfig.ENABLE_ALTERNATIVE_SCHEDULE_URL) {
+                scheduleUrlPreference
+                        .setOnPreferenceChangeListener((preference, newValue) -> {
+                            String url = (String) newValue;
+                            appRepository.updateScheduleUrl(url);
+                            Intent redrawIntent = new Intent();
+                            redrawIntent.putExtra(BundleKeys.BUNDLE_KEY_SCHEDULE_URL_UPDATED, true);
+                            getActivity().setResult(Activity.RESULT_OK, redrawIntent);
+                            return true;
+                        });
+            } else {
+                categoryGeneral.removePreference(scheduleUrlPreference);
+            }
 
             findPreference("alternative_highlight")
                     .setOnPreferenceChangeListener((preference, newValue) -> {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -89,6 +89,9 @@ public class SettingsActivity extends BaseActivity {
                     .setOnPreferenceChangeListener((preference, newValue) -> {
                         String url = (String) newValue;
                         appRepository.updateScheduleUrl(url);
+                        Intent redrawIntent = new Intent();
+                        redrawIntent.putExtra(BundleKeys.BUNDLE_KEY_SCHEDULE_URL_UPDATED, true);
+                        getActivity().setResult(Activity.RESULT_OK, redrawIntent);
                         return true;
                     });
 

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -4,6 +4,9 @@
     <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen &#8230;</string>
 
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">Alternative Fahrplan URL</string>
+
     <!-- Category Engelsystem -->
 
     <string name="preference_engelsystem_category_title">Engelsystem</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,7 +112,6 @@
 
     <string name="general_settings">Allgemein</string>
     <string name="starred_lectures">Favoriten</string>
-    <string name="schedule_url">Alternative Fahrplan URL</string>
     <string name="invalid_url">Ungültige URL</string>
     <string name="no_favorites">Keine favorisierten Vorträge</string>
     <string name="choose_to_delete">Wähle Vorträge</string>

--- a/app/src/main/res/values-es/preferences.xml
+++ b/app/src/main/res/values-es/preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">URL alternativa del calendario</string>
+
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -97,7 +97,6 @@
     <string name="schedule_changes_dialog_updated_to_text">El calendario ha sido actualizado a</string>
     <string name="schedule_updated">El calendario ha sido actualizado</string>
     <string name="schedule_updated_to">Actualizado a <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g></string>
-    <string name="schedule_url">URL alternativa del calendario</string>
     <string name="settings">Ajustes</string>
     <string name="share_error_activity_not_found">No hay ninguna aplicación apropiada instalada.</string>
     <string name="snack_engage_c3nav_action">Obtengalo ahora!</string>

--- a/app/src/main/res/values-fr/preferences.xml
+++ b/app/src/main/res/values-fr/preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">URL alternative du programme</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -121,7 +121,6 @@
     <string name="menu_item_title_close_event_details">Fermer les détails de l’évènement</string>
     <string name="notifications_schedule_update_channel_name">Changements dans le programme</string>
     <string name="trace_droid_dialog_title"> Envoi du rapport de crash du programme <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> … </string>
-    <string name="schedule_url">URL alternative du programme</string>
     <string name="schedule_changes">Changements du programme</string>
     <string name="no_changes">Aucun changement dans le programme</string>
     <string name="schedule_parsing_error_generic">Erreur inconnue lors de l’analyse du programme</string>

--- a/app/src/main/res/values-it/preferences.xml
+++ b/app/src/main/res/values-it/preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">URL alternativo del programma</string>
+
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -99,7 +99,6 @@
     <string name="schedule_changes_dialog_updated_to_text">Il programma è stato aggiornato a </string>
     <string name="schedule_updated">Il programma è stato aggiornato.</string>
     <string name="schedule_updated_to">Aggiornato a <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g></string>
-    <string name="schedule_url">URL alternativo del programma</string>
     <string name="settings">Preferenze</string>
     <string name="share_error_activity_not_found">Nessuna applicazione corrispondente installata.</string>
     <string name="snack_engage_c3nav_action">Ottenerla subito</string>

--- a/app/src/main/res/values-nl/preferences.xml
+++ b/app/src/main/res/values-nl/preferences.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">Alternatieve tijdschema URL</string>
+
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -109,7 +109,6 @@
 
     <string name="general_settings">Algemeen</string>
     <string name="starred_lectures">Favorieten</string>
-    <string name="schedule_url">Alternatieve tijdschema URL</string>
     <string name="invalid_url">Ongeldige URL</string>
     <string name="no_favorites">Geen favorieten evenementen</string>
     <string name="choose_to_delete">Kies evenementen</string>

--- a/app/src/main/res/values-pt/preferences.xml
+++ b/app/src/main/res/values-pt/preferences.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Customizar notificações &#8230;</string>
+
 </resources>

--- a/app/src/main/res/values-pt/preferences.xml
+++ b/app/src/main/res/values-pt/preferences.xml
@@ -4,4 +4,7 @@
     <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Customizar notificações &#8230;</string>
 
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">URL alternativa de cronograma</string>
+
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -109,7 +109,6 @@
 
     <string name="general_settings">Geral</string>
     <string name="starred_lectures">Favoritos</string>
-    <string name="schedule_url">URL alternativa de cronograma</string>
     <string name="invalid_url">URL inválida</string>
     <string name="choose_to_delete">Selecionar palestras</string>
     <string name="day_separator">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>

--- a/app/src/main/res/values-ru/preferences.xml
+++ b/app/src/main/res/values-ru/preferences.xml
@@ -4,4 +4,7 @@
     <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Настройки уведомлений &#8230;</string>
 
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_title">Альтернативный URL расписания</string>
+
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -115,7 +115,6 @@
     <string name="dash" translatable="false"><xliff:g id="dash">—</xliff:g></string>
     <string name="general_settings">Основное</string>
     <string name="starred_lectures">Избранное</string>
-    <string name="schedule_url">Альтернативный URL расписания</string>
     <string name="invalid_url">Некорректный URL</string>
     <string name="choose_to_delete">Выбрать лекции</string>
     <string name="day_separator">День <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>

--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <bool name="bundle_key_schedule_url_updated_default_value">false</bool>
     <bool name="bundle_key_engelsystem_shifts_url_updated_default_value">false</bool>
     <bool name="preferences_alternative_highlight_enabled_default_value">true</bool>
     <bool name="preferences_auto_update_enabled_default_value">true</bool>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -7,6 +7,16 @@
     <!-- Category general -->
     <string name="preference_key_category_general" translatable="false">preference_key_category_general</string>
 
+    <!-- Alternative schedule URL -->
+    <string name="preference_schedule_url_key" translatable="false">
+        schedule_url
+    </string>
+    <string name="preference_schedule_url_default_value" translatable="false" />
+    <string name="preference_schedule_url_hint" translatable="false">
+        https://yourhost/schedule.xml
+    </string>
+    <string name="preference_schedule_url_title">Alternative schedule URL</string>
+
     <!-- App notification settings -->
     <string name="preference_key_app_notification_settings" translatable="false">app_notification_settings</string>
     <string name="preference_title_app_notification_settings">Customize notifications &#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,7 +122,6 @@
     <string name="dash" translatable="false"><xliff:g id="dash">—</xliff:g></string>
     <string name="general_settings">General</string>
     <string name="starred_lectures">Favorites</string>
-    <string name="schedule_url">Alternative schedule URL</string>
     <string name="invalid_url">Invalid URL</string>
     <string name="choose_to_delete">Select lectures</string>
     <string name="day_separator">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
@@ -208,7 +207,6 @@
 
     <!-- Preferences -->
     <string name="preferences_reminder_tone_default_value" translatable="false" />
-    <string name="preferences_schedule_url_default_value" translatable="false" />
 
     <!-- Alarm time picker -->
     <string name="alarm_time_title_at_start_time">at start time</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -18,11 +18,11 @@
             android:title="@string/preference_title_app_notification_settings" />
 
         <EditTextPreference
-            android:defaultValue="@string/preferences_schedule_url_default_value"
-            android:hint="https://yourhost/schedule.xml"
+            android:defaultValue="@string/preference_schedule_url_default_value"
+            android:hint="@string/preference_schedule_url_hint"
             android:inputType="textUri"
-            android:key="schedule_url"
-            android:title="@string/schedule_url" />
+            android:key="@string/preference_schedule_url_key"
+            android:title="@string/preference_schedule_url_title" />
 
         <CheckBoxPreference
             android:defaultValue="@bool/preferences_alternative_highlight_enabled_default_value"


### PR DESCRIPTION
# Description
- Revising the "Alternative schedule URL" feature.
  - Reorganize string resources.
  - Use `AppRepository` as a common interface to access `PREFS_SCHEDULE_URL`.
- New:
  - Automatically reload schedule if alternative schedule URL is configured.
  - Allow to exclude the preference from a build.
    - Configuring an alternative schedule URL does not make sense for every event where the app is used. The retrieved schedule must be compatible with what the app expects aka. the original schedule.
      The preference was initially added as a backup if the main backend is not reachable for a longer time during an event.
    - Related commit: d387a4f8f4e9ea17328416cbc72d9c2202494a55.

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Nexus 9, Android 7.1.1 (API 25)
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

# Before
- Settings with the "Alternative schedule URL" setting.
![Settings with the "Alternative schedule URL" setting](https://user-images.githubusercontent.com/144518/71736021-51089600-2e50-11ea-926c-ce211994ec4d.png)

# After
- Settings without the "Alternative schedule URL" setting.
![Settings without the "Alternative schedule URL" setting](https://user-images.githubusercontent.com/144518/71736028-55cd4a00-2e50-11ea-8412-548a9c6a67e1.png)