### PR TITLE
Do not render "Schedule " prefix when schedule version is not provided.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -37,7 +37,14 @@ public class AboutDialog extends DialogFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         TextView text = view.findViewById(R.id.eventVersion);
-        text.setText(getString(R.string.fahrplan) + " " + MyApp.meta.getVersion());
+        String scheduleVersionText = MyApp.meta.getVersion();
+        if (TextUtils.isEmpty(scheduleVersionText)) {
+            text.setVisibility(View.GONE);
+        } else {
+            text.setVisibility(View.VISIBLE);
+            String prefixedScheduleVersionText = getString(R.string.fahrplan) + " " + scheduleVersionText;
+            text.setText(prefixedScheduleVersionText);
+        }
         text = view.findViewById(R.id.eventTitle);
         String title = MyApp.meta.getTitle();
         if (TextUtils.isEmpty(title)) {


### PR DESCRIPTION
# Description
- Some APIs do not provide any version information with the _schedule.xml_. The leads to nothing but the word `Schedule` being shown in the relevant part of the "About" screen.

# Successfully tested on
with `ccc36c3` flavor
- :heavy_check_mark: Google Pixel 2, Android 10 (API 29)

# Before
- "About" screen with the word "Schedule".
![About screen with the word "Schedule"](https://user-images.githubusercontent.com/144518/75392145-b9717200-58eb-11ea-87a4-a74eae9d598d.png)

# After
- "About" screen without the word "Schedule".
![About screen without the word "Schedule"](https://user-images.githubusercontent.com/144518/75392165-bfffe980-58eb-11ea-8ae7-88b0aeeb7c22.png)

