### PR TITLE
Stop displaying alien URLs in Engelsystem shifts

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
@@ -52,11 +52,13 @@ private fun Event.getCalendarDescription(context: Context): String = with(String
         links = StringUtils.getHtmlLinkFromMarkdown(links)
         append(links)
     } else {
-        val eventOnline = context.getString(R.string.event_online)
-        append(eventOnline)
-        append(": ")
         val eventUrl = EventUrlComposer(this@getCalendarDescription).getEventUrl()
-        append(eventUrl)
+        if (eventUrl.isNotEmpty()) {
+            val eventOnline = context.getString(R.string.event_online)
+            append(eventOnline)
+            append(": ")
+            append(eventUrl)
+        }
     }
     return toString()
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -7,13 +7,16 @@ import nerd.tuxmobil.fahrplan.congress.models.DayRange
 import nerd.tuxmobil.fahrplan.congress.models.Lecture
 import nerd.tuxmobil.fahrplan.congress.utils.DateHelper
 
+// Avoid conflicts with the IDs of the main schedule.
+private const val SHIFT_ID_OFFSET = 300000;
+
 fun Shift.toLectureAppModel(
 
         logging: Logging,
         virtualRoomName: String,
         dayRanges: List<DayRange>
 
-) = Lecture("$sID").apply {
+) = Lecture("${SHIFT_ID_OFFSET + sID}").apply {
     abstractt = ""
     date = startsAtLocalDateString
     dateUTC = dateUtcMs

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/EventDetailFragment.java
@@ -256,11 +256,16 @@ public class EventDetailFragment extends Fragment {
                 eventOnlineSection.setVisibility(View.GONE);
                 eventOnlineLink.setVisibility(View.GONE);
             } else {
-                eventOnlineSection.setVisibility(View.VISIBLE);
-                eventOnlineLink.setVisibility(View.VISIBLE);
-                final String eventUrl = new EventUrlComposer(lecture).getEventUrl();
-                final String eventLink = "<a href=\"" + eventUrl + "\">" + eventUrl + "</a>";
-                setUpHtmlTextView(eventOnlineLink, regular, eventLink);
+                String eventUrl = new EventUrlComposer(lecture).getEventUrl();
+                if (eventUrl.isEmpty()) {
+                    eventOnlineSection.setVisibility(View.GONE);
+                    eventOnlineLink.setVisibility(View.GONE);
+                } else {
+                    eventOnlineSection.setVisibility(View.VISIBLE);
+                    eventOnlineLink.setVisibility(View.VISIBLE);
+                    String eventLink = "<a href=\"" + eventUrl + "\">" + eventUrl + "</a>";
+                    setUpHtmlTextView(eventOnlineLink, regular, eventLink);
+                }
             }
 
             activity.invalidateOptionsMenu();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -36,7 +36,7 @@ object AppRepository {
      * for the database column. Do not change it!
      * Also used in app/src/<flavor>/res/xml/track_resource_names.xml.
      */
-    private const val ENGELSYSTEM_ROOM_NAME = "Engelshifts"
+    const val ENGELSYSTEM_ROOM_NAME = "Engelshifts"
     const val ALL_DAYS = -1
 
     private lateinit var context: Context

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposer.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
 
@@ -8,19 +9,43 @@ class EventUrlComposer @JvmOverloads constructor(
 
         private val event: Event,
         private val eventUrlTemplate: String = BuildConfig.EVENT_URL,
-        private val serverBackEndType: String = BuildConfig.SERVER_BACKEND_TYPE
+        private val serverBackEndType: String = BuildConfig.SERVER_BACKEND_TYPE,
+        private val specialRoomNames: Set<String> = setOf(AppRepository.ENGELSYSTEM_ROOM_NAME)
 
 ) {
 
+    /**
+     * Returns the website URL for the [event] if it can be composed
+     * otherwise an empty string.
+     *
+     * The URL composition depends on the backend system being used for the conference.
+     *
+     * Special handling is applied to events with a [room name][Event.room] which is part of
+     * the collection of [special room names][specialRoomNames]. If there an URL defined then
+     * it is returned. If there is no URL defined then no composition is tried but instead
+     * an empty string is returned.
+     */
     fun getEventUrl() = event.eventUrl
 
     private val Event.eventUrl: String
         get() = when (serverBackEndType) {
             PENTABARF.name -> getComposedEventUrl(event.slug)
-            else -> if (url.isNullOrEmpty()) getComposedEventUrl(lectureId) else url
+            else -> if (url.isNullOrEmpty()) {
+                if (specialRoomNames.contains(room)) {
+                    NO_URL
+                } else {
+                    getComposedEventUrl(lectureId)
+                }
+            } else {
+                url
+            }
         }
 
     private fun getComposedEventUrl(eventIdentifier: String) =
             String.format(eventUrlTemplate, eventIdentifier)
+
+    companion object {
+        private const val NO_URL = ""
+    }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EventUrlComposerTest.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
@@ -27,6 +28,16 @@ class EventUrlComposerTest {
         private val PRETALX_EVENT = Event("32").apply {
             url = "https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB"
             slug = "KDYQEB"
+        }
+
+        private val ENGELSYSTEM_SHIFT_EVENT_WITHOUT_URL = Event("7771").apply {
+            room = AppRepository.ENGELSYSTEM_ROOM_NAME
+            url = ""
+        }
+
+        private val ENGELSYSTEM_SHIFT_EVENT_WITH_URL = Event("7772").apply {
+            room = AppRepository.ENGELSYSTEM_ROOM_NAME
+            url = "https://helpful.to/the/angel"
         }
 
     }
@@ -62,6 +73,18 @@ class EventUrlComposerTest {
     fun getEventUrlWithPretalxEventWithPretalxBackend() {
         assertThat(EventUrlComposer(PRETALX_EVENT, "", ServerBackendType.PRETALX.name)
                 .getEventUrl()).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB")
+    }
+
+    @Test
+    fun getEventUrlWithShiftEventWithUrl() {
+        assertThat(EventUrlComposer(ENGELSYSTEM_SHIFT_EVENT_WITH_URL, FRAB_EVENT_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
+                .getEventUrl()).isEqualTo("https://helpful.to/the/angel")
+    }
+
+    @Test
+    fun getEventUrlWithShiftEventWithoutUrl() {
+        assertThat(EventUrlComposer(ENGELSYSTEM_SHIFT_EVENT_WITHOUT_URL, FRAB_EVENT_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
+                .getEventUrl()).isEqualTo("")
     }
 
 }


### PR DESCRIPTION
# Description
- Hide `Event online` section if the events URL is empty.
- Prevent composing invalid URLs for Engelsystem shifts.
- :bug: Bugfix: Stop displaying alien :alien: URLs in Engelsystem shifts.
  - This fixes an URL being shown in the `Event online` section of an Engelsystem shift which is associated with a different event.
  - The bug was caused by an overlap of the database IDs (`event_id` column).
- :heart: Thanks to Christian R. for reporting this!

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

# Before
- Engelsystem shift with alien URL in "Event online" section.
![Engelsystem shift with alien URL in "Event online" section](https://user-images.githubusercontent.com/144518/71772884-a4174180-2f53-11ea-9341-9f50bc1f57cf.png)


# After
- Engelsystem shift without "Event online" section.
![Engelsystem shift without "Event online" section](https://user-images.githubusercontent.com/144518/71772887-aaa5b900-2f53-11ea-8c8b-da3e9c7c4380.png)

