### PR TITLE
Lecture alarms housekeeping

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -50,13 +50,9 @@ public final class AlarmReceiver extends BroadcastReceiver {
             boolean defaultValue = context.getResources().getBoolean(R.bool.preferences_insistent_alarm_enabled_default_value);
             boolean insistent = prefs.getBoolean("insistent", defaultValue);
 
-            Intent notificationIntent = new Intent(context, MainActivity.class);
-            notificationIntent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID, lectureId);
-            notificationIntent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX, day);
-            notificationIntent.setFlags(
-                    Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+            Intent launchIntent = MainActivity.createLaunchIntent(context, lectureId, day);
             PendingIntent contentIntent = PendingIntent
-                    .getActivity(context, lid, notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+                    .getActivity(context, lid, launchIntent, PendingIntent.FLAG_ONE_SHOT);
 
             NotificationHelper notificationHelper = new NotificationHelper(context);
             String defaultReminderTone = context.getString(R.string.preferences_reminder_tone_default_value);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -51,8 +51,8 @@ public final class AlarmReceiver extends BroadcastReceiver {
             boolean insistent = prefs.getBoolean("insistent", defaultValue);
 
             Intent notificationIntent = new Intent(context, MainActivity.class);
-            notificationIntent.putExtra("lecture_id", lectureId);
-            notificationIntent.putExtra("day", day);
+            notificationIntent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID, lectureId);
+            notificationIntent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX, day);
             notificationIntent.setFlags(
                     Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
             PendingIntent contentIntent = PendingIntent

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -12,6 +12,12 @@ public interface BundleKeys {
     String ALARM_START_TIME =
             "nerd.tuxmobil.fahrplan.congress.ALARM_START_TIME";
 
+    // Lecture alarm notification
+    String BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID =
+            "lecture_id";
+    String BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX =
+            "day";
+
     // Event
     String EVENT_TITLE =
             "nerd.tuxmobil.fahrplan.congress.EVENT_TITLE";

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -50,6 +50,7 @@ import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment;
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing;
+import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.Lecture;
 import nerd.tuxmobil.fahrplan.congress.models.RoomData;
@@ -186,11 +187,11 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         inflater = Contexts.getLayoutInflater(context);
 
         Intent intent = requireActivity().getIntent();
-        lectureId = intent.getStringExtra("lecture_id");
+        lectureId = intent.getStringExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID);
 
         if (lectureId != null) {
             MyApp.LogDebug(LOG_TAG, "Open with lectureId " + lectureId);
-            mDay = intent.getIntExtra("day", mDay);
+            mDay = intent.getIntExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX, mDay);
             MyApp.LogDebug(LOG_TAG, "day " + mDay);
         }
 
@@ -213,11 +214,11 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
         Intent intent = activity.getIntent();
 
         Log.d(LOG_TAG, "lectureId = " + lectureId);
-        lectureId = intent.getStringExtra("lecture_id");
+        lectureId = intent.getStringExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID);
 
         if (lectureId != null) {
             Log.d(LOG_TAG, "Open with lectureId " + lectureId);
-            mDay = intent.getIntExtra("day", mDay);
+            mDay = intent.getIntExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX, mDay);
             Log.d(LOG_TAG, "day " + mDay);
             saveCurrentDay(mDay);
         }
@@ -251,7 +252,7 @@ public class FahrplanFragment extends Fragment implements LectureViewEventsHandl
                     ((MainActivity) activity).openLectureDetail(lecture, mDay, false);
                 }
             }
-            intent.removeExtra("lecture_id");   // jump to given lectureId only once
+            intent.removeExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID); // jump to given lectureId only once
         }
         fillTimes();
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule;
 import android.app.Activity;
 import android.app.KeyguardManager;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
@@ -561,4 +562,21 @@ public class MainActivity extends BaseActivity implements
     public static MainActivity getInstance() {
         return instance;
     }
+
+    /**
+     * Returns an intent to be used to launch this activity.
+     * The given parameters {@code lectureId} and {@code dayIndex} are passed along as bundle extras.
+     */
+    public static Intent createLaunchIntent(
+            @NonNull Context context,
+            @NonNull String lectureId,
+            int dayIndex
+    ) {
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_LECTURE_ID, lectureId);
+        intent.putExtra(BundleKeys.BUNDLE_KEY_LECTURE_ALARM_DAY_INDEX, dayIndex);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+        return intent;
+    }
+
 }


### PR DESCRIPTION
# Description
- Here, I cleaned up the bundle key strings for lecture alarms which have been defined in multiple locations.
- Further, I moved unneeded implementation details out of `AlarmReceiver`.

# Successfully tested on
with `ccc36c3` flavor, `release` build
- :heavy_check_mark: HTC Nexus 9, Android 7.1.1.
