### PR TITLE
Remove view width magic

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -279,9 +279,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         int boxHeight = getNormalizedBoxHeight(getResources(), scale, LOG_TAG);
 
         HorizontalSnapScrollView horizontalScroller = layoutRoot.findViewById(R.id.horizScroller);
-        if (horizontalScroller != null) {
-            horizontalScroller.scrollTo(0, 0);
-        }
+        horizontalScroller.scrollTo(0, 0);
 
         loadLectureList(appRepository, mDay, forceReload);
         List<Lecture> lecturesOfDay = scheduleData.getAllLectures();
@@ -291,21 +289,18 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
             conference.calculateTimeFrame(lecturesOfDay, dateUTC -> new Moment(dateUTC).getMinuteOfDay());
             MyApp.LogDebug(LOG_TAG, "Conference = " + conference);
         }
-        if (horizontalScroller != null) {
-            int roomCount = scheduleData.getRoomCount();
-            horizontalScroller.setRoomsCount(roomCount);
-            if (horizontalScroller.getColumnWidth() != 0) {
-                // update pre-calculated roomColumnWidth with actual layout
-                roomColumnWidth = horizontalScroller.getColumnWidth();
-            }
-            addRoomColumns(horizontalScroller, lecturesOfDay, roomCount, forceReload);
+
+        int roomCount = scheduleData.getRoomCount();
+        horizontalScroller.setRoomsCount(roomCount);
+        if (horizontalScroller.getColumnWidth() != 0) {
+            // update pre-calculated roomColumnWidth with actual layout
+            roomColumnWidth = horizontalScroller.getColumnWidth();
         }
+        addRoomColumns(horizontalScroller, lecturesOfDay, roomCount, forceReload);
 
         HorizontalScrollView roomScroller = layoutRoot.findViewById(R.id.roomScroller);
-        if (roomScroller != null) {
-            LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
-            addRoomTitleViews(roomTitlesRowLayout, scheduleData.getRoomNames());
-        }
+        LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
+        addRoomTitleViews(roomTitlesRowLayout, scheduleData.getRoomNames());
 
         MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
             scrollToCurrent(lecturesOfDay, mDay, boxHeight);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -114,8 +114,6 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
 
     private View contextMenuView;
 
-    private int roomColumnWidth;
-
     private ScheduleData scheduleData;
 
     private String lectureId;        // started with lectureId
@@ -171,13 +169,6 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
 
         Context context = view.getContext();
         scale = getResources().getDisplayMetrics().density;
-        int screenWidth = getResources().getDisplayMetrics().widthPixels;
-        MyApp.LogDebug(LOG_TAG, "screen width = " + screenWidth);
-        MyApp.LogDebug(LOG_TAG, "time width " + getResources().getDimension(R.dimen.time_width));
-        screenWidth -= getResources().getDimension(R.dimen.time_width);
-        int maxRoomColumnsVisible = HorizontalSnapScrollView.calcMaxCols(getResources(), screenWidth);
-        MyApp.LogDebug(LOG_TAG, "max cols: " + maxRoomColumnsVisible);
-        roomColumnWidth = (int) ((float) screenWidth / maxRoomColumnsVisible); // TODO Assignment might be obsolete. Remove if verified.
         HorizontalScrollView roomScroller =
                 view.findViewById(R.id.roomScroller);
         if (roomScroller != null) {
@@ -291,15 +282,12 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
 
         int roomCount = scheduleData.getRoomCount();
         horizontalScroller.setRoomsCount(roomCount);
-        if (horizontalScroller.getColumnWidth() != 0) {
-            // update pre-calculated roomColumnWidth with actual layout
-            roomColumnWidth = horizontalScroller.getColumnWidth();
-        }
         addRoomColumns(horizontalScroller, lecturesOfDay, roomCount, forceReload);
 
         HorizontalScrollView roomScroller = layoutRoot.findViewById(R.id.roomScroller);
         LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
-        addRoomTitleViews(roomTitlesRowLayout, scheduleData.getRoomNames());
+        int columnWidth = horizontalScroller.getColumnWidth();
+        addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.getRoomNames());
 
         MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
             scrollToCurrent(lecturesOfDay, mDay, boxHeight);
@@ -374,6 +362,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
      */
     private void addRoomTitleViews(
             @NonNull LinearLayout roomTitlesRowLayout,
+            int columnWidth,
             @NonNull List<String> roomNames
     ) {
         roomTitlesRowLayout.removeAllViews();
@@ -381,7 +370,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         for (String roomName : roomNames) {
             TextView roomTitle = new TextView(context);
             LinearLayout.LayoutParams p = new LayoutParams(
-                    roomColumnWidth, LayoutParams.WRAP_CONTENT, 1);
+                    columnWidth, LayoutParams.WRAP_CONTENT, 1);
             p.gravity = Gravity.CENTER;
             roomTitle.setLayoutParams(p);
             roomTitle.setMaxLines(1);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -317,8 +317,8 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
             int roomCount,
             boolean forceReload
     ) {
-        int columnIndexLeft = horizontalScroller.getColumn();
-        int columnIndexRight = horizontalScroller.getLastVisibleColumn();
+        int columnIndexLeft = horizontalScroller.getColumnIndex();
+        int columnIndexRight = horizontalScroller.getLastVisibleColumnIndex();
 
         // whenever possible, just update recycler views
         if (!forceReload && !adapterByRoomIndex.isEmpty()) {
@@ -410,7 +410,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
 
         int col = -1;
         if (horiz != null) {
-            col = horiz.getColumn();
+            col = horiz.getColumnIndex();
             MyApp.LogDebug(LOG_TAG, "y pos  = " + col);
         }
         int time = conference.getFirstEventStartsAt();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -115,7 +115,6 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
     private View contextMenuView;
 
     private int roomColumnWidth;
-    private int maxRoomColumnsVisible;
 
     private ScheduleData scheduleData;
 
@@ -176,7 +175,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         MyApp.LogDebug(LOG_TAG, "screen width = " + screenWidth);
         MyApp.LogDebug(LOG_TAG, "time width " + getResources().getDimension(R.dimen.time_width));
         screenWidth -= getResources().getDimension(R.dimen.time_width);
-        maxRoomColumnsVisible = HorizontalSnapScrollView.calcMaxCols(getResources(), screenWidth);
+        int maxRoomColumnsVisible = HorizontalSnapScrollView.calcMaxCols(getResources(), screenWidth);
         MyApp.LogDebug(LOG_TAG, "max cols: " + maxRoomColumnsVisible);
         roomColumnWidth = (int) ((float) screenWidth / maxRoomColumnsVisible); // TODO Assignment might be obsolete. Remove if verified.
         HorizontalScrollView roomScroller =
@@ -331,7 +330,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
             boolean forceReload
     ) {
         int columnIndexLeft = horizontalScroller.getColumn();
-        int columnIndexRight = columnIndexLeft + maxRoomColumnsVisible;
+        int columnIndexRight = horizontalScroller.getLastVisibleColumn();
 
         // whenever possible, just update recycler views
         if (!forceReload && !adapterByRoomIndex.isEmpty()) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -244,7 +244,7 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
         scrollToColumn(activeColumnIndex, true);
     }
 
-    public void setColumnWidth(int pixels) {
+    private void setColumnWidth(int pixels) {
         MyApp.LogDebug(LOG_TAG, "setColumnWidth " + pixels);
         columnWidth = pixels;
         if (pixels == 0) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -45,11 +45,11 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
      *
      * @return index (0..n)
      */
-    public int getColumn() {
+    public int getColumnIndex() {
         return activeColumnIndex;
     }
 
-    public int getLastVisibleColumn() {
+    public int getLastVisibleColumnIndex() {
         return activeColumnIndex + maximumColumns - 1;
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -186,20 +186,6 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
         }
     }
 
-    public static int calcMaxCols(Resources res, int availPixels) {
-        int maxCols = res.getInteger(R.integer.max_cols);
-        int minWidthDip = res.getInteger(R.integer.min_width_dip);
-        float scale = res.getDisplayMetrics().density;
-        MyApp.LogDebug(LOG_TAG, "calcMaxCols: avail " + availPixels + " min width dip " + minWidthDip);
-        int dip;
-        do {
-            dip = (int) ((((float) availPixels) / maxCols) / scale);
-            MyApp.LogDebug(LOG_TAG, "calcMaxCols: " + dip + " on " + maxCols + " cols.");
-            maxCols--;
-        } while (dip < minWidthDip && maxCols > 0);
-        return maxCols + 1;
-    }
-
     // FIXME: Landscape patch to expand a column to full width if there is space available
     private static int calcMaxCols(Resources res, int availPixels, int columnsCount) {
         int maxCols = res.getInteger(R.integer.max_cols);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.java
@@ -49,6 +49,10 @@ public class HorizontalSnapScrollView extends HorizontalScrollView {
         return activeColumnIndex;
     }
 
+    public int getLastVisibleColumn() {
+        return activeColumnIndex + maximumColumns - 1;
+    }
+
     class YScrollDetector extends SimpleOnGestureListener {
 
         @Override


### PR DESCRIPTION
# Description
- Query views for the current value instead of either holding on to old values or trying to recreate the calculation in the view
- Remove some null checks for views that are present in all relevant layouts. If one day they aren't we should crash!

Tested on a Pixel 2, Android R DP and Nexus 9, Android 7.1.1, ccc36c3 flavor

This is removing a method that is modified by PR #276. It's probably best to get this merged first and then update the other PR.