### PR TITLE
Prevent crashes caused by closed database connections.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
@@ -63,7 +63,6 @@ public class AlarmList extends ActionBarListActivity {
                     null, null, null, Columns.TIME);
         } catch (SQLiteException e) {
             e.printStackTrace();
-            db.close();
             return;
         }
         startManagingCursor(cursor);
@@ -76,12 +75,6 @@ public class AlarmList extends ActionBarListActivity {
         registerForContextMenu(getListView());
 
         setResult(RESULT_CANCELED);
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        db.close();
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -258,9 +258,8 @@ object AppRepository {
         alarmsDatabaseRepository.query(eventId).toAlarmsAppModel()
     }
 
-    @JvmOverloads
-    fun deleteAlarmForAlarmId(alarmId: Int, closeSQLiteOpenHelper: Boolean = true) =
-            alarmsDatabaseRepository.deleteForAlarmId(alarmId, closeSQLiteOpenHelper)
+    fun deleteAlarmForAlarmId(alarmId: Int) =
+            alarmsDatabaseRepository.deleteForAlarmId(alarmId)
 
     fun deleteAlarmForEventId(eventId: String) =
             alarmsDatabaseRepository.deleteForEventId(eventId)

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SQLiteDatabaseExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SQLiteDatabaseExtensions.kt
@@ -35,24 +35,20 @@ fun SQLiteDatabase.delete(tableName: String, columnName: String? = null, columnV
 }
 
 /**
- * Executes the delete [query] within a transaction and finally closes the database.
+ * Executes the delete [query] within a transaction.
  */
 internal fun SQLiteDatabase.delete(query: SQLiteDatabase.() -> Int) =
-        use {
-            it.transaction {
-                query()
-            }
+        transaction {
+            query()
         }
 
 /**
- * Executes the [delete] and the [insert] queries within a transaction and finally closes the database.
+ * Executes the [delete] and the [insert] queries within a transaction.
  */
 internal fun SQLiteDatabase.upsert(delete: SQLiteDatabase.() -> Int, insert: SQLiteDatabase.() -> Long) =
-        use {
-            it.transaction {
-                delete()
-                insert()
-            }
+        transaction {
+            delete()
+            insert()
         }
 
 /**

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
@@ -23,7 +23,6 @@ class AlarmsDatabaseRepository(
         }, {
             insert(AlarmsTable.NAME, values)
         })
-        close()
     }
 
     fun query(): List<Alarm> = query {
@@ -44,15 +43,11 @@ class AlarmsDatabaseRepository(
         } catch (e: SQLiteException) {
             e.printStackTrace()
             Log.e(javaClass.name, "Failure on alarm query.")
-            database.close()
-            sqLiteOpenHelper.close()
             return alarms.toList()
         }
 
         if (cursor.count == 0) {
             cursor.close()
-            database.close()
-            sqLiteOpenHelper.close()
             Log.d(javaClass.name, "No alarms found.")
             return alarms.toList()
         }
@@ -70,13 +65,11 @@ class AlarmsDatabaseRepository(
             cursor.moveToNext()
         }
         cursor.close()
-        database.close()
-        sqLiteOpenHelper.close()
 
         return alarms.toList()
     }
 
-    fun deleteForAlarmId(alarmId: Int, closeSQLiteOpenHelper: Boolean) = delete(closeSQLiteOpenHelper) {
+    fun deleteForAlarmId(alarmId: Int) = delete {
         delete(AlarmsTable.NAME, ID, "$alarmId")
     }
 
@@ -84,12 +77,9 @@ class AlarmsDatabaseRepository(
         delete(AlarmsTable.NAME, EVENT_ID, eventId)
     }
 
-    private fun delete(closeSQLiteOpenHelper: Boolean = true, query: SQLiteDatabase.() -> Int) =
+    private fun delete(query: SQLiteDatabase.() -> Int) =
             with(sqLiteOpenHelper) {
                 writableDatabase.delete(query)
-                if (closeSQLiteOpenHelper) {
-                    close()
-                }
             }
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -23,7 +23,6 @@ class HighlightsDatabaseRepository(
         }, {
             insert(HighlightsTable.NAME, values)
         })
-        close()
     }
 
     fun query(): List<Highlight> {
@@ -34,8 +33,6 @@ class HighlightsDatabaseRepository(
             cursor = database.read(HighlightsTable.NAME)
         } catch (e: SQLiteException) {
             e.printStackTrace()
-            database.close()
-            sqLiteOpenHelper.close()
             return highlights.toList()
         }
 
@@ -50,8 +47,6 @@ class HighlightsDatabaseRepository(
             cursor.moveToNext()
         }
         cursor.close()
-        database.close()
-        sqLiteOpenHelper.close()
 
         return highlights.toList()
     }
@@ -65,8 +60,6 @@ class HighlightsDatabaseRepository(
                 selectionArgs = arrayOf(eventId.toString())
             )
         } catch (e: SQLiteException) {
-            database.close()
-            sqLiteOpenHelper.close()
             return null
         }
 
@@ -80,8 +73,6 @@ class HighlightsDatabaseRepository(
             }
         }
 
-        database.close()
-        sqLiteOpenHelper.close()
         return highlight
     }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
@@ -9,6 +9,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Le
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.LecturesTable.Columns.*
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.LecturesTable.Values.REC_OPT_OUT_OFF
 import info.metadude.android.eventfahrplan.database.extensions.*
+import info.metadude.android.eventfahrplan.database.extensions.transaction
 import info.metadude.android.eventfahrplan.database.models.Lecture
 import info.metadude.android.eventfahrplan.database.sqliteopenhelper.LecturesDBOpenHelper
 
@@ -20,15 +21,12 @@ class LecturesDatabaseRepository(
 ) {
 
     fun insert(list: List<ContentValues>) = with(sqLiteOpenHelper) {
-        writableDatabase.use {
-            it.transaction {
-                delete(LecturesTable.NAME)
-                list.forEach { contentValues ->
-                    insert(LecturesTable.NAME, contentValues)
-                }
+        writableDatabase.transaction {
+            delete(LecturesTable.NAME)
+            list.forEach { contentValues ->
+                insert(LecturesTable.NAME, contentValues)
             }
         }
-        close()
     }
 
     fun queryLectureByLectureId(lectureId: String): Lecture {
@@ -79,15 +77,11 @@ class LecturesDatabaseRepository(
             cursor = query()
         } catch (e: SQLiteException) {
             e.printStackTrace()
-            close()
-            sqLiteOpenHelper.close()
             return lectures.toList()
         }
 
         if (cursor.count == 0) {
             cursor.close()
-            close()
-            sqLiteOpenHelper.close()
             return lectures.toList()
         }
 
@@ -139,8 +133,6 @@ class LecturesDatabaseRepository(
             cursor.moveToNext()
         }
         cursor.close()
-        close()
-        sqLiteOpenHelper.close()
         return lectures.toList()
     }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
@@ -27,7 +27,6 @@ class MetaDatabaseRepository(
         }, {
             insert(MetasTable.NAME, values)
         })
-        close()
     }
 
     fun query(): Meta {
@@ -38,8 +37,6 @@ class MetaDatabaseRepository(
             cursor = database.read(MetasTable.NAME)
         } catch (e: SQLiteException) {
             e.printStackTrace()
-            database.close()
-            sqLiteOpenHelper.close()
             return Meta()
         }
 
@@ -61,8 +58,6 @@ class MetaDatabaseRepository(
         Log.d(javaClass.name, "query(): $meta")
 
         cursor.close()
-        database.close()
-        sqLiteOpenHelper.close()
 
         return meta
     }


### PR DESCRIPTION
# Description
+ Errors: :bomb: 
  + `SQLiteDatabaseLockedException: database is locked.`
  + `IllegalStateException: Cannot perform this operation because the connection pool has been closed.`
+ Crashes might still occur since `AlarmList` uses a `CursorAdapter` to access and manage the database.
+ Related commit: acfef066bfc83a602c2faf507b56e8b914be12e9

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

Resolves #229 
Resolves #228