### PR TITLE
Fix that single room expands to full available width.

### DIFF
--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -56,7 +56,7 @@
 
             <nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView
                     android:id="@+id/horizScroller"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:fadingEdge="none"
                     android:scrollbars="none">


### PR DESCRIPTION
# Successfully tested
- with `ccc36c3` debug build
- with multiple rooms, multiple days schedule
- with single room, single day schedule
- at Google Pixel 2, Android 10
- at HTC Nexus 9, Android 7.1.1

# Before / after screenshots
- See issue #278.

---

Resolves #278