### PR TITLE
Restore the "roomIndex fix"

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/LectureListTransformer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/LectureListTransformer.kt
@@ -39,7 +39,16 @@ class LectureListTransformer(private val prioritizedRoomProvider: PrioritizedRoo
             }
         }
 
+        legacyRoomIndexFixup(roomDataList)
+
         return ScheduleData(dayIndex, roomDataList)
+    }
+
+    private fun legacyRoomIndexFixup(roomDataList: List<RoomData>) {
+        // Set Lecture.roomIndex to match the index in ScheduleData.roomDataList
+        roomDataList.forEachIndexed { index, roomData ->
+            roomData.lectures.forEach { it.roomIndex = index }
+        }
     }
 
 }


### PR DESCRIPTION
Restores the code that fixes up `Lecture` instances to make `roomIndex` match the index of a room in `ScheduleData.roomDataList`.

Tested on Pixel 2, Android 11, 36c3 flavor

Fixes #279