### PR TITLE
Reduce CertificateDialogFragment complexity by extracting CertificateChainFormatter.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CertificateChainFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/CertificateChainFormatter.kt
@@ -1,0 +1,81 @@
+package nerd.tuxmobil.fahrplan.congress.net
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import nerd.tuxmobil.fahrplan.congress.R
+import java.security.cert.X509Certificate
+
+/**
+ * Formats the given chain of certificates and its associated fingerprints to be displayed to the
+ * user in a readable format.
+ *
+ * The [pairs of certificates and fingerprints][fingerprintsByCertificates] are expected to be passed
+ * in the original order of the certificates in the chain.
+ */
+internal class CertificateChainFormatter @VisibleForTesting constructor(
+
+        private val fingerprintsByCertificates: List<Pair<X509Certificate, String>>,
+        private val getHeadlineText: (Int) -> String,
+        private val getSubjectText: (String) -> String,
+        private val getIssuerText: (String) -> String,
+        private val getIssuedOnText: (String) -> String,
+        private val getExpiresOnText: (String) -> String,
+        private val getSha1FingerprintText: (String) -> String,
+        private val dateFormatter: DateFormatter = DateFormatter.newInstance()
+
+) {
+
+    companion object {
+
+        @JvmStatic
+        @JvmOverloads
+        fun getNewInstance(
+                fingerprintsByCertificates: List<Pair<X509Certificate, String>>,
+                context: Context,
+                dateFormatter: DateFormatter = DateFormatter.newInstance()
+        ) = CertificateChainFormatter(
+                fingerprintsByCertificates = fingerprintsByCertificates,
+                getHeadlineText = { chainIndex: Int -> context.getString(R.string.certificate_info_headline, chainIndex) },
+                getSubjectText = { subject: String -> context.getString(R.string.certificate_info_subject, subject) },
+                getIssuerText = { issuer: String -> context.getString(R.string.certificate_info_issuer, issuer) },
+                getIssuedOnText = { issuedOn: String -> context.getString(R.string.certificate_info_issued_on, issuedOn) },
+                getExpiresOnText = { expiredOn: String -> context.getString(R.string.certificate_info_expires_on, expiredOn) },
+                getSha1FingerprintText = { sha1: String -> context.getString(R.string.certificate_info_sha1_fingerprint, sha1) },
+                dateFormatter = dateFormatter
+        )
+
+    }
+
+    /**
+     * Returns a formatted info text or an empty string if no certificates are present.
+     */
+    fun getCertificateChainInfo(): String {
+        val chainLength = fingerprintsByCertificates.size
+        if (chainLength > 0) {
+            val buffer = StringBuffer(100)
+            var index = 0
+            for ((certificate, fingerprint) in fingerprintsByCertificates) {
+                buffer.appendCertificateInfo(index, certificate, fingerprint)
+                if (index + 1 < chainLength) {
+                    buffer.append("\n")
+                }
+                index++
+            }
+            return buffer.toString()
+        }
+        return ""
+    }
+
+    private fun StringBuffer.appendCertificateInfo(index: Int, certificate: X509Certificate, fingerprint: String) {
+        append(getHeadlineText(index)).append("\n")
+        append(getSubjectText(certificate.subjectDN.toString())).append("\n")
+        append(getIssuerText(certificate.issuerDN.toString())).append("\n")
+        val issuedOn = dateFormatter.getFormattedDate(certificate.notBefore)
+        val expiredOn = dateFormatter.getFormattedDate(certificate.notAfter)
+        append(getIssuedOnText(issuedOn)).append("\n")
+        append(getExpiresOnText(expiredOn)).append("\n")
+        append(getSha1FingerprintText(fingerprint)).append("\n")
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,26 @@
     <string name="OK">OK</string>
 
     <!-- CertificateDialog -->
+    <string name="certificate_info_headline" translatable="false">
+        Certificate chain[<xliff:g example="0" id="index">%d</xliff:g>]:
+    </string>
+    <string name="certificate_info_subject" translatable="false">
+        Subject: <xliff:g example="events.ccc.de" id="subject">%s</xliff:g>
+    </string>
+    <string name="certificate_info_issuer" translatable="false">
+        Issuer: <xliff:g example="Let's Encrypt" id="issuer">%s</xliff:g>
+    </string>
+    <string name="certificate_info_issued_on" translatable="false">
+        Issued on: <xliff:g example="12.07.2020" id="issuedOn">%s</xliff:g>
+    </string>
+    <string name="certificate_info_expires_on" translatable="false">
+        Expires on: <xliff:g example="10.10.2020" id="expiresOn">%s</xliff:g>
+    </string>
+    <string name="certificate_info_sha1_fingerprint" translatable="false">
+        SHA1 fingerprint:
+        <xliff:g example="95 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F 67 E5" id="sha1">%s</xliff:g>
+    </string>
+
     <string name="dlg_certificate_message_fmt">
         Failed to establish secure connection.\n
         (<xliff:g example="Unknown Error" id="error">%s</xliff:g>)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/net/CertificateChainFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/net/CertificateChainFormatterTest.kt
@@ -1,0 +1,122 @@
+package nerd.tuxmobil.fahrplan.congress.net
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.security.cert.X509Certificate
+import java.util.Locale
+import java.util.TimeZone
+
+class CertificateChainFormatterTest {
+
+    private companion object {
+
+        /**
+         * Milliseconds representation of March 1, 2020 01:00:00 AM GMT.
+         */
+        private const val MAR_01_2020_01_00 = 1583024400000L
+
+        /**
+         * Milliseconds representation of November 1, 2020 01:00:00 AM GMT
+         */
+        private const val NOV_01_2020_01_00 = 1604192400000
+
+        /**
+         * Milliseconds representation of December 1, 2020 01:00:00 AM GMT
+         */
+        private const val DEC_01_2020_01_00 = 1606784400000L
+
+    }
+
+    private val systemLocale = Locale.getDefault()
+    private val systemTimezone = TimeZone.getDefault()
+
+    @Before
+    fun setUp() {
+        // Fixate locale & time zone to prevent date formatting issues on certain systems.
+        Locale.setDefault(Locale.US)
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
+    }
+
+    @After
+    fun tearDown() {
+        Locale.setDefault(systemLocale)
+        TimeZone.setDefault(systemTimezone)
+    }
+
+    @Test
+    fun `getCertificateChainInfo returns empty string when passing empty collection`() {
+        val formatter = createFormatter(emptyList())
+        assertThat(formatter.getCertificateChainInfo()).isEqualTo("")
+    }
+
+    @Test
+    fun `getCertificateChainInfo returns formatted info text block for single certificate and fingerprint`() {
+        val expectedInfo = """
+            Certificate chain[0]
+            Subject: test.ccc.de
+            Issuer: Let's certificate all the things
+            Issued on: 3/1/20
+            Expires on: 12/1/20
+            SHA1 fingerprint: 95 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F 67 E5
+
+        """.trimIndent()
+        val certificate = TestCertificate.of(
+                subject = "test.ccc.de",
+                issuer = "Let's certificate all the things",
+                notBeforeTimeMs = MAR_01_2020_01_00,
+                notAfterTimeMs = DEC_01_2020_01_00)
+        val fingerprintByCertificate = certificate to "95 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F 67 E5"
+        val formatter = createFormatter(listOf(fingerprintByCertificate))
+        assertThat(formatter.getCertificateChainInfo()).isEqualTo(expectedInfo)
+    }
+
+    @Test
+    fun `getCertificateChainInfo returns formatted info text block for chain`() {
+        val expectedInfo = """
+            Certificate chain[0]
+            Subject: test.ccc.de
+            Issuer: Let's certificate all the things
+            Issued on: 3/1/20
+            Expires on: 12/1/20
+            SHA1 fingerprint: 95 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F 67 E5
+
+            Certificate chain[1]
+            Subject: test.eff.org
+            Issuer: Let's free all the things
+            Issued on: 3/1/20
+            Expires on: 11/1/20
+            SHA1 fingerprint: C4 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F C3 AA
+
+        """.trimIndent()
+        val certificate1 = TestCertificate.of(
+                subject = "test.ccc.de",
+                issuer = "Let's certificate all the things",
+                notBeforeTimeMs = MAR_01_2020_01_00,
+                notAfterTimeMs = DEC_01_2020_01_00)
+        val certificate2 = TestCertificate.of(
+                subject = "test.eff.org",
+                issuer = "Let's free all the things",
+                notBeforeTimeMs = MAR_01_2020_01_00,
+                notAfterTimeMs = NOV_01_2020_01_00)
+        val formatter = createFormatter(listOf(
+                certificate1 to "95 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F 67 E5",
+                certificate2 to "C4 36 C0 C8 6E 0B C5 AE 1F 3E 4B 37 58 D4 8E 3E DE 2F C3 AA"
+        ))
+        assertThat(formatter.getCertificateChainInfo()).isEqualTo(expectedInfo)
+    }
+
+    private fun createFormatter(fingerprintsByCertificates: List<Pair<X509Certificate, String>>) = CertificateChainFormatter(
+            fingerprintsByCertificates = fingerprintsByCertificates,
+            getHeadlineText = { chainIndex -> "Certificate chain[$chainIndex]" },
+            getSubjectText = { subject -> "Subject: $subject" },
+            getIssuerText = { issuer -> "Issuer: $issuer" },
+            getIssuedOnText = { issuedOn -> "Issued on: $issuedOn" },
+            getExpiresOnText = { expiresOn -> "Expires on: $expiresOn" },
+            getSha1FingerprintText = { sha1 -> "SHA1 fingerprint: $sha1" },
+            dateFormatter = DateFormatter.newInstance()
+    )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/net/TestCertificate.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/net/TestCertificate.kt
@@ -1,0 +1,75 @@
+package nerd.tuxmobil.fahrplan.congress.net
+
+import java.security.Principal
+import java.security.PublicKey
+import java.security.cert.X509Certificate
+import java.util.Date
+import java.util.Objects
+
+/**
+ * X509 certificate for testing purposes.
+ *
+ * Use [TestCertificate.of] to create an instance.
+ */
+internal class TestCertificate private constructor(
+
+        private val subject: String,
+        private val issuer: String,
+        private val notBeforeTimeMs: Long,
+        private val notAfterTimeMs: Long
+
+) : X509Certificate() {
+
+    companion object {
+
+        fun of(subject: String, issuer: String, notBeforeTimeMs: Long, notAfterTimeMs: Long) =
+                TestCertificate(subject, issuer, notBeforeTimeMs, notAfterTimeMs)
+
+    }
+
+    private fun principalOf(principalName: String) = object : Principal {
+        override fun getName() = principalName
+        override fun toString() = name
+    }
+
+    override fun getSubjectDN() = principalOf(subject)
+    override fun getIssuerDN() = principalOf(issuer)
+    override fun getNotBefore() = Date(notBeforeTimeMs)
+    override fun getNotAfter() = Date(notAfterTimeMs)
+    override fun getEncoded(): ByteArray {
+        val fakeHash = Objects.hash(subject, issuer, notBeforeTimeMs, notAfterTimeMs)
+        return byteArrayOf(fakeHash.toByte())
+    }
+
+    override fun toString(): String {
+        return "TestCertificate(" +
+                "subjectDN=$subjectDN, " +
+                "issuerDN=$issuerDN, " +
+                "notBefore=$notBefore, " +
+                "notAfter=$notAfter" +
+                ")"
+    }
+
+    // Down from here: Not relevant for current test usage.
+
+    override fun getPublicKey() = throw NotImplementedError()
+    override fun getCriticalExtensionOIDs() = throw NotImplementedError()
+    override fun getNonCriticalExtensionOIDs() = throw NotImplementedError()
+    override fun getSubjectUniqueID() = throw NotImplementedError()
+    override fun getSignature() = throw NotImplementedError()
+    override fun getSigAlgName() = throw NotImplementedError()
+    override fun getExtensionValue(oid: String?) = throw NotImplementedError()
+    override fun getVersion() = throw NotImplementedError()
+    override fun verify(key: PublicKey?) = throw NotImplementedError()
+    override fun verify(key: PublicKey?, sigProvider: String?) = throw NotImplementedError()
+    override fun getBasicConstraints() = throw NotImplementedError()
+    override fun getSigAlgParams() = throw NotImplementedError()
+    override fun getSigAlgOID() = throw NotImplementedError()
+    override fun checkValidity() = throw NotImplementedError()
+    override fun checkValidity(date: Date?) = throw NotImplementedError()
+    override fun getTBSCertificate() = throw NotImplementedError()
+    override fun getKeyUsage() = throw NotImplementedError()
+    override fun hasUnsupportedCriticalExtension() = throw NotImplementedError()
+    override fun getSerialNumber() = throw NotImplementedError()
+    override fun getIssuerUniqueID() = throw NotImplementedError()
+}

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -31,7 +31,13 @@ class DateFormatter private constructor() {
      * Returns day month and year in current system locale.
      * E.g. 1/22/19 or 22.01.19
      */
-    fun getFormattedDate(time: Long): String = dateShort.format(Date(time))
+    fun getFormattedDate(time: Long): String = getFormattedDate(Date(time))
+
+    /**
+     * Returns day month and year in current system locale.
+     * E.g. 1/22/19 or 22.01.19
+     */
+    fun getFormattedDate(date: Date): String = dateShort.format(date)
 
     /**
      * Returns day month, year and time in current system locale in long format.

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
@@ -58,12 +59,21 @@ class DateFormatterTest {
     }
 
     @Test
-    fun getFormattedDate() {
+    fun `getFormattedDate with Long`() {
         Locale.setDefault(Locale.US)
         assertThat(DateFormatter.newInstance().getFormattedDate(timestamp)).isEqualTo("1/22/19")
 
         Locale.setDefault(Locale.GERMANY)
         assertThat(DateFormatter.newInstance().getFormattedDate(timestamp)).isEqualTo("22.01.19")
+    }
+
+    @Test
+    fun `getFormattedDate with Date`() {
+        Locale.setDefault(Locale.US)
+        assertThat(DateFormatter.newInstance().getFormattedDate(Date(timestamp))).isEqualTo("1/22/19")
+
+        Locale.setDefault(Locale.GERMANY)
+        assertThat(DateFormatter.newInstance().getFormattedDate(Date(timestamp))).isEqualTo("22.01.19")
     }
 
     @Test


### PR DESCRIPTION
# Description
+ Replace usage of deprecated `Date` methods with internal `DateFormatter`.
+ Extract string resources.
+ Add unit tests.
+ There is **no functional change** intended in these commits.