### PR TITLE
Hide feedback button for wiki events because there is no feedback system.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -315,7 +315,8 @@ public class EventDetailFragment extends Fragment {
             }
         }
         item = menu.findItem(R.id.menu_item_feedback);
-        if (SHOW_FEEDBACK_MENU_ITEM) {
+        String feedbackUrl = new FeedbackUrlComposer(lecture, SCHEDULE_FEEDBACK_URL).getFeedbackUrl();
+        if (SHOW_FEEDBACK_MENU_ITEM && !TextUtils.isEmpty(feedbackUrl)) {
             if (item != null) {
                 item.setVisible(true);
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/EventExtensions.kt
@@ -10,3 +10,9 @@ import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
  */
 val Event.originatesFromPretalx
     get() = !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.contains("/talk/") && subtitle.isNullOrEmpty()
+
+// The track name constant must match the "track" name in the schedule.xml!
+const val WIKI_EVENT_TRACK_NAME = "self organized sessions"
+
+val Event.originatesFromWiki
+    get() = WIKI_EVENT_TRACK_NAME == track

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.utils
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.extensions.originatesFromPretalx
+import nerd.tuxmobil.fahrplan.congress.extensions.originatesFromWiki
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
 class FeedbackUrlComposer(
@@ -16,15 +17,20 @@ class FeedbackUrlComposer(
      * otherwise an empty string.
      *
      * The [Frab schedule feedback URL][frabScheduleFeedbackUrl] is
-     * composed from the event id. Currently, events extracted from
-     * the wiki of the Chaos Communication Congress cannot be
-     * distinguished from regular Frab events. Therefore, visiting the
-     * resulting schedule feedback URL results in an HTTP 404 error.
+     * composed from the event id.
+     * For events extracted from the wiki of the Chaos Communication Congress
+     * aka. "self organized sessions" an empty string is returned because
+     * there is no feedback system for them.
      */
-    fun getFeedbackUrl() = if (event.originatesFromPretalx) {
-        event.pretalxScheduleFeedbackUrl
-    } else {
-        event.frabScheduleFeedbackUrl
+    fun getFeedbackUrl(): String {
+        if (event.originatesFromWiki) {
+            return NO_URL
+        }
+        return if (event.originatesFromPretalx) {
+            event.pretalxScheduleFeedbackUrl
+        } else {
+            event.frabScheduleFeedbackUrl
+        }
     }
 
     private val Event.frabScheduleFeedbackUrl

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
+import nerd.tuxmobil.fahrplan.congress.extensions.WIKI_EVENT_TRACK_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
@@ -20,6 +21,11 @@ class FeedbackUrlComposerTest {
             slug = "2019-202-board-games-of-medieval-europe"
         }
 
+        private val WIKI_EVENT = Event("1346").apply {
+            track = WIKI_EVENT_TRACK_NAME
+            url = "https://events.ccc.de/congress/2019/wiki/index.php/Session:Mobile_Apps"
+        }
+
     }
 
     @Test
@@ -38,6 +44,12 @@ class FeedbackUrlComposerTest {
     fun getFeedbackUrlWithPretalxEventWithFrabScheduleFeedbackUrl() {
         assertThat(FeedbackUrlComposer(PRETALX_EVENT, FRAB_SCHEDULE_FEEDBACK_URL)
                 .getFeedbackUrl()).isEqualTo("https://talks.mrmcd.net/2019/talk/9XL7SP/feedback/")
+    }
+
+    @Test
+    fun getFeedbackUrlWithWikiEvent() {
+        assertThat(FeedbackUrlComposer(WIKI_EVENT, "")
+                .getFeedbackUrl()).isEqualTo("")
     }
 
 }


### PR DESCRIPTION
# Description
+ This only works as long as the `track` name in the _schedule.xml_ is set to `self organized sessions` for these sessions.
  Let's see how long this works .. :crossed_fingers: 
+ :heart: Thanks to Christian R. for reporting this!

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Nexus 9, Android 7.1.1 (API 25)
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

# Before
- A wiki event with the feedback button being displayed.
![A wiki event with the feedback button being displayed](https://user-images.githubusercontent.com/144518/71772275-1cc4d080-2f49-11ea-8cb3-13c6bec9fda6.png)


# After
- A wiki event without the feedback button being displayed
![A wiki event without the feedback button being displayed](https://user-images.githubusercontent.com/144518/71772277-22221b00-2f49-11ea-9fbf-ae5ec160877c.png)