### PR TITLE
Replace deprecated "Html#fromHtml" with "HtmlCompat#fromHtml".

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.about;
 
 import android.os.Bundle;
-import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.text.method.MovementMethod;
 import android.view.LayoutInflater;
@@ -16,6 +15,7 @@ import androidx.fragment.app.DialogFragment;
 
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.R;
+import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
 
 public class AboutDialog extends DialogFragment {
 
@@ -101,32 +101,32 @@ public class AboutDialog extends DialogFragment {
         MovementMethod movementMethod = LinkMovementMethod.getInstance();
 
         TextView logoCopyright = view.findViewById(R.id.about_copyright_logo_view);
-        logoCopyright.setText(Html.fromHtml(getString(R.string.copyright_logo)));
+        logoCopyright.setText(Strings.toSpanned(getString(R.string.copyright_logo)));
         logoCopyright.setLinkTextColor(linkTextColor);
         logoCopyright.setMovementMethod(movementMethod);
 
         TextView conferenceUrl = view.findViewById(R.id.about_conference_url_view);
-        conferenceUrl.setText(Html.fromHtml(getString(R.string.conference_url)));
+        conferenceUrl.setText(Strings.toSpanned(getString(R.string.conference_url)));
         conferenceUrl.setMovementMethod(movementMethod);
         conferenceUrl.setLinkTextColor(linkTextColor);
 
         TextView sourceCode = view.findViewById(R.id.about_source_code_view);
-        sourceCode.setText(Html.fromHtml(getString(R.string.source_code)));
+        sourceCode.setText(Strings.toSpanned(getString(R.string.source_code)));
         sourceCode.setMovementMethod(movementMethod);
         sourceCode.setLinkTextColor(linkTextColor);
 
         TextView issues = view.findViewById(R.id.about_issues_view);
-        issues.setText(Html.fromHtml(getString(R.string.issues)));
+        issues.setText(Strings.toSpanned(getString(R.string.issues)));
         issues.setMovementMethod(movementMethod);
         issues.setLinkTextColor(linkTextColor);
 
         TextView googlePlayStore = view.findViewById(R.id.about_google_play_view);
-        googlePlayStore.setText(Html.fromHtml(getString(R.string.google_play_store)));
+        googlePlayStore.setText(Strings.toSpanned(getString(R.string.google_play_store)));
         googlePlayStore.setMovementMethod(movementMethod);
         googlePlayStore.setLinkTextColor(linkTextColor);
 
         TextView dataPrivacyStatement = view.findViewById(R.id.about_data_privacy_statement_view);
-        dataPrivacyStatement.setText(Html.fromHtml(getString(R.string.about_data_privacy_statement)));
+        dataPrivacyStatement.setText(Strings.toSpanned(getString(R.string.about_data_privacy_statement)));
         dataPrivacyStatement.setMovementMethod(movementMethod);
         dataPrivacyStatement.setLinkTextColor(linkTextColor);
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.java
@@ -7,7 +7,6 @@ import android.content.res.AssetManager;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
-import android.text.Html;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
@@ -35,6 +34,7 @@ import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment;
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
+import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
 import nerd.tuxmobil.fahrplan.congress.models.Session;
 import nerd.tuxmobil.fahrplan.congress.navigation.RoomForC3NavConverter;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
@@ -281,7 +281,7 @@ public class SessionDetailsFragment extends Fragment {
                                    @NonNull Typeface typeface,
                                    @NonNull String text) {
         textView.setTypeface(typeface);
-        textView.setText(Html.fromHtml(text), TextView.BufferType.SPANNABLE);
+        textView.setText(Strings.toSpanned(text), TextView.BufferType.SPANNABLE);
         textView.setLinkTextColor(ContextCompat.getColor(textView.getContext(), R.color.text_link_color));
         textView.setMovementMethod(new LinkMovementMethod());
         textView.setVisibility(View.VISIBLE);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/StringExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/StringExtensions.kt
@@ -1,0 +1,17 @@
+@file:JvmName("Strings")
+
+package nerd.tuxmobil.fahrplan.congress.extensions
+
+import android.text.Spanned
+import androidx.core.text.HtmlCompat
+
+/**
+ * Converts this HTML string into a displayable styled text.
+ *
+ * See also: [android.text.Html.fromHtml]
+ */
+@Suppress("NOTHING_TO_INLINE")
+@JvmOverloads
+inline fun String.toSpanned(
+        flags: Int = HtmlCompat.FROM_HTML_MODE_LEGACY
+): Spanned = HtmlCompat.fromHtml(this, flags)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.java
@@ -16,7 +16,6 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.provider.Settings;
-import android.text.Html;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
@@ -29,6 +28,7 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices;
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
+import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 
@@ -141,7 +141,7 @@ public class SettingsActivity extends BaseActivity {
             PreferenceCategory engelsystemCategory = (PreferenceCategory) findPreference(getString(R.string.preference_engelsystem_category_key));
             if (BuildConfig.ENABLE_ENGELSYSTEM_SHIFTS) {
                 Preference urlPreference = findPreference(getString(R.string.preference_engelsystem_json_export_url_key));
-                urlPreference.setSummary(Html.fromHtml(getString(R.string.preference_engelsystem_json_export_url_summary)));
+                urlPreference.setSummary(Strings.toSpanned(getString(R.string.preference_engelsystem_json_export_url_summary)));
                 urlPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     String url = (String) newValue;
                     appRepository.updateEngelsystemShiftsUrl(url);


### PR DESCRIPTION
# Description
+ Replace deprecated `Html#fromHtml` with `HtmlCompat#fromHtml`.
+ Prepare extension function to be used once it is called from Kotlin.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 2 device, Android 10 (API 29)