### PR TITLE
Add "commons-testing" module to DRY tests.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -164,11 +164,11 @@ dependencies {
     implementation Libs.snackengagePlayrate
     implementation Libs.tracedroid
 
+    testImplementation project(":commons-testing")
     testImplementation Libs.annotation
     testImplementation Libs.assertjAndroid
     testImplementation Libs.junit
     testImplementation Libs.mockitoCore
-    testImplementation Libs.mockitoKotlin
     testImplementation Libs.threeTenBp
     testImplementation Libs.truth
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -7,9 +7,8 @@ import android.content.Intent
 import android.net.Uri
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import org.junit.Test
@@ -32,8 +31,8 @@ class AlarmServicesTest {
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
         alarmServices.scheduleSessionAlarm(mockContext, alarm, true)
-        verify(alarmManager, once()).cancel(pendingIntent)
-        verify(alarmManager, once()).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
+        verifyInvokedOnce(alarmManager).cancel(pendingIntent)
+        verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
     }
 
     @Test
@@ -47,8 +46,8 @@ class AlarmServicesTest {
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
         alarmServices.scheduleSessionAlarm(mockContext, alarm, false)
-        verify(alarmManager, never()).cancel(pendingIntent)
-        verify(alarmManager, once()).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
+        verifyInvokedNever(alarmManager).cancel(pendingIntent)
+        verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
     }
 
     @Test
@@ -62,7 +61,7 @@ class AlarmServicesTest {
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
         alarmServices.discardSessionAlarm(mockContext, alarm)
-        verify(alarmManager, once()).cancel(pendingIntent)
+        verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
 
 
@@ -78,7 +77,7 @@ class AlarmServicesTest {
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
         alarmServices.discardAutoUpdateAlarm(mockContext)
-        verify(alarmManager, once()).cancel(pendingIntent)
+        verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
 
     // TODO Move into a unit test for AlarmReceiver once it is written.
@@ -91,7 +90,5 @@ class AlarmServicesTest {
         assertThat(intent.action).isEqualTo(action)
         assertThat(intent.data).isEqualTo(Uri.parse("alarm://${alarm.sessionId}"))
     }
-
-    private fun once() = times(1)
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.java
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.java
@@ -7,9 +7,9 @@ import org.junit.runners.JUnit4;
 
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame;
 
+import static info.metadude.android.eventfahrplan.commons.testing.Verification.verifyInvokedNever;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 
@@ -44,9 +44,9 @@ public class AlarmUpdaterTest {
         // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
         long interval = alarmUpdater.calculateInterval(1451212200000L, false);
         assertThat(interval).isEqualTo(7200000L);
-        verify(mockListener, never()).onCancelAlarm();
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onCancelAlarm();
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     @Test
@@ -56,7 +56,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(7200000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451212200000L + 7200000L);
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
     }
 
     // Time == End
@@ -67,8 +67,8 @@ public class AlarmUpdaterTest {
         long interval = alarmUpdater.calculateInterval(1451516400000L, false);
         assertThat(interval).isEqualTo(0);
         verify(mockListener).onCancelAlarm();
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     @Test
@@ -77,8 +77,8 @@ public class AlarmUpdaterTest {
         long interval = alarmUpdater.calculateInterval(1451516400000L, true);
         assertThat(interval).isEqualTo(0);
         verify(mockListener).onCancelAlarm();
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     // Time < Start, diff == 1 second
@@ -90,7 +90,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(7200000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     @Test
@@ -100,7 +100,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(7200000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L);
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
     }
 
     // Time < Start, diff == 1 day
@@ -112,7 +112,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(7200000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(7200000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L);
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
     }
 
     // Time < Start, diff > 1 day
@@ -133,9 +133,9 @@ public class AlarmUpdaterTest {
         long interval = alarmUpdater.calculateInterval(1451084399000L, false);
         assertThat(interval).isEqualTo(86400000L);
         // TODO Is this behavior intended?
-        verify(mockListener, never()).onCancelAlarm();
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
-        verify(mockListener, never()).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onCancelAlarm();
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(86400000L);
         verify(mockListener).onCancelAlarm();
         verify(mockListener).onRescheduleInitialAlarm(86400000L, 1451084399000L + 86400000L);
-        verify(mockListener, never()).onRescheduleAlarm(NEVER_USED, NEVER_USED);
+        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED);
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -1,7 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.repositories
 
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSessionsDatabaseModel
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -109,7 +112,7 @@ class AppRepositorySessionsTest {
     fun `loadChangedSessions passes through an empty list`() {
         whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn emptyList()
         assertThat(testableAppRepository.loadChangedSessions()).isEmpty()
-        verify(sessionsDatabaseRepository, once()).querySessionsOrderedByDateUtc()
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
     }
 
     @Test
@@ -118,14 +121,14 @@ class AppRepositorySessionsTest {
         whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn sessions.toSessionsDatabaseModel()
         val changedSessions = testableAppRepository.loadChangedSessions()
         assertThat(changedSessions).containsExactly(SESSION_1002, SESSION_1003, SESSION_1004, SESSION_1005)
-        verify(sessionsDatabaseRepository, once()).querySessionsOrderedByDateUtc()
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
     }
 
     @Test
     fun `loadStarredSessions passes through an empty list`() {
         whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn emptyList()
         assertThat(testableAppRepository.loadStarredSessions()).isEmpty()
-        verify(sessionsDatabaseRepository, once()).querySessionsOrderedByDateUtc()
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
     }
 
     @Test
@@ -134,14 +137,14 @@ class AppRepositorySessionsTest {
         whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn sessions.toSessionsDatabaseModel()
         val starredSessions = testableAppRepository.loadStarredSessions()
         assertThat(starredSessions).containsExactly(SESSION_2002)
-        verify(sessionsDatabaseRepository, once()).querySessionsOrderedByDateUtc()
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
     }
 
     @Test
     fun `loadUncanceledSessionsForDayIndex passes through an empty list`() {
         whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(anyInt())) doReturn emptyList()
         assertThat(testableAppRepository.loadUncanceledSessionsForDayIndex(0)).isEmpty()
-        verify(sessionsDatabaseRepository, once()).querySessionsForDayIndexOrderedByDateUtc(anyInt())
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(anyInt())
     }
 
     @Test
@@ -150,9 +153,7 @@ class AppRepositorySessionsTest {
         whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(anyInt())) doReturn sessions.toSessionsDatabaseModel()
         val uncanceledSessions = testableAppRepository.loadUncanceledSessionsForDayIndex(0)
         assertThat(uncanceledSessions).containsExactly(SESSION_3001)
-        verify(sessionsDatabaseRepository, once()).querySessionsForDayIndexOrderedByDateUtc(anyInt())
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(anyInt())
     }
-
-    private fun once() = times(1)
 
 }

--- a/commons-testing/build.gradle
+++ b/commons-testing/build.gradle
@@ -1,0 +1,32 @@
+import nerd.tuxmobil.fahrplan.congress.Android
+import nerd.tuxmobil.fahrplan.congress.Libs
+
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
+
+android {
+    compileSdkVersion Android.compileSdkVersion
+    buildToolsVersion Android.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion Android.minSdkVersion
+        targetSdkVersion Android.targetSdkVersion
+        versionCode 1
+        versionName "1.0.0"
+    }
+
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+
+    implementation Libs.kotlinStdlib
+    api Libs.mockitoKotlin
+
+}

--- a/commons-testing/src/main/AndroidManifest.xml
+++ b/commons-testing/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="info.metadude.android.eventfahrplan.commons.testing" />

--- a/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/Verification.kt
+++ b/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/Verification.kt
@@ -1,0 +1,26 @@
+@file:JvmName("Verification")
+
+package info.metadude.android.eventfahrplan.commons.testing
+
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import org.mockito.Mockito
+
+/**
+ *  Verifies certain behavior happened never.
+ *
+ *  Parameterized alias for [Mockito.verify].
+ */
+fun <T> verifyInvokedNever(mock: T): T {
+    return verify(mock, never())
+}
+
+/**
+ *  Verifies certain behavior happened exactly once.
+ *
+ *  Parameterized alias for [Mockito.verify].
+ */
+fun <T> verifyInvokedOnce(mock: T): T {
+    return verify(mock, times(1))
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':commons', ':database', ':engelsystem', ':network'
+include ':app', ':commons', ':commons-testing', ':database', ':engelsystem', ':network'


### PR DESCRIPTION
# Description
- This commit introduces a new `commons-testing` module which is intended for putting commonly shared helper methods for testing purposes.
- By moving these methods into the module the call sites become somewhat less repetitive aka. DRY.
- New methods introduced here: `Verification#verifyInvokedNever` and `Verification#verifyInvokedOnce.`