### PR TITLE
Observing data - part 03

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -88,7 +88,6 @@ public class UpdateService extends SafeJobIntentService {
             return;
         }
 
-        MyApp.meta.setETag(fetchScheduleResult.getETag());
         // Parser is automatically invoked when response has been received.
         MyApp.task_running = TASKS.PARSE;
     }
@@ -102,7 +101,7 @@ public class UpdateService extends SafeJobIntentService {
             MyApp.task_running = TASKS.FETCH;
             String url = appRepository.readScheduleUrl();
             OkHttpClient okHttpClient = CustomHttpClient.createHttpClient();
-            appRepository.loadSchedule(url, MyApp.meta.getETag(),
+            appRepository.loadSchedule(url,
                     okHttpClient,
                     fetchScheduleResult -> {
                         onGotResponse(fetchScheduleResult);
@@ -142,7 +141,6 @@ public class UpdateService extends SafeJobIntentService {
     }
 
     private void fetchSchedule() {
-        MyApp.meta = appRepository.readMeta(); // to load eTag
         MyApp.LogDebug(LOG_TAG, "Fetching schedule ...");
         FahrplanMisc.setUpdateAlarm(this, false);
         fetchFahrplan();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -79,9 +79,6 @@ public class UpdateService extends SafeJobIntentService {
     public void onGotResponse(@NonNull FetchScheduleResult fetchScheduleResult) {
         HttpStatus status = fetchScheduleResult.getHttpStatus();
         MyApp.task_running = TASKS.NONE;
-        if (status == HttpStatus.HTTP_OK || status == HttpStatus.HTTP_NOT_MODIFIED) {
-            appRepository.updateScheduleLastFetchingTime();
-        }
         if (status != HttpStatus.HTTP_OK) {
             MyApp.LogDebug(LOG_TAG, "Background schedule update failed. HTTP status code: " + status);
             stopSelf();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensions.kt
@@ -5,14 +5,6 @@ import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult as AppFetchSchedu
 
 fun NetworkFetchScheduleResult.toAppFetchScheduleResult() = AppFetchScheduleResult(
         httpStatus = httpStatus.toAppHttpStatus(),
-        eTag = eTag,
-        hostName = hostName,
-        exceptionMessage = exceptionMessage
-)
-
-fun AppFetchScheduleResult.toNetworkFetchScheduleResult() = NetworkFetchScheduleResult(
-        httpStatus = httpStatus.toNetworkHttpStatus(),
-        eTag = eTag,
         hostName = hostName,
         exceptionMessage = exceptionMessage
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
@@ -4,6 +4,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 
 data class Meta(
 
+        @Deprecated("To be removed. Access from AppRepository only. Left here only for data transfer.")
         var eTag: String = "",
         var numDays: Int = MetasTable.Defaults.NUM_DAYS_DEFAULT,
         var subtitle: String = "",

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/FetchScheduleResult.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.net
 data class FetchScheduleResult(
 
         val httpStatus: HttpStatus,
-        val eTag: String = "",
         val hostName: String,
         val exceptionMessage: String = ""
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -90,7 +90,6 @@ object AppRepository {
     }
 
     fun loadSchedule(url: String,
-                     eTag: String,
                      okHttpClient: OkHttpClient,
                      onFetchingDone: (fetchScheduleResult: FetchScheduleResult) -> Unit,
                      onParsingDone: (parseScheduleResult: ParseResult) -> Unit,
@@ -98,16 +97,18 @@ object AppRepository {
     ) {
         check(onFetchingDone != {}) { "Nobody registered to receive FetchScheduleResult." }
         // Fetching
-        scheduleNetworkRepository.fetchSchedule(okHttpClient, url, eTag) { fetchScheduleResult ->
+        val meta = readMeta()
+        scheduleNetworkRepository.fetchSchedule(okHttpClient, url, meta.eTag) { fetchScheduleResult ->
             val fetchResult = fetchScheduleResult.toAppFetchScheduleResult()
             onFetchingDone.invoke(fetchResult)
 
             if (fetchResult.isSuccessful) {
+                updateMeta(meta.copy(eTag = fetchScheduleResult.eTag))
                 check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
                 // Parsing
                 parseSchedule(
                         fetchScheduleResult.scheduleXml,
-                        fetchResult.eTag,
+                        fetchScheduleResult.eTag,
                         okHttpClient,
                         onParsingDone,
                         onLoadingShiftsDone
@@ -366,6 +367,14 @@ object AppRepository {
     fun readMeta() =
             metaDatabaseRepository.query().toMetaAppModel()
 
+    /**
+     * Updates the [Meta] information in the database.
+     *
+     * The [Meta.eTag] field should only be written if a network response is received
+     * with a status code of HTTP 200 (OK).
+     *
+     * See also: [HttpStatus.HTTP_OK]
+     */
     private fun updateMeta(meta: Meta) {
         val metaDatabaseModel = meta.toMetaDatabaseModel()
         val values = metaDatabaseModel.toContentValues()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -102,6 +102,10 @@ object AppRepository {
             val fetchResult = fetchScheduleResult.toAppFetchScheduleResult()
             onFetchingDone.invoke(fetchResult)
 
+            if (fetchResult.isNotModified || fetchResult.isSuccessful) {
+                updateScheduleLastFetchingTime()
+            }
+
             if (fetchResult.isSuccessful) {
                 updateMeta(meta.copy(eTag = fetchScheduleResult.eTag))
                 check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
@@ -400,7 +404,7 @@ object AppRepository {
     fun readScheduleLastFetchingTime() =
             sharedPreferencesRepository.getScheduleLastFetchedAt()
 
-    fun updateScheduleLastFetchingTime() = with(Moment()) {
+    private fun updateScheduleLastFetchingTime() = with(Moment()) {
         sharedPreferencesRepository.setScheduleLastFetchedAt(toMilliseconds())
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -288,11 +288,12 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         if (roomScroller != null) {
             addRoomTitleViews(roomScroller);
         }
-
-        MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
-            scrollToCurrent(mDay, boxHeight);
-            return Unit.INSTANCE;
-        });
+        if (lecturesOfDay != null) {
+            MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
+                scrollToCurrent(lecturesOfDay, mDay, boxHeight);
+                return Unit.INSTANCE;
+            });
+        }
         updateNavigationMenuSelection();
     }
 
@@ -379,7 +380,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
     /**
      * jump to current time or lecture, if we are on today's lecture list
      */
-    private void scrollToCurrent(int day, int height) {
+    private void scrollToCurrent(@NonNull List<Lecture> lectures, int day, int height) {
         // Log.d(LOG_TAG, "lectureListDay: " + MyApp.lectureListDay);
         if (lectureId != null) {
             return;
@@ -425,7 +426,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
                 }
             }
 
-            for (Lecture l : MyApp.lectureList) {
+            for (Lecture l : lectures) {
                 if (l.day == day && l.startTime <= time && l.startTime + l.duration > time) {
                     if (col == -1 || col >= 0 && l.roomIndex == MyApp.roomList.get(col)) {
                         MyApp.LogDebug(LOG_TAG, l.title);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -277,6 +277,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
                 MyApp.LogDebug(LOG_TAG, "Conference = " + conference);
             }
             if (horizontalScroller != null) {
+                horizontalScroller.setRoomsCount(MyApp.roomCount);
                 if (horizontalScroller.getColumnWidth() != 0) {
                     // update pre-calculated roomColumnWidth with actual layout
                     roomColumnWidth = horizontalScroller.getColumnWidth();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -281,7 +281,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
                     // update pre-calculated roomColumnWidth with actual layout
                     roomColumnWidth = horizontalScroller.getColumnWidth();
                 }
-                addRoomColumns(horizontalScroller, lecturesOfDay, forceReload);
+                addRoomColumns(horizontalScroller, lecturesOfDay, MyApp.roomCount, forceReload);
             }
         }
 
@@ -308,7 +308,17 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         }
     }
 
-    private void addRoomColumns(@NonNull HorizontalSnapScrollView horizontalScroller, @NonNull List<Lecture> lectures, boolean forceReload) {
+    /**
+     * Adds {@code roomCount} room column views as child views to the first child
+     * (which is a row layout) of the given {@code horizontalScroller} layout.
+     * Previously added child views are removed.
+     */
+    private void addRoomColumns(
+            @NonNull HorizontalSnapScrollView horizontalScroller,
+            @NonNull List<Lecture> lectures,
+            int roomCount,
+            boolean forceReload
+    ) {
         int columnIndexLeft = horizontalScroller.getColumn();
         int columnIndexRight = columnIndexLeft + maxRoomColumnsVisible;
 
@@ -330,7 +340,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         LecturesByRoomIndex lecturesByRoomIndex = new LecturesByRoomIndex(lectures);
         LayoutCalculator layoutCalculator = new LayoutCalculator(Logging.Companion.get(), boxHeight);
 
-        for (int columnIndex = 0; columnIndex < MyApp.roomCount; columnIndex++) {
+        for (int columnIndex = 0; columnIndex < roomCount; columnIndex++) {
             int roomIndex = MyApp.roomList.get(columnIndex);
             List<Lecture> roomLectures = lecturesByRoomIndex.get(roomIndex);
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -15,6 +15,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
+import android.util.SparseIntArray;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.Gravity;
@@ -37,12 +38,12 @@ import org.ligi.tracedroid.logging.Log;
 import org.threeten.bp.Duration;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging;
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
@@ -286,7 +287,8 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
 
         HorizontalScrollView roomScroller = layoutRoot.findViewById(R.id.roomScroller);
         if (roomScroller != null) {
-            addRoomTitleViews(roomScroller);
+            LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
+            addRoomTitleViews(roomTitlesRowLayout, MyApp.roomsMap.entrySet(), MyApp.roomList);
         }
         if (lecturesOfDay != null) {
             MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
@@ -348,12 +350,20 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         }
     }
 
-    private void addRoomTitleViews(HorizontalScrollView scroller) {
-        LinearLayout root = (LinearLayout) scroller.getChildAt(0);
-        root.removeAllViews();
-        Set<Entry<String, Integer>> roomTitleSet = MyApp.roomsMap.entrySet();
+    /**
+     * Adds room title views as child views to the given {@code roomTitlesRowLayout}.
+     * Previously added child views are removed.
+     */
+    // TODO Simplify by passing list of room names.
+    private void addRoomTitleViews(
+            @NonNull LinearLayout roomTitlesRowLayout,
+            @NonNull Collection<Entry<String, Integer>> roomTitleSet,
+            @SuppressWarnings("SameParameterValue")
+            @NonNull SparseIntArray roomList
+    ) {
+        roomTitlesRowLayout.removeAllViews();
         int textSize = getResources().getInteger(R.integer.room_title_size);
-        for (int i = 0; i < MyApp.roomCount; i++) {
+        for (int i = 0; i < roomTitleSet.size(); i++) {
             TextView roomTitle = new TextView(context);
             LinearLayout.LayoutParams p = new LayoutParams(
                     roomColumnWidth, LayoutParams.WRAP_CONTENT, 1);
@@ -364,7 +374,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
             roomTitle.setPadding(0, 0, getEventPadding(), 0);
             roomTitle.setGravity(Gravity.CENTER);
             roomTitle.setTypeface(light);
-            int v = MyApp.roomList.get(i);
+            int v = roomList.get(i);
             for (Entry<String, Integer> entry : roomTitleSet) {
                 if (entry.getValue() == v) {
                     roomTitle.setText(entry.getKey());
@@ -373,7 +383,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
             }
             roomTitle.setTextColor(0xffffffff);
             roomTitle.setTextSize(textSize);
-            root.addView(roomTitle);
+            roomTitlesRowLayout.addView(roomTitle);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.support.annotation.IntRange;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.GestureDetector.SimpleOnGestureListener;
@@ -27,9 +28,13 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
 
     private int columnWidth;
 
+    private int roomsCount = NOT_INITIALIZED;
+
     private HorizontalScrollView roomNames = null;
 
     private int maximumColumns;
+
+    private static final int NOT_INITIALIZED = Integer.MIN_VALUE;
 
     private static final int SWIPE_MIN_DISTANCE = 5;
 
@@ -91,6 +96,14 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
         boolean result = super.onInterceptTouchEvent(ev);
         gestureDetector.onTouchEvent(ev);
         return result;
+    }
+
+    /**
+     * Sets the rooms count so it can be used to calculate
+     * the room column dimensions in the next layout phase.
+     */
+    public void setRoomsCount(@IntRange(from = 1) int roomsCount) {
+        this.roomsCount = roomsCount;
     }
 
     public void scrollToColumn(int col, boolean fast) {
@@ -205,7 +218,7 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
     protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
         MyApp.LogDebug(LOG_TAG, "onSizeChanged " + oldWidth + ", " + oldHeight + ", " + width + ", " + height + " getMW:" + getMeasuredWidth());
         super.onSizeChanged(width, height, oldWidth, oldHeight);
-        maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), MyApp.roomCount);
+        maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), roomsCount);
 
         int newItemWidth = Math.round((float) getMeasuredWidth() / maximumColumns);
         float scale = getResources().getDisplayMetrics().density;
@@ -228,6 +241,9 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
     }
 
     public int getColumnWidth() {
+        if (roomsCount == NOT_INITIALIZED) {
+            throw new IllegalStateException("The \"roomsCount\" field must be initialized before invoking \"getColumnWidth\".");
+        }
         return columnWidth;
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -184,8 +184,6 @@ public class MainActivity extends BaseActivity implements
         showUpdateAction = true;
         invalidateOptionsMenu();
 
-        MyApp.meta.setETag(fetchScheduleResult.getETag());
-
         // Parser is automatically invoked when response has been received.
         showParsingStatus();
         MyApp.task_running = TASKS.PARSE;
@@ -272,7 +270,7 @@ public class MainActivity extends BaseActivity implements
             showFetchingStatus();
             String url = appRepository.readScheduleUrl();
             OkHttpClient okHttpClient = CustomHttpClient.createHttpClient();
-            appRepository.loadSchedule(url, MyApp.meta.getETag(),
+            appRepository.loadSchedule(url,
                     okHttpClient,
                     fetchScheduleResult -> {
                         onGotResponse(fetchScheduleResult);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -169,9 +169,6 @@ public class MainActivity extends BaseActivity implements
         if (MyApp.meta.getNumDays() == 0) {
             hideProgressDialog();
         }
-        if (status == HttpStatus.HTTP_OK || status == HttpStatus.HTTP_NOT_MODIFIED) {
-            appRepository.updateScheduleLastFetchingTime();
-        }
         if (status != HttpStatus.HTTP_OK) {
             showErrorDialog(fetchScheduleResult.getExceptionMessage(), fetchScheduleResult.getHostName(), status);
             progressBar.setVisibility(View.INVISIBLE);

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -28,6 +28,9 @@
                     android:orientation="horizontal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
+
+                <!-- Room title views are added here at runtime. -->
+
             </LinearLayout>
         </HorizontalScrollView>
     </LinearLayout>

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -65,6 +65,9 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:orientation="horizontal">
+
+                    <!-- Room column views are added here at runtime. -->
+
                 </LinearLayout>
 
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -71,6 +71,8 @@
                         android:layout_weight="1"
                         android:orientation="horizontal">
 
+                    <!-- Room column views are added here at runtime. -->
+
                 </LinearLayout>
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -28,6 +28,9 @@
                     android:orientation="horizontal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content">
+
+                <!-- Room title views are added here at runtime. -->
+
             </LinearLayout>
         </HorizontalScrollView>
 

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -71,6 +71,8 @@
                         android:layout_weight="1"
                         android:orientation="horizontal">
 
+                    <!-- Room column views are added here at runtime. -->
+
                 </LinearLayout>
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -30,6 +30,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
+                <!-- Room title views are added here at runtime. -->
+
             </LinearLayout>
         </HorizontalScrollView>
     </LinearLayout>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
@@ -1,25 +1,13 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
-import nerd.tuxmobil.fahrplan.congress.net.HttpStatus as AppHttpStatus
-import info.metadude.android.eventfahrplan.network.fetching.HttpStatus as NetworkHttpStatus
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult as NetworkFetchScheduleResult
+import info.metadude.android.eventfahrplan.network.fetching.HttpStatus as NetworkHttpStatus
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult as AppFetchScheduleResult
+import nerd.tuxmobil.fahrplan.congress.net.HttpStatus as AppHttpStatus
 
 class FetchScheduleResultExtensionsTest {
-
-    @Test
-    fun networkFetchScheduleResult_toAppFetchScheduleResult_toNetworkFetchScheduleResult() {
-        val fetchScheduleResult = NetworkFetchScheduleResult(
-                httpStatus = NetworkHttpStatus.HTTP_NOT_MODIFIED,
-                scheduleXml = "",
-                eTag = "mno456",
-                hostName = "example.com",
-                exceptionMessage = "SSLException"
-        )
-        assertThat(fetchScheduleResult.toAppFetchScheduleResult().toNetworkFetchScheduleResult()).isEqualTo(fetchScheduleResult)
-    }
 
     @Test
     fun networkFetchScheduleResult_toAppFetchScheduleResult() {
@@ -32,11 +20,12 @@ class FetchScheduleResultExtensionsTest {
         )
         val appFetchScheduleResult = AppFetchScheduleResult(
                 httpStatus = AppHttpStatus.HTTP_NOT_MODIFIED,
-                eTag = "mno456",
                 hostName = "example.com",
                 exceptionMessage = "SSLException"
         )
-        assertThat(networkFetchScheduleResult.toAppFetchScheduleResult()).isEqualTo(appFetchScheduleResult)
+        assertThat(networkFetchScheduleResult
+                .toAppFetchScheduleResult())
+                .isEqualTo(appFetchScheduleResult)
     }
 
 }


### PR DESCRIPTION
# Description
- This branch contains a couple of commits which add to the overall goal of first localizing all static `MyApp` fields in `FahrplanFragment#viewDay` and later refactoring `FahrplanFragment#loadLectureList` to get rid of these fields. See #246.
Please refer to the individual commit messages to get more context.
- Additionally _updating the last fetching time_ is now encapsulated within `AppRepository`.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 2, Android 10.

# Related
- [Pull Request #259: Observing data - part 02](https://github.com/EventFahrplan/EventFahrplan/pull/259)
- [Pull Request #249: Observing data - part 01](https://github.com/EventFahrplan/EventFahrplan/pull/249)