### PR TITLE
Clear "subtitle" if it matches the "title" of a session.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensions.kt
@@ -187,6 +187,9 @@ fun LectureNetworkModel.toLectureAppModel(): Lecture {
 }
 
 fun Lecture.sanitize(): Lecture {
+    if (title == subtitle) {
+        subtitle = ""
+    }
     if (abstractt == description) {
         abstractt = ""
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/LectureExtensionsTest.kt
@@ -118,6 +118,32 @@ class LectureExtensionsTest {
     }
 
     @Test
+    fun sanitizeWithSameTitleAndSubtitle() {
+        val lecture = Lecture("").apply {
+            subtitle = "Lorem ipsum"
+            title = "Lorem ipsum"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            subtitle = ""
+            title = "Lorem ipsum"
+        }
+        assertThat(lecture).isEqualTo(expected)
+    }
+
+    @Test
+    fun sanitizeWithDifferentTitleAndSubtitle() {
+        val lecture = Lecture("").apply {
+            subtitle = "Dolor sit amet"
+            title = "Lorem ipsum"
+        }.sanitize()
+        val expected = Lecture("").apply {
+            subtitle = "Dolor sit amet"
+            title = "Lorem ipsum"
+        }
+        assertThat(lecture).isEqualTo(expected)
+    }
+
+    @Test
     fun sanitizeWithSameAbstractAndDescription() {
         val lecture = Lecture("").apply {
             abstractt = "Lorem ipsum"


### PR DESCRIPTION
# Description
- This removes the "subtitle" text if it matches the "title". There is no value in showing the text twice.

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

# Before
- Session with identical title and subtitle.
![Session with identical title and subtitle](https://user-images.githubusercontent.com/144518/71777342-d8641f80-2f9e-11ea-914e-8bd5c0c9e4b3.png)


# After
- Session with title but without the subtitle.
![Session with title but without the subtitle](https://user-images.githubusercontent.com/144518/71777344-dd28d380-2f9e-11ea-9967-16c58aaddb96.png)
