### PR TITLE
Allow to use logging in all modules.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,6 +182,7 @@ tasks.withType(Test) {
 }
 
 dependencies {
+    implementation project(":commons")
     implementation project(":database")
     implementation project(":network")
     implementation project(":engelsystem")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
@@ -12,7 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.TimeZone;
 
-import nerd.tuxmobil.fahrplan.congress.logging.Logging;
+import info.metadude.android.eventfahrplan.commons.logging.Logging;
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.models.Meta;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -1,8 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import android.support.annotation.VisibleForTesting
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.kotlin.library.engelsystem.models.Shift
-import nerd.tuxmobil.fahrplan.congress.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.models.DayRange
 import nerd.tuxmobil.fahrplan.congress.models.Lecture
 import nerd.tuxmobil.fahrplan.congress.utils.DateHelper

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftsExtensions.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.kotlin.library.engelsystem.models.Shift
-import nerd.tuxmobil.fahrplan.congress.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.models.DayRange
 
 fun List<Shift>.toLectureAppModels(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/exceptions/AppExceptionHandler.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/exceptions/AppExceptionHandler.kt
@@ -1,6 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.exceptions
 
-import nerd.tuxmobil.fahrplan.congress.logging.Logging
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import kotlin.coroutines.CoroutineContext
 
 class AppExceptionHandler(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import android.content.Context
 import android.text.format.Time
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.database.extensions.toContentValues
 import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseRepository
 import info.metadude.android.eventfahrplan.database.repositories.HighlightsDatabaseRepository
@@ -20,7 +21,6 @@ import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.MyApp
 import nerd.tuxmobil.fahrplan.congress.dataconverters.*
 import nerd.tuxmobil.fahrplan.congress.exceptions.AppExceptionHandler
-import nerd.tuxmobil.fahrplan.congress.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.Lecture
 import nerd.tuxmobil.fahrplan.congress.models.Meta

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.kotlin.library.engelsystem.models.Shift
-import nerd.tuxmobil.fahrplan.congress.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.models.DayRange
 import nerd.tuxmobil.fahrplan.congress.utils.DateHelper
 import org.assertj.core.api.Assertions.assertThat

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -1,0 +1,26 @@
+import nerd.tuxmobil.fahrplan.congress.Android
+import nerd.tuxmobil.fahrplan.congress.Libs
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    compileSdkVersion Android.compileSdkVersion
+    buildToolsVersion Android.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion Android.minSdkVersion
+        targetSdkVersion Android.targetSdkVersion
+        versionCode 1
+        versionName "1.0.0"
+    }
+
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation Libs.kotlinStdlib
+}

--- a/commons/src/main/AndroidManifest.xml
+++ b/commons/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="info.metadude.android.eventfahrplan.commons" />

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/ConsoleLogger.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/ConsoleLogger.kt
@@ -1,12 +1,11 @@
-package nerd.tuxmobil.fahrplan.congress.logging
+package info.metadude.android.eventfahrplan.commons.logging
 
 import android.util.Log
-import nerd.tuxmobil.fahrplan.congress.MyApp
 
 object ConsoleLogger : Logging {
 
     override fun d(tag: String, message: String) {
-        MyApp.LogDebug(tag, message)
+        Log.d(tag, message)
     }
 
     override fun e(tag: String, message: String) {

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/Logging.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/Logging.kt
@@ -1,6 +1,6 @@
-package nerd.tuxmobil.fahrplan.congress.logging
+package info.metadude.android.eventfahrplan.commons.logging
 
-import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import info.metadude.android.eventfahrplan.commons.BuildConfig
 
 interface Logging {
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/NoLogging.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/logging/NoLogging.kt
@@ -1,4 +1,4 @@
-package nerd.tuxmobil.fahrplan.congress.logging
+package info.metadude.android.eventfahrplan.commons.logging
 
 object NoLogging : Logging {
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':database', ':engelsystem', ':network'
+include ':app', ':commons', ':database', ':engelsystem', ':network'


### PR DESCRIPTION
# Description
+ Introduce `commons` module.
+ Debug logging is no longer controlled by the `MyApp.LogDebug` flag.

# Successfully tested on
with `ccc36c3` flavor, `DEBUG` + `RELEASE`
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)
