### PR TITLE
Revise Session equals & hashCode methods

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.core.util.ObjectsCompat;
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
@@ -127,7 +128,7 @@ public class Session {
         return (dateUTC > 0) ? dateUTC : getStartTimeMoment().toMilliseconds();
     }
 
-    @SuppressWarnings("EqualsReplaceableByObjectsCall")
+    @SuppressWarnings("RedundantIfStatement")
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -139,20 +140,16 @@ public class Session {
         if (duration != session.duration) return false;
         if (recordingOptOut != session.recordingOptOut) return false;
         if (startTime != session.startTime) return false;
-        if (date != null ? !date.equals(session.date) : session.date != null) return false;
-        if (lang != null ? !lang.equals(session.lang) : session.lang != null) return false;
+        if (!ObjectsCompat.equals(date, session.date)) return false;
+        if (!ObjectsCompat.equals(lang, session.lang)) return false;
         if (!sessionId.equals(session.sessionId)) return false;
-        if (recordingLicense != null ? !recordingLicense.equals(session.recordingLicense) :
-                session.recordingLicense != null)
-            return false;
-        if (room != null ? !room.equals(session.room) : session.room != null) return false;
-        if (speakers != null ? !speakers.equals(session.speakers) : session.speakers != null)
-            return false;
-        if (subtitle != null ? !subtitle.equals(session.subtitle) : session.subtitle != null)
-            return false;
+        if (!ObjectsCompat.equals(recordingLicense, session.recordingLicense)) return false;
+        if (!ObjectsCompat.equals(room, session.room)) return false;
+        if (!ObjectsCompat.equals(speakers, session.speakers)) return false;
+        if (!ObjectsCompat.equals(subtitle, session.subtitle)) return false;
         if (!title.equals(session.title)) return false;
-        if (track != null ? !track.equals(session.track) : session.track != null) return false;
-        if (type != null ? !type.equals(session.type) : session.type != null) return false;
+        if (!ObjectsCompat.equals(track, session.track)) return false;
+        if (!ObjectsCompat.equals(type, session.type)) return false;
         if (dateUTC != session.dateUTC) return false;
 
         return true;
@@ -161,18 +158,18 @@ public class Session {
     @Override
     public int hashCode() {
         int result = title.hashCode();
-        result = 31 * result + (subtitle != null ? subtitle.hashCode() : 0);
+        result = 31 * result + ObjectsCompat.hashCode(subtitle);
         result = 31 * result + day;
-        result = 31 * result + (room != null ? room.hashCode() : 0);
+        result = 31 * result + ObjectsCompat.hashCode(room);
         result = 31 * result + startTime;
         result = 31 * result + duration;
-        result = 31 * result + (speakers != null ? speakers.hashCode() : 0);
-        result = 31 * result + (track != null ? track.hashCode() : 0);
+        result = 31 * result + ObjectsCompat.hashCode(speakers);
+        result = 31 * result + ObjectsCompat.hashCode(track);
         result = 31 * result + sessionId.hashCode();
-        result = 31 * result + (type != null ? type.hashCode() : 0);
-        result = 31 * result + (lang != null ? lang.hashCode() : 0);
-        result = 31 * result + (date != null ? date.hashCode() : 0);
-        result = 31 * result + (recordingLicense != null ? recordingLicense.hashCode() : 0);
+        result = 31 * result + ObjectsCompat.hashCode(type);
+        result = 31 * result + ObjectsCompat.hashCode(lang);
+        result = 31 * result + ObjectsCompat.hashCode(date);
+        result = 31 * result + ObjectsCompat.hashCode(recordingLicense);
         result = 31 * result + (recordingOptOut ? 1 : 0);
         result = 31 * result + (int) dateUTC;
         return result;

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -3,7 +3,247 @@ package nerd.tuxmobil.fahrplan.congress.models
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+private typealias SessionModification = Session.() -> Unit
+
 class SessionTest {
+
+    companion object {
+
+        fun createSession() = Session("s1").apply {
+            title = "Lorem ipsum"
+            subtitle = "Gravida arcu ac tortor"
+            day = 3
+            date = "2020-02-29"
+            dateUTC = 1439478900000L
+            startTime = 1125
+            duration = 60
+            room = "Main hall"
+            speakers = "Janet"
+            track = "science"
+            type = "workshop"
+            lang = "cz"
+            recordingLicense = "CC-0"
+            recordingOptOut = true
+
+            // Not considered in equal nor hashCode.
+            url = "https://example.com"
+            relStartTime = 500
+            roomIndex = 6
+            slug = "lorem-ipsum"
+            abstractt = "Sodales ut etiam sit amet nisl purus"
+            description = "Lorem ipsum dolor sit amet"
+            links = "http://sample.com"
+            highlight = true
+            hasAlarm = true
+
+            // Not considered in equal nor hashCode, too.
+            changedTitle = true
+            changedSubtitle = true
+            changedRoom = true
+            changedDay = true
+            changedTime = true
+            changedDuration = true
+            changedSpeakers = true
+            changedRecordingOptOut = true
+            changedLanguage = true
+            changedTrack = true
+            changedIsNew = true
+            changedIsCanceled = true
+        }
+
+        fun createSessionModifyingNonConsideredFields() = createSession().apply {
+            url = "https://foobar-url.org"
+            relStartTime = 999
+            roomIndex = 13
+            slug = "foo-bar"
+            abstractt = "Foo abstract"
+            description = "Foo description"
+            links = "https://foobar-links.org"
+            highlight = false
+            hasAlarm = false
+
+            changedTitle = false
+            changedSubtitle = false
+            changedRoom = false
+            changedDay = false
+            changedTime = false
+            changedDuration = false
+            changedSpeakers = false
+            changedRecordingOptOut = false
+            changedLanguage = false
+            changedTrack = false
+            changedIsNew = false
+            changedIsCanceled = false
+        }
+
+    }
+
+    @Test
+    fun `equals evaluates true for equal sessions`() {
+        val session1 = createSession()
+        val session2 = createSession()
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1).isEqualTo(session2)
+    }
+
+    @Test
+    fun `equals evaluates true for sessions with not considered fields modified`() {
+        val session1 = createSession()
+        val session2 = createSessionModifyingNonConsideredFields()
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1).isEqualTo(session2)
+    }
+
+    @Test
+    fun `equals evaluates false when comparing with null`() {
+        val session1 = createSession()
+        val session2 = null
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1).isNotEqualTo(session2)
+    }
+
+    @Test
+    fun `equals evaluates false when comparing with other type`() {
+        val session1 = createSession()
+        val session2 = "Other type"
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1).isNotEqualTo(session2)
+    }
+
+    @Test
+    fun `hashCode evaluates true for equal sessions`() {
+        val session1 = createSession()
+        val session2 = createSession()
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1.hashCode()).isEqualTo(session2.hashCode())
+    }
+
+    @Test
+    fun `hashCode evaluates true for sessions with not considered fields modified`() {
+        val session1 = createSession()
+        val session2 = createSessionModifyingNonConsideredFields()
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1.hashCode()).isEqualTo(session2.hashCode())
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd sessionId`() {
+        val session2Modification: SessionModification = { sessionId = "Odd session ID" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd title`() {
+        val session2Modification: SessionModification = { title = "Odd title" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd subtitle`() {
+        val session2Modification: SessionModification = { subtitle = "Odd subtitle" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd day`() {
+        val session2Modification: SessionModification = { day = 2 }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd date`() {
+        val session2Modification: SessionModification = { date = "1999-12-23" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd dateUTC`() {
+        val session2Modification: SessionModification = { dateUTC = 1439471100000L }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd startTime`() {
+        val session2Modification: SessionModification = { startTime = 1350 }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd duration`() {
+        val session2Modification: SessionModification = { duration = 45 }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd room`() {
+        val session2Modification: SessionModification = { room = "Odd room" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd speakers`() {
+        val session2Modification: SessionModification = { speakers = "Odd speakers" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd track`() {
+        val session2Modification: SessionModification = { track = "Odd track" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd type`() {
+        val session2Modification: SessionModification = { type = "Odd type" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd lang`() {
+        val session2Modification: SessionModification = { lang = "Odd language" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd recordingLicense`() {
+        val session2Modification: SessionModification = { recordingLicense = "Odd recording license" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd recordingOptOut`() {
+        val session2Modification: SessionModification = { recordingOptOut = false }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    private fun assertOddSessionsAreNotEqual(session2Modification: SessionModification) {
+        val session1 = createSession()
+        val session2 = createSession().apply { session2Modification() }
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1).isNotEqualTo(session2)
+    }
+
+    private fun assertOddSessionsHaveOddHashCodes(session2Modification: SessionModification) {
+        val session1 = createSession()
+        val session2 = createSession().apply { session2Modification() }
+        assertThat(session1).isNotSameAs(session2)
+        assertThat(session1.hashCode()).isNotEqualTo(session2.hashCode())
+    }
 
     @Test
     fun getStartTimeMoment() {


### PR DESCRIPTION
# Description
- Add unit test to prevent undesired modifications of `equals` & `hashCode` methods in `Session` class.
  - Some fields are not part of the `equals` & `hashCode` methods. Adding them might have undesired consequences in other parts of the project. These test provide some level of protection so one can make an informed decision when needed.
- Simplify `equals` & `hashCode` methods of `Session` class by using `ObjectsCompat#equals` and `ObjectsCompat#hashCode`.

---

I discovered `ObjectsCompat` in the [AntennaPod](https://github.com/AntennaPod/AntennaPod) code base. Thanks to @ByteHamster.