### PR TITLE
Append time zone offset when sharing a session as plain text.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
@@ -47,10 +47,10 @@ public class SimpleSessionFormat {
 
     private static void appendSession(StringBuilder builder, Session session) {
         long startTime = session.getStartTimeMilliseconds();
-        String formattedTime = DateFormatter.newInstance().getFormattedDateTime(startTime);
+        String shareableStartTime = DateFormatter.newInstance().getFormattedShareable(startTime);
         builder.append(session.title);
         builder.append(LINE_BREAK);
-        builder.append(formattedTime);
+        builder.append(shareableStartTime);
         builder.append(COMMA);
         builder.append(SPACE);
         builder.append(session.room);

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -4,6 +4,7 @@ import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.format.DateTimeFormatter
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.TimeZone
 
 /**
  * Format timestamps according to system locale and system time zone.
@@ -34,10 +35,16 @@ class DateFormatter private constructor() {
     fun getFormattedDate(time: Long): String = dateShort.format(Date(time))
 
     /**
-     * Returns day month, year and time in current system locale in long format.
-     * E.g. Tuesday, January 22, 2019 1:00 AM
+     * Returns a formatted string suitable for sharing it with people worldwide.
+     * It contains day, month, year and time in current system locale in long format
+     * and the associated time zone offset.
+     * E.g. Tuesday, January 22, 2019 1:00 AM GMT+01:00
      */
-    fun getFormattedDateTime(time: Long): String = dateTimeFull.format(Date(time))
+    fun getFormattedShareable(time: Long): String {
+        val timeZoneOffset = dateTimeFull.timeZone.getDisplayName(true, TimeZone.SHORT)
+        // TODO Append time zone name once it is provided. See https://github.com/EventFahrplan/EventFahrplan/pull/296.
+        return "${dateTimeFull.format(Date(time))} $timeZoneOffset"
+    }
 
     /**
      * Returns day month, year and time in current system locale in short format.

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -67,12 +67,14 @@ class DateFormatterTest {
     }
 
     @Test
-    fun getFormattedDateTime() {
+    fun getFormattedShareable() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedDateTime(timestamp)).isEqualTo("Tuesday, January 22, 2019 1:00 AM")
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp))
+                .isEqualTo("Tuesday, January 22, 2019 1:00 AM GMT+01:00")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedDateTime(timestamp)).isEqualTo("Dienstag, 22. Januar 2019 01:00")
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp))
+                .isEqualTo("Dienstag, 22. Januar 2019 01:00 GMT+01:00")
     }
 
     @Test


### PR DESCRIPTION
# Description
- This affects the text output when sharing a session via the context menu.
- This is useful in social media because people the session is shared with might not be in the same time zone as the person who shares the session.
- Add TODO for appending the _time zone name_ once it is provided by _frab_ and _Pretix_.


# Before
- Example: `Tuesday, July 28, 2020 19:00`

![Tweet example without time zone information](https://user-images.githubusercontent.com/144518/88697099-62730180-d104-11ea-96fe-228b4725250f.png)


# After
- Example: `Tuesday, July 28, 2020 19:00 GMT+02:00`

![Tweet example with time zone information](https://user-images.githubusercontent.com/144518/88697121-6868e280-d104-11ea-97bc-287fe791e6d7.png)

# Related
- [voc/schedule issue #69: Add time_zone_name element](https://github.com/voc/schedule/issues/69)
- [voc/schedule PR #70: add optional time_zone_name element to schedule XML schema](https://github.com/voc/schedule/issues/70)