### PR TITLE
Fix HorizontalSnapScrollView column calculation

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -191,16 +191,18 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
      * the screen density of the device and the column count of the schedule. Further limiting
      * factors are a maximum column count to be displayed and a minimum column width.
      */
-    private static int calculateDisplayColumnCount(Resources res, int availablePixels, int columnsCount) {
-        int maxColumnCountForLayout = res.getInteger(R.integer.max_cols);
+    public static int calculateDisplayColumnCount(
+            int availablePixels,
+            int columnsCount,
+            int maxColumnCountForLayout,
+            float densityScaleFactor,
+            int minColumnWidthDip
+    ) {
         int columnCountLimit = Math.min(columnsCount, maxColumnCountForLayout);
         if (columnCountLimit == 1) {
             return 1;
         }
-
-        float densityScaleFactor = res.getDisplayMetrics().density;
         float availableDips = ((float) availablePixels) / densityScaleFactor;
-        int minColumnWidthDip = res.getInteger(R.integer.min_width_dip);
         int minWidthColumnCount = (int) Math.floor(availableDips / minColumnWidthDip);
         int columnCount = Math.min(minWidthColumnCount, columnCountLimit);
         return Math.max(1, columnCount);
@@ -210,10 +212,16 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
     protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
         MyApp.LogDebug(LOG_TAG, "onSizeChanged " + oldWidth + ", " + oldHeight + ", " + width + ", " + height + " getMW:" + getMeasuredWidth());
         super.onSizeChanged(width, height, oldWidth, oldHeight);
+        Resources resources = getResources();
         if (roomsCount == NOT_INITIALIZED) {
             displayColumnCount = 1;
         } else {
-            displayColumnCount = calculateDisplayColumnCount(getResources(), getMeasuredWidth(), roomsCount);
+            displayColumnCount = calculateDisplayColumnCount(
+                    getMeasuredWidth(),
+                    roomsCount,
+                    resources.getInteger(R.integer.max_cols),
+                    resources.getDisplayMetrics().density,
+                    resources.getInteger(R.integer.min_width_dip));
         }
 
         int newItemWidth = Math.round((float) getMeasuredWidth() / displayColumnCount);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -186,22 +186,19 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
         }
     }
 
-    // FIXME: Landscape patch to expand a column to full width if there is space available
-    private static int calcMaxCols(Resources res, int availPixels, int columnsCount) {
-        int maxCols = res.getInteger(R.integer.max_cols);
-        // TODO: The next line is the relevant monkey patch
-        maxCols = Math.min(columnsCount, maxCols);
-        // TODO: The previous line is the relevant monkey patch
-        int minWidthDip = res.getInteger(R.integer.min_width_dip);
-        float scale = res.getDisplayMetrics().density;
-        MyApp.LogDebug(LOG_TAG, "calcMaxCols: avail " + availPixels + " min width dip " + minWidthDip);
-        int dip;
-        do {
-            dip = (int) ((((float) availPixels) / maxCols) / scale);
-            MyApp.LogDebug(LOG_TAG, "calcMaxCols: " + dip + " on " + maxCols + " cols.");
-            maxCols--;
-        } while (dip < minWidthDip && maxCols > 0);
-        return maxCols + 1;
+    private static int calcMaxCols(Resources res, int availablePixels, int columnsCount) {
+        int maxColumnsForLayout = res.getInteger(R.integer.max_cols);
+        int maxColumns = Math.min(columnsCount, maxColumnsForLayout);
+        if (maxColumns == 1) {
+            return 1;
+        }
+
+        float densityScaleFactor = res.getDisplayMetrics().density;
+        float availableDips = ((float) availablePixels) / densityScaleFactor;
+        int minColumnWidthDip = res.getInteger(R.integer.min_width_dip);
+        int minWidthColumns = (int) Math.floor(availableDips / minColumnWidthDip);
+        int columns = Math.min(minWidthColumns, maxColumns);
+        return Math.max(1, columns);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -205,8 +205,11 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
     protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
         MyApp.LogDebug(LOG_TAG, "onSizeChanged " + oldWidth + ", " + oldHeight + ", " + width + ", " + height + " getMW:" + getMeasuredWidth());
         super.onSizeChanged(width, height, oldWidth, oldHeight);
-        int columnsCount = (roomsCount == NOT_INITIALIZED) ? 0 : roomsCount;
-        maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), columnsCount);
+        if (roomsCount == NOT_INITIALIZED) {
+            maximumColumns = 1;
+        } else {
+            maximumColumns = calcMaxCols(getResources(), getMeasuredWidth(), roomsCount);
+        }
 
         int newItemWidth = Math.round((float) getMeasuredWidth() / maximumColumns);
         float scale = getResources().getDisplayMetrics().density;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule;
 import android.content.Context;
 import android.content.res.Resources;
 import android.support.annotation.IntRange;
+import android.support.annotation.VisibleForTesting;
 import android.util.AttributeSet;
 import android.view.GestureDetector;
 import android.view.GestureDetector.SimpleOnGestureListener;
@@ -191,6 +192,7 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
      * the screen density of the device and the column count of the schedule. Further limiting
      * factors are a maximum column count to be displayed and a minimum column width.
      */
+    @VisibleForTesting
     public static int calculateDisplayColumnCount(
             int availablePixels,
             int columnsCount,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollViewCalculateDisplayColumnCountTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollViewCalculateDisplayColumnCountTest.kt
@@ -1,0 +1,215 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.R
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Parameterized unit test for [HorizontalSnapScrollView.calculateDisplayColumnCount].
+ */
+@RunWith(Parameterized::class)
+class HorizontalSnapScrollViewCalculateDisplayColumnCountTest(
+        private val availablePixels: Int,
+        private val totalColumnCount: Int,
+        private val maxColumnCountForLayout: Int,
+        private val densityScaleFactor: Float,
+        private val minColumnWidthDip: Int,
+        private val calculatedColumnCount: Int,
+        @Suppress("unused") private val testDescription: String
+) {
+
+    companion object {
+
+        private class Device(
+                val title: String,
+                private val availableHeightInDip: Int,
+                private val availableWidthInDip: Int,
+                val screenDensity: Float
+        ) {
+            fun getAvailablePixel(isPortraitMode: Boolean) = if (isPortraitMode) availableHeightInDip else availableWidthInDip
+        }
+
+        private fun scenario(
+                device: Device,
+                isPortraitMode: Boolean,
+                totalColumnCount: Int,
+                maxColumnCountForLayout: Int,
+                minColumnWidthDip: Int,
+                calculatedColumnCount: Int
+        ): Array<Any> {
+            val orientationText = if (isPortraitMode) "Portrait" else "Landscape"
+            val testDescription = "${device.title}, $orientationText, totalColumnCount=$totalColumnCount, maxColumnCountForLayout=$maxColumnCountForLayout --> $calculatedColumnCount"
+            return arrayOf(
+                    device.getAvailablePixel(isPortraitMode),
+                    totalColumnCount,
+                    maxColumnCountForLayout,
+                    device.screenDensity,
+                    minColumnWidthDip,
+                    calculatedColumnCount,
+                    testDescription
+            )
+        }
+
+        // Device metrics are retrieved from debugging values at the actual devices.
+        private val nexus5 = Device("Nexus 5", availableHeightInDip = 978, availableWidthInDip = 1706, screenDensity = 3.0f)
+        private val pixel2 = Device("Pixel 2", availableHeightInDip = 993, availableWidthInDip = 1731, screenDensity = 2.625f)
+        private val nexus9 = Device("Nexus 9", availableHeightInDip = 1462, availableWidthInDip = 1974, screenDensity = 2.0f)
+
+        /**
+         * See [R.integer.min_width_dip]
+         */
+        private const val MIN_COLUMN_WIDTH_140_DIP = 140
+
+        /**
+         * See [R.integer.min_width_dip]
+         */
+        private const val MIN_COLUMN_WIDTH_160_DIP = 160
+
+        /**
+         * See [R.integer.max_cols]
+         */
+        private const val MAX_COLUMN_COUNT_FOR_LAYOUT_1 = 1
+
+        /**
+         * See [R.integer.max_cols]
+         */
+        private const val MAX_COLUMN_COUNT_FOR_LAYOUT_4 = 4
+
+        /**
+         * See [R.integer.max_cols]
+         */
+        private const val MAX_COLUMN_COUNT_FOR_LAYOUT_6 = 6
+
+        private fun pixel2Portrait(totalColumnCount: Int, @Suppress("SameParameterValue") calculatedColumnCount: Int) = scenario(
+                device = pixel2,
+                isPortraitMode = true,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_1,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_160_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        private fun pixel2Landscape(totalColumnCount: Int, calculatedColumnCount: Int) = scenario(
+                device = pixel2,
+                isPortraitMode = false,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_4,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_140_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        private fun nexus5Portrait(totalColumnCount: Int, @Suppress("SameParameterValue") calculatedColumnCount: Int) = scenario(
+                device = nexus5,
+                isPortraitMode = true,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_1,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_160_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        private fun nexus5Landscape(totalColumnCount: Int, calculatedColumnCount: Int) = scenario(
+                device = nexus5,
+                isPortraitMode = false,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_4,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_140_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        private fun nexus9Portrait(totalColumnCount: Int, calculatedColumnCount: Int) = scenario(
+                device = nexus9,
+                isPortraitMode = true,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_6,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_160_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        private fun nexus9Landscape(totalColumnCount: Int, calculatedColumnCount: Int) = scenario(
+                device = nexus9,
+                isPortraitMode = false,
+                totalColumnCount = totalColumnCount,
+                maxColumnCountForLayout = MAX_COLUMN_COUNT_FOR_LAYOUT_6,
+                minColumnWidthDip = MIN_COLUMN_WIDTH_160_DIP,
+                calculatedColumnCount = calculatedColumnCount
+        )
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: \"{6}\"")
+        fun data() = listOf(
+                // Pixel 2 portrait (maxColumnCountForLayout=1)
+                pixel2Portrait(totalColumnCount = 1, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 2, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 3, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 4, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 5, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 6, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 7, calculatedColumnCount = 1),
+                pixel2Portrait(totalColumnCount = 55, calculatedColumnCount = 1),
+
+                // Pixel 2 landscape (maxColumnCountForLayout=4)
+                pixel2Landscape(totalColumnCount = 1, calculatedColumnCount = 1),
+                pixel2Landscape(totalColumnCount = 2, calculatedColumnCount = 2),
+                pixel2Landscape(totalColumnCount = 3, calculatedColumnCount = 3),
+                pixel2Landscape(totalColumnCount = 4, calculatedColumnCount = 4),
+                pixel2Landscape(totalColumnCount = 5, calculatedColumnCount = 4),
+                pixel2Landscape(totalColumnCount = 6, calculatedColumnCount = 4),
+                pixel2Landscape(totalColumnCount = 7, calculatedColumnCount = 4),
+                pixel2Landscape(totalColumnCount = 55, calculatedColumnCount = 4),
+
+                // Nexus 5 portrait (maxColumnCountForLayout=1)
+                nexus5Portrait(totalColumnCount = 1, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 2, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 3, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 4, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 5, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 6, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 7, calculatedColumnCount = 1),
+                nexus5Portrait(totalColumnCount = 55, calculatedColumnCount = 1),
+
+                // Nexus 5 landscape (maxColumnCountForLayout=4)
+                nexus5Landscape(totalColumnCount = 1, calculatedColumnCount = 1),
+                nexus5Landscape(totalColumnCount = 2, calculatedColumnCount = 2),
+                nexus5Landscape(totalColumnCount = 3, calculatedColumnCount = 3),
+                nexus5Landscape(totalColumnCount = 4, calculatedColumnCount = 4),
+                nexus5Landscape(totalColumnCount = 5, calculatedColumnCount = 4),
+                nexus5Landscape(totalColumnCount = 6, calculatedColumnCount = 4),
+                nexus5Landscape(totalColumnCount = 7, calculatedColumnCount = 4),
+                nexus5Landscape(totalColumnCount = 55, calculatedColumnCount = 4),
+
+                // Nexus 9 portrait, sw720dp (maxColumnCountForLayout=6)
+                nexus9Portrait(totalColumnCount = 1, calculatedColumnCount = 1),
+                nexus9Portrait(totalColumnCount = 2, calculatedColumnCount = 2),
+                nexus9Portrait(totalColumnCount = 3, calculatedColumnCount = 3),
+                nexus9Portrait(totalColumnCount = 4, calculatedColumnCount = 4),
+                nexus9Portrait(totalColumnCount = 5, calculatedColumnCount = 4),
+                nexus9Portrait(totalColumnCount = 6, calculatedColumnCount = 4),
+                nexus9Portrait(totalColumnCount = 7, calculatedColumnCount = 4),
+                nexus9Portrait(totalColumnCount = 55, calculatedColumnCount = 4),
+
+                // Nexus 9 landscape, sw720dp (maxColumnCountForLayout=6)
+                nexus9Landscape(totalColumnCount = 1, calculatedColumnCount = 1),
+                nexus9Landscape(totalColumnCount = 2, calculatedColumnCount = 2),
+                nexus9Landscape(totalColumnCount = 3, calculatedColumnCount = 3),
+                nexus9Landscape(totalColumnCount = 4, calculatedColumnCount = 4),
+                nexus9Landscape(totalColumnCount = 5, calculatedColumnCount = 5),
+                nexus9Landscape(totalColumnCount = 6, calculatedColumnCount = 6),
+                nexus9Landscape(totalColumnCount = 7, calculatedColumnCount = 6),
+                nexus9Landscape(totalColumnCount = 55, calculatedColumnCount = 6)
+        )
+    }
+
+    @Test
+    fun calculateDisplayColumnCount() {
+        assertThat(HorizontalSnapScrollView.calculateDisplayColumnCount(
+                availablePixels,
+                totalColumnCount,
+                maxColumnCountForLayout,
+                densityScaleFactor,
+                minColumnWidthDip
+        )).isEqualTo(calculatedColumnCount)
+    }
+
+}


### PR DESCRIPTION
# Description
- Replace the iterative approach to calculate the number of columns to display with the proper formula 

Tested on a Pixel 2, Android R DP and Nexus 9, Android 7.1.1, ccc36c3 flavor
