### PR TITLE
Customize menues and colors (details and alarms screens)

### DIFF
--- a/app/src/main/res/drawable-v21/popup_background.xml
+++ b/app/src/main/res/drawable-v21/popup_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Workaround to fix visual distortion of popup menu on Android 5.0 (Lollipop)
+See: https://issuetracker.google.com/issues/37038337, https://stackoverflow.com/a/29637669/356895
+-->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <corners android:radius="2dp" />
+    <solid android:color="@color/popupBackground" />
+
+</shape>

--- a/app/src/main/res/values-v21/styles_congress.xml
+++ b/app/src/main/res/values-v21/styles_congress.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="PopupMenuOverflowStyle" parent="@style/Widget.AppCompat.Light.PopupMenu.Overflow">
+        <!--
+        Workaround to fix visual distortion of popup menu on Android 5.0 (Lollipop)
+        See: https://issuetracker.google.com/issues/37038337, https://stackoverflow.com/a/29637669/356895
+        -->
+        <item name="android:popupBackground">@drawable/popup_background</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values-v22/styles_congress.xml
+++ b/app/src/main/res/values-v22/styles_congress.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <style name="PopupMenuOverflowStyle" parent="@style/Widget.AppCompat.Light.PopupMenu.Overflow">
+        <!--
+        Move into values/styles_congress.xml once its counterpart
+        in values-21/styles_congress.xml is gone.
+        -->
+        <item name="android:popupBackground">@color/popupBackground</item>
+    </style>
+
+</resources>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -29,6 +29,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <!-- The rest of your attributes -->
+        <item name="actionOverflowMenuStyle">@style/PopupMenuOverflowStyle</item>
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/colorPrimary</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -30,6 +30,7 @@
 
         <!-- The rest of your attributes -->
         <item name="actionOverflowMenuStyle">@style/PopupMenuOverflowStyle</item>
+        <item name="android:contextPopupMenuStyle" tools:targetApi="N">@style/ContextPopupMenuStyle</item>
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/colorPrimary</item>


### PR DESCRIPTION
# Description
- This fixes a visual distortion error on Android 5.0 (Lollipop) which affects the overflow menu in schedule screen.
  - See https://issuetracker.google.com/issues/37038337 and https://stackoverflow.com/a/29637669/356895.
- This is a follow-up to #257 to customize the background color of the overflow and context menu in the details and alarms screens.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Emulator, Android 5.0.2.
- :heavy_check_mark: Pixel 2, Android 10.

# Hint for reviewers
- Setting alarms can be tested without hazzle by setting the system date to 26.12.2019 temporarily, because then they are not fired immediately.

# 36C3 before
- Details screen, overflow menu
![details-before](https://user-images.githubusercontent.com/144518/81726710-1c54bd00-9488-11ea-8a68-837caf330f30.png)
- Alarms screen, overflow menu
![alarms-overflow-before](https://user-images.githubusercontent.com/144518/81726773-355d6e00-9488-11ea-9077-6cb08122074e.png)
- Alarms screen, context menu
![alarms-context-menu-before](https://user-images.githubusercontent.com/144518/81726806-40b09980-9488-11ea-8fe5-233240958736.png)

# 36C3 after
- Details screen, overflow menu
![details-after](https://user-images.githubusercontent.com/144518/81726852-53c36980-9488-11ea-87cc-f0a41044135f.png)
- Alarms screen, overflow menu
![alarms-overflow-after](https://user-images.githubusercontent.com/144518/81726861-58881d80-9488-11ea-89b7-84182c62eecb.png)
- Alarms screen, context menu
![alarms-context-menu-after](https://user-images.githubusercontent.com/144518/81726872-5cb43b00-9488-11ea-9370-61b252696ca9.png)

# Related
- [Pull request #257: Customizing menues and colors](https://github.com/EventFahrplan/EventFahrplan/pull/257)