### PR TITLE
Ensure speaker names are visible when track name is long.

### DIFF
--- a/app/src/main/res/layout-port/session_layout.xml
+++ b/app/src/main/res/layout-port/session_layout.xml
@@ -57,28 +57,16 @@
             android:textSize="12sp"
             tools:text="@string/placeholder_session_subtitle"/>
 
-    <RelativeLayout
+    <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="bottom">
 
         <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:fontFamily="sans-serif-condensed"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:textSize="11sp"
-                tools:text="@string/placeholder_session_track"/>
-
-        <TextView
                 android:id="@+id/session_speakers_view"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true"
-                android:layout_toLeftOf="@id/session_track_view"
+                android:layout_weight="0.6"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif-condensed"
                 android:paddingRight="10dp"
@@ -86,6 +74,20 @@
                 android:textColor="@color/session_title_on_default_background"
                 android:textSize="11sp"
                 tools:text="@string/placeholder_session_speakers"/>
-    </RelativeLayout>
+
+        <TextView
+                android:id="@+id/session_track_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.4"
+                android:ellipsize="start"
+                android:fontFamily="sans-serif-condensed"
+                android:gravity="end"
+                android:singleLine="true"
+                android:textColor="@color/track_name"
+                android:textSize="11sp"
+                tools:text="@string/placeholder_session_track"/>
+
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/session_layout_land.xml
+++ b/app/src/main/res/layout/session_layout_land.xml
@@ -57,35 +57,37 @@
             android:textSize="9sp"
             tools:text="@string/placeholder_session_subtitle"/>
 
-    <RelativeLayout
+    <LinearLayout
             android:layout_width="match_parent"
-            android:gravity="bottom"
-            android:layout_height="wrap_content">
-
-        <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="wrap_content"
-                android:textSize="8sp"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:layout_alignParentRight="true"
-                android:fontFamily="sans-serif-condensed"
-                android:layout_height="wrap_content"
-                tools:text="@string/placeholder_session_track"/>
+            android:layout_height="wrap_content"
+            android:gravity="bottom">
 
         <TextView
                 android:id="@+id/session_speakers_view"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:textSize="8sp"
-                android:singleLine="true"
-                android:layout_width="wrap_content"
-                android:textColor="#000000"
+                android:layout_weight="0.6"
                 android:ellipsize="end"
-                android:layout_alignParentLeft="true"
-                android:layout_toLeftOf="@id/session_track_view"
-                android:paddingRight="10dp"
                 android:fontFamily="sans-serif-condensed"
-                tools:text="@string/placeholder_session_speakers"
-                />
-    </RelativeLayout>
+                android:paddingRight="10dp"
+                android:singleLine="true"
+                android:textColor="#000000"
+                android:textSize="8sp"
+                tools:text="@string/placeholder_session_speakers" />
+
+        <TextView
+                android:id="@+id/session_track_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.4"
+                android:ellipsize="start"
+                android:fontFamily="sans-serif-condensed"
+                android:gravity="end"
+                android:singleLine="true"
+                android:textColor="@color/track_name"
+                android:textSize="8sp"
+                tools:text="@string/placeholder_session_track"/>
+
+    </LinearLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/session_layout_land_large.xml
+++ b/app/src/main/res/layout/session_layout_land_large.xml
@@ -56,34 +56,37 @@
             tools:text="@string/placeholder_session_subtitle"
             />
 
-    <RelativeLayout
+    <LinearLayout
             android:layout_width="match_parent"
-            android:gravity="bottom"
-            android:layout_height="wrap_content">
-
-        <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:fontFamily="sans-serif-condensed"
-                android:textSize="13sp"
-                tools:text="@string/placeholder_session_track"/>
+            android:layout_height="wrap_content"
+            android:gravity="bottom">
 
         <TextView
                 android:id="@+id/session_speakers_view"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true"
-                android:layout_toLeftOf="@id/session_track_view"
+                android:layout_weight="0.6"
                 android:ellipsize="end"
+                android:fontFamily="sans-serif-condensed"
                 android:paddingRight="10dp"
                 android:singleLine="true"
                 android:textColor="#000000"
-                android:fontFamily="sans-serif-condensed"
                 android:textSize="13sp"
-                tools:text="@string/placeholder_session_speakers"/>
-    </RelativeLayout>
+                tools:text="@string/placeholder_session_speakers" />
+
+        <TextView
+                android:id="@+id/session_track_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.4"
+                android:ellipsize="start"
+                android:fontFamily="sans-serif-condensed"
+                android:gravity="end"
+                android:singleLine="true"
+                android:textColor="@color/track_name"
+                android:textSize="13sp"
+                tools:text="@string/placeholder_session_track" />
+
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
# Description
+ With this change speaker names can take up to 60% while track names can cover 40% of the width. Both texts are ellipsized when they exceed their maximum length. The track name is ellipsized at the start because the language token at the end of the composed text must be visible.

# Successfully tested on
with `ccc36c3` + `froscon2020`, debug builds
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)

# Before
- Speakers names are not visible when track names are long.
![long-track-before](https://user-images.githubusercontent.com/144518/89716397-ef437800-d9ac-11ea-8694-67c97e71f37b.png)
![long-track-before-t](https://user-images.githubusercontent.com/144518/89716398-efdc0e80-d9ac-11ea-9556-890cade82a96.png)


# After
- Both, speakers and track names are visible.
![long-track-after](https://user-images.githubusercontent.com/144518/89716400-f66a8600-d9ac-11ea-801f-89ba18c74ddf.png)
![long-track-after-t](https://user-images.githubusercontent.com/144518/89716402-f7031c80-d9ac-11ea-8e5c-c8e3235bd700.png)
