### PR TITLE
Let getStartTimeMilliseconds() be a method of the Lecture class.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
@@ -9,7 +9,6 @@ import android.widget.Toast
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.utils.EventUrlComposer
-import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 import nerd.tuxmobil.fahrplan.congress.utils.StringUtils
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 import nerd.tuxmobil.fahrplan.congress.models.Lecture as Event
@@ -28,7 +27,7 @@ private fun Event.toCalendarInsertIntent(context: Context): Intent {
     val title = this.title
     val description = this.getCalendarDescription(context)
     val location = this.room
-    val startTime = FahrplanMisc.getLectureStartTime(this)
+    val startTime = startTimeMilliseconds
     val endTime = startTime + this.duration * 60000
     return Intent(Intent.ACTION_INSERT, CalendarContract.Events.CONTENT_URI).apply {
         putExtra(CalendarContract.Events.TITLE, title)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Lecture.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Lecture.java
@@ -104,6 +104,16 @@ public class Lecture {
         return moment;
     }
 
+    /**
+     * Returns the start time in milliseconds.
+     * <p>
+     * The {@link #dateUTC} is given precedence if its value is bigger then `0`.
+     * Otherwise the start time is determined based on {@link #getStartTimeMoment}.
+     */
+    public long getStartTimeMilliseconds() {
+        return (dateUTC > 0) ? dateUTC : getStartTimeMoment().toMilliseconds();
+    }
+
     @SuppressWarnings("EqualsReplaceableByObjectsCall")
     @Override
     public boolean equals(Object o) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleLectureFormat.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleLectureFormat.java
@@ -8,7 +8,6 @@ import java.util.List;
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.utils.EventUrlComposer;
-import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 import nerd.tuxmobil.fahrplan.congress.wiki.WikiEventUtils;
 
 public class SimpleLectureFormat {
@@ -47,7 +46,7 @@ public class SimpleLectureFormat {
     }
 
     private static void appendLecture(StringBuilder builder, Lecture lecture) {
-        long startTime = FahrplanMisc.getLectureStartTime(lecture);
+        long startTime = lecture.getStartTimeMilliseconds();
         String formattedTime = DateFormatter.newInstance().getFormattedDateTime(startTime);
         builder.append(lecture.title);
         builder.append(LINE_BREAK);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -50,17 +50,6 @@ public class FahrplanMisc {
         }
     }
 
-    public static long getLectureStartTime(@NonNull Lecture lecture) {
-        long when;
-        if (lecture.dateUTC > 0) {
-            when = lecture.dateUTC;
-        } else {
-            Moment moment = lecture.getStartTimeMoment();
-            when = moment.toMilliseconds();
-        }
-        return when;
-    }
-
     public static void deleteAlarm(@NonNull Context context, @NonNull AppRepository appRepository, @NonNull Lecture lecture) {
         String eventId = lecture.lectureId;
         List<Alarm> alarms = appRepository.readAlarms(eventId);

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/LectureTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/LectureTest.kt
@@ -19,4 +19,23 @@ class LectureTest {
         assertThat(moment.monthDay).isEqualTo(27)
         assertThat(moment.year).isEqualTo(2019)
     }
+
+    @Test
+    fun `getLectureStartTime returns the "dateUTC" value when "dateUTC" is set`() {
+        val lecture = Lecture("1").apply {
+            dateUTC = 1
+            date = "2020-03-20"
+        }
+        assertThat(lecture.startTimeMilliseconds).isEqualTo(1)
+    }
+
+    @Test
+    fun `getLectureStartTime returns the "date" value when "dateUTC" is not set`() {
+        val lecture = Lecture("1").apply {
+            dateUTC = 0
+            date = "2020-03-20"
+        }
+        assertThat(lecture.startTimeMilliseconds).isEqualTo(1584662400000L)
+    }
+
 }


### PR DESCRIPTION
# Description
- This moves the former `getLectureStartTime()` method from `FahrplanMisc` into the `Lecture` class as it directly acts on fields of this class.
- The method is renamed to `getStartTimeMilliseconds()` to better describe its behavior.
- Add unit tests & JavaDoc.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 2, Android 10.

## Test scenarios
- Add a lecture to your calendar and verify the time is correct.
- Share a lecture to some other app and verify the time is correct.