### PR TITLE
Fix schedule view not starting to render on tablets.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -218,7 +218,8 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
     protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
         MyApp.LogDebug(LOG_TAG, "onSizeChanged " + oldWidth + ", " + oldHeight + ", " + width + ", " + height + " getMW:" + getMeasuredWidth());
         super.onSizeChanged(width, height, oldWidth, oldHeight);
-        maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), roomsCount);
+        int columnsCount = (roomsCount == NOT_INITIALIZED) ? 0 : roomsCount;
+        maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), columnsCount);
 
         int newItemWidth = Math.round((float) getMeasuredWidth() / maximumColumns);
         float scale = getResources().getDisplayMetrics().density;


### PR DESCRIPTION
# Description
+ Affected app version: [v.1.43.0](https://github.com/EventFahrplan/EventFahrplan/releases/tag/v.1.43.0)
+ When the app is installed the app does not render the schedule - only the grey background appears.
![notstarting](https://user-images.githubusercontent.com/144518/82763003-adbb1c00-9e04-11ea-96ef-cdaa74a38641.png)

+ **Tablet specific!**
+ Bug introduced in d54ccfe4ba88eef66038bc2a271e8bc8a1460732.
+ In `HorizontalSnapScrollView#calcMaxCols` `Integer.MIN_VALUE` causes an "endless" loop when `maxCols` is set to `Integer.MIN_VALUE` and decremented shortly after which sets the value to `Integer.MAX_VALUE`.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: HTC Nexus 9, Android 7.1.1, both landscape and portrait.
- :heavy_check_mark: Google Pixel 2, Android 10, both landscape and portrait.