### PR TITLE
Observing data - part 02

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
@@ -64,8 +64,6 @@ public class MyApp extends Application {
 
     public static TASKS task_running = TASKS.NONE;
 
-    public static String fahrplan_xml;
-
     public static int lectureListDay = 0;
 
     public static final SparseIntArray roomList = new SparseIntArray();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -6,7 +6,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.content.ContextCompat;
 import android.text.Html;
-import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.method.MovementMethod;
 import android.view.LayoutInflater;
@@ -15,10 +14,39 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
-import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
 
 public class AboutDialog extends DialogFragment {
+
+    private static final String BUNDLE_KEY_SCHEDULE_VERSION =
+            BuildConfig.APPLICATION_ID + ".BUNDLE_KEY_SCHEDULE_VERSION";
+    private static final String BUNDLE_KEY_SUBTITLE =
+            BuildConfig.APPLICATION_ID + ".BUNDLE_KEY_SUBTITLE";
+    private static final String BUNDLE_KEY_TITLE =
+            BuildConfig.APPLICATION_ID + ".BUNDLE_KEY_TITLE";
+
+    public static AboutDialog newInstance(
+            @NonNull String scheduleVersion,
+            @NonNull String subtitle,
+            @NonNull String title
+    ) {
+        Bundle arguments = new Bundle();
+        arguments.putString(BUNDLE_KEY_SCHEDULE_VERSION, scheduleVersion);
+        arguments.putString(BUNDLE_KEY_SUBTITLE, subtitle);
+        arguments.putString(BUNDLE_KEY_TITLE, title);
+        AboutDialog dialog = new AboutDialog();
+        dialog.setArguments(arguments);
+        return dialog;
+    }
+
+    @NonNull
+    private String scheduleVersionText = "";
+
+    @NonNull
+    private String subtitleText = "";
+
+    @NonNull
+    private String titleText = "";
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -31,14 +59,19 @@ public class AboutDialog extends DialogFragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setStyle(DialogFragment.STYLE_NO_TITLE, R.style.Dialog);
+        Bundle arguments = getArguments();
+        if (arguments != null) {
+            scheduleVersionText = arguments.getString(BUNDLE_KEY_SCHEDULE_VERSION, "");
+            subtitleText = arguments.getString(BUNDLE_KEY_SUBTITLE, "");
+            titleText = arguments.getString(BUNDLE_KEY_TITLE, "");
+        }
     }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         TextView text = view.findViewById(R.id.eventVersion);
-        String scheduleVersionText = MyApp.meta.getVersion();
-        if (TextUtils.isEmpty(scheduleVersionText)) {
+        if (scheduleVersionText.isEmpty()) {
             text.setVisibility(View.GONE);
         } else {
             text.setVisibility(View.VISIBLE);
@@ -46,17 +79,15 @@ public class AboutDialog extends DialogFragment {
             text.setText(prefixedScheduleVersionText);
         }
         text = view.findViewById(R.id.eventTitle);
-        String title = MyApp.meta.getTitle();
-        if (TextUtils.isEmpty(title)) {
-            title = getString(R.string.app_name);
+        if (titleText.isEmpty()) {
+            titleText = getString(R.string.app_name);
         }
-        text.setText(title);
+        text.setText(titleText);
         text = view.findViewById(R.id.eventSubtitle);
-        String subtitle = MyApp.meta.getSubtitle();
-        if (TextUtils.isEmpty(subtitle)) {
-            subtitle = getString(R.string.app_hardcoded_subtitle);
+        if (subtitleText.isEmpty()) {
+            subtitleText = getString(R.string.app_hardcoded_subtitle);
         }
-        text.setText(subtitle);
+        text.setText(subtitleText);
         text = view.findViewById(R.id.appVersion);
         String appVersionText = getString(R.string.appVersion, BuildConfig.VERSION_NAME);
         text.setText(appVersionText);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -44,7 +44,6 @@ public class UpdateService extends SafeJobIntentService {
     public void onParseDone(@NonNull ParseResult result) {
         MyApp.LogDebug(LOG_TAG, "parseDone: " + result.isSuccess() + " , numDays=" + MyApp.meta.getNumDays());
         MyApp.task_running = TASKS.NONE;
-        MyApp.fahrplan_xml = null;
         List<Lecture> changesList = appRepository.loadChangedLectures();
         if (!changesList.isEmpty() && result instanceof ParseScheduleResult) {
             showScheduleUpdateNotification(((ParseScheduleResult) result).getVersion(), changesList.size());
@@ -89,7 +88,6 @@ public class UpdateService extends SafeJobIntentService {
             return;
         }
 
-        MyApp.fahrplan_xml = fetchScheduleResult.getScheduleXml();
         MyApp.meta.setETag(fetchScheduleResult.getETag());
         // Parser is automatically invoked when response has been received.
         MyApp.task_running = TASKS.PARSE;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -71,4 +71,6 @@ public interface BundleKeys {
             "nerd.tuxmobil.fahrplan.congress.Prefs.ALTERNATIVE_HIGHLIGHT";
     String PREFS_ALARM_TIME_INDEX =
             "nerd.tuxmobil.fahrplan.congress.Prefs.ALARM_TIME_INDEX";
+    String PREFS_DISPLAY_DAY_INDEX =
+            "nerd.tuxmobil.fahrplan.congress.Prefs.DISPLAY_DAY_INDEX";
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensions.kt
@@ -5,7 +5,6 @@ import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult as AppFetchSchedu
 
 fun NetworkFetchScheduleResult.toAppFetchScheduleResult() = AppFetchScheduleResult(
         httpStatus = httpStatus.toAppHttpStatus(),
-        scheduleXml = scheduleXml,
         eTag = eTag,
         hostName = hostName,
         exceptionMessage = exceptionMessage
@@ -13,7 +12,6 @@ fun NetworkFetchScheduleResult.toAppFetchScheduleResult() = AppFetchScheduleResu
 
 fun AppFetchScheduleResult.toNetworkFetchScheduleResult() = NetworkFetchScheduleResult(
         httpStatus = httpStatus.toNetworkHttpStatus(),
-        scheduleXml = scheduleXml,
         eTag = eTag,
         hostName = hostName,
         exceptionMessage = exceptionMessage

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
@@ -6,8 +6,6 @@ import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkMod
 
 
 fun Meta.toMetaDatabaseModel() = MetaDatabaseModel(
-        dayChangeHour = dayChangeHour,
-        dayChangeMinute = dayChangeMinute,
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
@@ -16,8 +14,6 @@ fun Meta.toMetaDatabaseModel() = MetaDatabaseModel(
 )
 
 fun Meta.toMetaNetworkModel() = MetaNetworkModel(
-        dayChangeHour = dayChangeHour,
-        dayChangeMinute = dayChangeMinute,
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
@@ -26,8 +22,6 @@ fun Meta.toMetaNetworkModel() = MetaNetworkModel(
 )
 
 fun MetaDatabaseModel.toMetaAppModel() = Meta(
-        dayChangeHour = dayChangeHour,
-        dayChangeMinute = dayChangeMinute,
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
@@ -36,8 +30,6 @@ fun MetaDatabaseModel.toMetaAppModel() = Meta(
 )
 
 fun MetaNetworkModel.toMetaAppModel() = Meta(
-        dayChangeHour = dayChangeHour,
-        dayChangeMinute = dayChangeMinute,
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfo.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfo.kt
@@ -6,11 +6,22 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
  * Represents a connection between given [date] and [dayIdx].
  * Useful to later ask for a [dayIdx] providing a date (see [getDayIndex]).
  */
-data class DateInfo(val dayIdx: Int, val date: Moment) {
+data class DateInfo(
+
+        val dayIdx: Int,
+        val date: Moment
+
+) {
+
+    companion object {
+        const val DAY_INDEX_NOT_FOUND = -1
+    }
 
     /**
      * Retrieve day index of stored date.
-     * @return if given [date] matches the stored [date], returns stored [dayIdx], -1 otherwise.
+     * @return if given [date] matches the stored [date]
+     * returns stored [dayIdx], [DAY_INDEX_NOT_FOUND] otherwise.
      */
-    fun getDayIndex(date: Moment): Int = if (this.date == date) dayIdx else -1
+    fun getDayIndex(date: Moment) = if (this.date == date) dayIdx else DAY_INDEX_NOT_FOUND
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.java
@@ -7,6 +7,14 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 public class DateInfos extends ArrayList<DateInfo> {
 
     private static final long serialVersionUID = 1L;
+    /**
+     * Hour of day change (all lectures which start before count to the previous day).
+     */
+    private static final int DAY_CHANGE_HOUR_DEFAULT = 4;
+    /**
+     * Minute of day change.
+     */
+    private static final int DAY_CHANGE_MINUTE_DEFAULT = 0;
 
     public boolean sameDay(Moment today, int lectureListDay) {
         Moment currentDate = today.startOfDay();
@@ -20,20 +28,17 @@ public class DateInfos extends ArrayList<DateInfo> {
     }
 
     /**
-     * Returns the index of today
+     * Returns the index of today.
      *
-     * @param hourOfDayChange   Hour of day change (all lectures which start before count to the
-     *                          previous day)
-     * @param minuteOfDayChange Minute of day change
      * @return dayIndex if found, {@link DateInfo#DAY_INDEX_NOT_FOUND} otherwise.
      */
-    public int getIndexOfToday(int hourOfDayChange, int minuteOfDayChange) {
+    public int getIndexOfToday() {
         if (isEmpty()) {
             return DateInfo.DAY_INDEX_NOT_FOUND;
         }
         Moment today = new Moment();
-        today.minusHours(hourOfDayChange);
-        today.minusMinutes(minuteOfDayChange);
+        today.minusHours(DAY_CHANGE_HOUR_DEFAULT);
+        today.minusMinutes(DAY_CHANGE_MINUTE_DEFAULT);
 
         Moment currentDate = today.startOfDay();
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.java
@@ -25,11 +25,11 @@ public class DateInfos extends ArrayList<DateInfo> {
      * @param hourOfDayChange   Hour of day change (all lectures which start before count to the
      *                          previous day)
      * @param minuteOfDayChange Minute of day change
-     * @return dayIndex if found, -1 otherwise
+     * @return dayIndex if found, {@link DateInfo#DAY_INDEX_NOT_FOUND} otherwise.
      */
     public int getIndexOfToday(int hourOfDayChange, int minuteOfDayChange) {
         if (isEmpty()) {
-            return -1;
+            return DateInfo.DAY_INDEX_NOT_FOUND;
         }
         Moment today = new Moment();
         today.minusHours(hourOfDayChange);
@@ -37,10 +37,10 @@ public class DateInfos extends ArrayList<DateInfo> {
 
         Moment currentDate = today.startOfDay();
 
-        int dayIndex = -1;
+        int dayIndex = DateInfo.DAY_INDEX_NOT_FOUND;
         for (DateInfo dateInfo : this) {
             dayIndex = dateInfo.getDayIndex(currentDate);
-            if (dayIndex != -1) {
+            if (dayIndex != DateInfo.DAY_INDEX_NOT_FOUND) {
                 return dayIndex;
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
@@ -4,8 +4,6 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 
 data class Meta(
 
-        var dayChangeHour: Int = MetasTable.Defaults.DAY_CHANGE_HOUR_DEFAULT,
-        var dayChangeMinute: Int = MetasTable.Defaults.DAY_CHANGE_MINUTE_DEFAULT,
         var eTag: String = "",
         var numDays: Int = MetasTable.Defaults.NUM_DAYS_DEFAULT,
         var subtitle: String = "",

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.net
 data class FetchScheduleResult(
 
         val httpStatus: HttpStatus,
-        val scheduleXml: String = "",
         val eTag: String = "",
         val hostName: String,
         val exceptionMessage: String = ""

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -10,6 +10,14 @@ class SharedPreferencesRepository(val context: Context) {
 
     private val preferences: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context.applicationContext)
 
+    fun getDisplayDayIndex()
+            = preferences.getInt(BundleKeys.PREFS_DISPLAY_DAY_INDEX, 1)
+
+    fun setDisplayDayIndex(displayDayIndex: Int) = with(preferences.edit()) {
+        putInt(BundleKeys.PREFS_DISPLAY_DAY_INDEX, displayDayIndex)
+        apply()
+    }
+
     fun getScheduleLastFetchedAt() =
             preferences.getLong(BundleKeys.PREFS_SCHEDULE_LAST_FETCHED_AT, 0)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -106,7 +106,7 @@ object AppRepository {
                 check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
                 // Parsing
                 parseSchedule(
-                        fetchResult.scheduleXml,
+                        fetchScheduleResult.scheduleXml,
                         fetchResult.eTag,
                         okHttpClient,
                         onParsingDone,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -404,4 +404,10 @@ object AppRepository {
     private fun resetChangesSeenFlag() =
             updateScheduleChangesSeen(false)
 
+    fun readDisplayDayIndex() =
+            sharedPreferencesRepository.getDisplayDayIndex()
+
+    fun updateDisplayDayIndex(displayDayIndex: Int) =
+            sharedPreferencesRepository.setDisplayDayIndex(displayDayIndex)
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -352,8 +352,7 @@ public class FahrplanFragment extends Fragment implements View.OnClickListener, 
         if (lectureId != null) {
             return;
         }
-        if (MyApp.lectureListDay != MyApp.dateInfos.getIndexOfToday(
-                MyApp.meta.getDayChangeHour(), MyApp.meta.getDayChangeMinute())) {
+        if (MyApp.lectureListDay != MyApp.dateInfos.getIndexOfToday()) {
             return;
         }
         Moment nowMoment = new Moment();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.schedule;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -110,8 +109,6 @@ public class FahrplanFragment extends Fragment implements View.OnClickListener, 
             "Lounge"
     };
 
-    public static final String PREFS_NAME = "settings";
-
     private Typeface light;
 
     private View contextMenuView;
@@ -170,8 +167,7 @@ public class FahrplanFragment extends Fragment implements View.OnClickListener, 
             roomScroller.setOnTouchListener((v, event) -> true);
         }
 
-        SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, 0);
-        mDay = prefs.getInt("displayDay", 1);
+        mDay = appRepository.readDisplayDayIndex();
 
         inflater = Contexts.getLayoutInflater(context);
 
@@ -190,10 +186,7 @@ public class FahrplanFragment extends Fragment implements View.OnClickListener, 
     }
 
     private void saveCurrentDay(int day) {
-        SharedPreferences settings = requireContext().getSharedPreferences(PREFS_NAME, 0);
-        SharedPreferences.Editor editor = settings.edit();
-        editor.putInt("displayDay", day);
-        editor.apply();
+        appRepository.updateDisplayDayIndex(day);
     }
 
     @Override
@@ -656,8 +649,7 @@ public class FahrplanFragment extends Fragment implements View.OnClickListener, 
                 if (MyApp.meta.getNumDays() > 1) {
                     buildNavigationMenu();
                 }
-                SharedPreferences prefs = activity.getSharedPreferences(PREFS_NAME, 0);
-                mDay = prefs.getInt("displayDay", 1);
+                mDay = appRepository.readDisplayDayIndex();
                 if (mDay > MyApp.meta.getNumDays()) {
                     mDay = 1;
                 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -184,7 +184,6 @@ public class MainActivity extends BaseActivity implements
         showUpdateAction = true;
         invalidateOptionsMenu();
 
-        MyApp.fahrplan_xml = fetchScheduleResult.getScheduleXml();
         MyApp.meta.setETag(fetchScheduleResult.getETag());
 
         // Parser is automatically invoked when response has been received.
@@ -210,7 +209,6 @@ public class MainActivity extends BaseActivity implements
             MyApp.LogDebug(LOG_TAG, "Parsing Engelsystem shifts done successfully: " + result.isSuccess());
         }
         MyApp.task_running = TASKS.NONE;
-        MyApp.fahrplan_xml = null;
 
         if (MyApp.meta.getNumDays() == 0) {
             hideProgressDialog();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -345,10 +345,14 @@ public class MainActivity extends BaseActivity implements
     }
 
     void showAboutDialog() {
+        Meta meta = appRepository.readMeta();
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.addToBackStack(null);
-        DialogFragment about = new AboutDialog();
-        about.show(ft, "about");
+        AboutDialog.newInstance(
+                meta.getVersion(),
+                meta.getSubtitle(),
+                meta.getTitle()
+        ).show(ft, "about");
     }
 
     @Override

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
@@ -1,22 +1,42 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
-import info.metadude.android.eventfahrplan.network.fetching.HttpStatus
+import nerd.tuxmobil.fahrplan.congress.net.HttpStatus as AppHttpStatus
+import info.metadude.android.eventfahrplan.network.fetching.HttpStatus as NetworkHttpStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult as NetworkFetchScheduleResult
+import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult as AppFetchScheduleResult
 
 class FetchScheduleResultExtensionsTest {
 
     @Test
     fun networkFetchScheduleResult_toAppFetchScheduleResult_toNetworkFetchScheduleResult() {
         val fetchScheduleResult = NetworkFetchScheduleResult(
-                httpStatus = HttpStatus.HTTP_NOT_MODIFIED,
-                scheduleXml = "<xml></xml>",
+                httpStatus = NetworkHttpStatus.HTTP_NOT_MODIFIED,
+                scheduleXml = "",
                 eTag = "mno456",
                 hostName = "example.com",
                 exceptionMessage = "SSLException"
         )
         assertThat(fetchScheduleResult.toAppFetchScheduleResult().toNetworkFetchScheduleResult()).isEqualTo(fetchScheduleResult)
+    }
+
+    @Test
+    fun networkFetchScheduleResult_toAppFetchScheduleResult() {
+        val networkFetchScheduleResult = NetworkFetchScheduleResult(
+                httpStatus = NetworkHttpStatus.HTTP_NOT_MODIFIED,
+                scheduleXml = "<xml></xml>",
+                eTag = "mno456",
+                hostName = "example.com",
+                exceptionMessage = "SSLException"
+        )
+        val appFetchScheduleResult = AppFetchScheduleResult(
+                httpStatus = AppHttpStatus.HTTP_NOT_MODIFIED,
+                eTag = "mno456",
+                hostName = "example.com",
+                exceptionMessage = "SSLException"
+        )
+        assertThat(networkFetchScheduleResult.toAppFetchScheduleResult()).isEqualTo(appFetchScheduleResult)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -10,8 +10,6 @@ class MetaExtensionsTest {
     @Test
     fun databaseMeta_toMetaAppModel_toMetaDatabaseModel() {
         val meta = DatabaseMeta(
-                dayChangeHour = 13,
-                dayChangeMinute = 7,
                 eTag = "abc123",
                 numDays = 23,
                 subtitle = "My subtitle",
@@ -24,8 +22,6 @@ class MetaExtensionsTest {
     @Test
     fun networkMeta_toMetaAppModel_toMetaNetworkModel() {
         val meta = NetworkMeta(
-                dayChangeHour = 13,
-                dayChangeMinute = 7,
                 eTag = "abc123",
                 numDays = 23,
                 subtitle = "My subtitle",

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
@@ -13,8 +13,6 @@ class MetaExtensionsTest {
     @Test
     fun toContentValues() {
         val meta = Meta(
-                dayChangeHour = 13,
-                dayChangeMinute = 7,
                 eTag = "abc123",
                 numDays = 23,
                 subtitle = "My subtitle",
@@ -22,8 +20,6 @@ class MetaExtensionsTest {
                 version = "v.9.9.9"
         )
         val values = meta.toContentValues()
-        assertThat(values.getAsInteger(DAY_CHANGE_HOUR)).isEqualTo(13)
-        assertThat(values.getAsInteger(DAY_CHANGE_MINUTE)).isEqualTo(7)
         assertThat(values.getAsString(ETAG)).isEqualTo("abc123")
         assertThat(values.getAsInteger(NUM_DAYS)).isEqualTo(23)
         assertThat(values.getAsString(SUBTITLE)).isEqualTo("My subtitle")

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -13,8 +13,8 @@ public interface FahrplanContract {
             /* 0 */ String VERSION = "version";
             /* 1 */ String TITLE = "title";
             /* 2 */ String SUBTITLE = "subtitle";
-            /* 3 */ String DAY_CHANGE_HOUR = "day_change_hour";
-            /* 4 */ String DAY_CHANGE_MINUTE = "day_change_minute";
+            /* 3 */ // Zombie: Former "day_change_hour" column.
+            /* 4 */ // Zombie: Former "day_change_minute" column.
             /* 5 */ String ETAG = "etag";
             /* 6 */ String NUM_DAYS = "numdays";
         }
@@ -22,8 +22,6 @@ public interface FahrplanContract {
         interface Defaults {
 
             int NUM_DAYS_DEFAULT = 0;
-            int DAY_CHANGE_HOUR_DEFAULT = 4;
-            int DAY_CHANGE_MINUTE_DEFAULT = 0;
             String ETAG_DEFAULT = "''";
         }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
@@ -5,8 +5,6 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 import info.metadude.android.eventfahrplan.database.models.Meta
 
 fun Meta.toContentValues() = ContentValues().apply {
-    put(DAY_CHANGE_HOUR, dayChangeHour)
-    put(DAY_CHANGE_MINUTE, dayChangeMinute)
     put(ETAG, eTag)
     put(NUM_DAYS, numDays)
     put(SUBTITLE, subtitle)

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
@@ -1,11 +1,9 @@
 package info.metadude.android.eventfahrplan.database.models
 
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Defaults.*
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Defaults.NUM_DAYS_DEFAULT
 
 data class Meta(
 
-        val dayChangeHour: Int = DAY_CHANGE_HOUR_DEFAULT,
-        val dayChangeMinute: Int = DAY_CHANGE_MINUTE_DEFAULT,
         val eTag: String = "",
         val numDays: Int = NUM_DAYS_DEFAULT,
         val subtitle: String = "",

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
@@ -45,8 +45,6 @@ class MetaDatabaseRepository(
                         version = cursor.getString(VERSION),
                         title = cursor.getString(TITLE),
                         subtitle = cursor.getString(SUBTITLE),
-                        dayChangeHour = cursor.getInt(DAY_CHANGE_HOUR),
-                        dayChangeMinute = cursor.getInt(DAY_CHANGE_MINUTE),
                         eTag = cursor.getString(ETAG)
                 )
             } else {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
@@ -21,8 +21,6 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
                     Columns.VERSION + " TEXT, " +
                     Columns.TITLE + " TEXT, " +
                     Columns.SUBTITLE + " TEXT, " +
-                    Columns.DAY_CHANGE_HOUR + " INTEGER, " +
-                    Columns.DAY_CHANGE_MINUTE + " INTEGER, " +
                     Columns.ETAG + " TEXT);";
 
     public MetaDBOpenHelper(@NonNull Context context) {
@@ -36,15 +34,6 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        if (oldVersion < 2 && newVersion >= 2) {
-            db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
-                    Columns.DAY_CHANGE_HOUR + " INTEGER DEFAULT " +
-                    Defaults.DAY_CHANGE_HOUR_DEFAULT);
-            db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
-                    Columns.DAY_CHANGE_MINUTE + " INTEGER DEFAULT " +
-                    Defaults.DAY_CHANGE_MINUTE_DEFAULT);
-        }
-
         if (oldVersion < 3 && newVersion >= 3) {
             db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
                     Columns.ETAG + " TEXT DEFAULT " + Defaults.ETAG_DEFAULT);

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
@@ -2,8 +2,6 @@ package info.metadude.android.eventfahrplan.network.models
 
 data class Meta(
 
-        var dayChangeHour: Int = 0,
-        var dayChangeMinute: Int = 0,
         var eTag: String = "",
         var numDays: Int = 0,
         var subtitle: String = "",


### PR DESCRIPTION
# Description
- This branch is a combination of cleaning up dead code, gradually getting rid of the static `MyApp#meta` field and using the `AppRepository` as the abstract interface to access any kind of data. Here is a broad overview:
  - Use `AppRepository` to access the "display day index" preference.
  - Remove unused code related to `MyApp#fahrplan_xml`.
  - Decouple `AboutDialog` from static `MyApp#meta` field.
  - Ease understanding by introducing `DateInfo#DAY_INDEX_NOT_FOUND` constant.
  - Encapsulate day change constant(s) in `DateInfos` class.
- Relates to issue #246.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 2, Android 10.