### PR TITLE
Clean up reading from Cursor

### DIFF
--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
@@ -39,3 +39,14 @@ inline fun Cursor.getLong(columnName: String): Long = getLong(getColumnIndexOrTh
  * @see Cursor.getString
  */
 inline fun Cursor.getString(columnName: String): String = getString(getColumnIndexOrThrow(columnName))
+
+/**
+ * Returns a list containing the results of applying the given [transform] function to each row
+ * in the [Cursor]. Closes the Cursor afterwards.
+ */
+inline fun <T> Cursor.map(transform: (Cursor) -> T): List<T> = this.use {
+    List(count) { index ->
+        moveToPosition(index)
+        transform(this)
+    }
+}

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
@@ -34,39 +34,31 @@ class AlarmsDatabaseRepository(
     }
 
     private fun query(query: SQLiteDatabase.() -> Cursor): List<Alarm> {
-        val alarms = mutableListOf<Alarm>()
         val database = sqLiteOpenHelper.readableDatabase
-        val cursor: Cursor
 
-        try {
-            cursor = database.query()
+        val cursor = try {
+            database.query()
         } catch (e: SQLiteException) {
             e.printStackTrace()
             Log.e(javaClass.name, "Failure on alarm query.")
-            return alarms.toList()
+            return emptyList()
         }
 
-        if (cursor.count == 0) {
-            cursor.close()
-            Log.d(javaClass.name, "No alarms found.")
-            return alarms.toList()
-        }
-
-        cursor.moveToFirst()
-        while (!cursor.isAfterLast) {
-            val alarm = Alarm(
+        val alarms = cursor.map {
+            Alarm(
                     id = cursor.getInt(ID),
                     day = cursor.getInt(DAY),
                     eventId = cursor.getString(EVENT_ID),
                     time = cursor.getLong(TIME),
                     title = cursor.getString(EVENT_TITLE)
             )
-            alarms.add(alarm)
-            cursor.moveToNext()
         }
-        cursor.close()
 
-        return alarms.toList()
+        if (alarms.isEmpty()) {
+            Log.d(javaClass.name, "No alarms found.")
+        }
+
+        return alarms
     }
 
     fun deleteForAlarmId(alarmId: Int) = delete {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -1,7 +1,6 @@
 package info.metadude.android.eventfahrplan.database.repositories
 
 import android.content.ContentValues
-import android.database.Cursor
 import android.database.sqlite.SQLiteException
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.EVENT_ID
@@ -28,27 +27,22 @@ class HighlightsDatabaseRepository(
     fun query(): List<Highlight> {
         val highlights = mutableListOf<Highlight>()
         val database = sqLiteOpenHelper.readableDatabase
-        val cursor: Cursor
-        try {
-            cursor = database.read(HighlightsTable.NAME)
+
+        val cursor = try {
+            database.read(HighlightsTable.NAME)
         } catch (e: SQLiteException) {
             e.printStackTrace()
             return highlights.toList()
         }
 
-        cursor.moveToFirst()
-        while (!cursor.isAfterLast) {
+        return cursor.map {
             val eventIdString = cursor.getString(EVENT_ID)
             val eventId = Integer.parseInt(eventIdString)
             val highlightState = cursor.getInt(HIGHLIGHT)
             val isHighlighted = highlightState == HIGHLIGHT_STATE_ON
-            val highlight = Highlight(eventId, isHighlighted)
-            highlights.add(highlight)
-            cursor.moveToNext()
-        }
-        cursor.close()
 
-        return highlights.toList()
+            Highlight(eventId, isHighlighted)
+        }
     }
 
     fun queryByEventId(eventId: Int): Highlight? {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/LecturesDatabaseRepository.kt
@@ -70,30 +70,21 @@ class LecturesDatabaseRepository(
     }
 
     private fun query(query: SQLiteDatabase.() -> Cursor): List<Lecture> = with(sqLiteOpenHelper.readableDatabase) {
-        val lectures = mutableListOf<Lecture>()
-        val cursor: Cursor
-
-        try {
-            cursor = query()
+        val cursor = try {
+            query()
         } catch (e: SQLiteException) {
             e.printStackTrace()
-            return lectures.toList()
+            return emptyList()
         }
 
-        if (cursor.count == 0) {
-            cursor.close()
-            return lectures.toList()
-        }
-
-        cursor.moveToFirst()
-        while (!cursor.isAfterLast) {
+        return cursor.map {
             val recordingOptOut =
                     if (cursor.getInt(REC_OPTOUT) == REC_OPT_OUT_OFF)
                         Lecture.RECORDING_OPT_OUT_OFF
                     else
                         Lecture.RECORDING_OPT_OUT_ON
 
-            val lecture = Lecture(
+            Lecture(
                     eventId = cursor.getString(EVENT_ID),
                     abstractt = cursor.getString(ABSTRACT),
                     date = cursor.getString(DATE),
@@ -129,11 +120,7 @@ class LecturesDatabaseRepository(
                     changedTitle = cursor.getInt(CHANGED_TITLE).isChanged,
                     changedTrack = cursor.getInt(CHANGED_TRACK).isChanged
             )
-            lectures.add(lecture)
-            cursor.moveToNext()
         }
-        cursor.close()
-        return lectures.toList()
     }
 
     private val Int.isChanged

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
@@ -1,7 +1,6 @@
 package info.metadude.android.eventfahrplan.database.repositories
 
 import android.content.ContentValues
-import android.database.Cursor
 import android.database.sqlite.SQLiteException
 import android.util.Log
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable
@@ -32,32 +31,30 @@ class MetaDatabaseRepository(
     fun query(): Meta {
         val database = sqLiteOpenHelper.readableDatabase
 
-        val cursor: Cursor
-        try {
-            cursor = database.read(MetasTable.NAME)
+        val cursor = try {
+            database.read(MetasTable.NAME)
         } catch (e: SQLiteException) {
             e.printStackTrace()
             return Meta()
         }
 
-        val meta = if (cursor.count == 0) {
-            Meta()
-        } else {
-            cursor.moveToFirst()
-            Meta(
-                    numDays = cursor.getInt(NUM_DAYS),
-                    version = cursor.getString(VERSION),
-                    title = cursor.getString(TITLE),
-                    subtitle = cursor.getString(SUBTITLE),
-                    dayChangeHour = cursor.getInt(DAY_CHANGE_HOUR),
-                    dayChangeMinute = cursor.getInt(DAY_CHANGE_MINUTE),
-                    eTag = cursor.getString(ETAG)
-            )
+        val meta = cursor.use {
+            if (cursor.moveToFirst()) {
+                Meta(
+                        numDays = cursor.getInt(NUM_DAYS),
+                        version = cursor.getString(VERSION),
+                        title = cursor.getString(TITLE),
+                        subtitle = cursor.getString(SUBTITLE),
+                        dayChangeHour = cursor.getInt(DAY_CHANGE_HOUR),
+                        dayChangeMinute = cursor.getInt(DAY_CHANGE_MINUTE),
+                        eTag = cursor.getString(ETAG)
+                )
+            } else {
+                Meta()
+            }
         }
 
         Log.d(javaClass.name, "query(): $meta")
-
-        cursor.close()
 
         return meta
     }


### PR DESCRIPTION
Clean up code that reads from `Cursor` to hopefully be easier to read. Now with less opportunities to forget closing the `Cursor`.