### PR TITLE
Reorganize Gradle plugins

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,7 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 apply plugin: "kotlin-kapt"
 apply plugin: "de.mobilej.unmock"
-apply plugin: "org.sonarqube"
-apply from: "../sonarqube.gradle"
+apply from: "../gradle/sonarqube.gradle"
 
 android {
     compileSdkVersion Android.compileSdkVersion

--- a/build.gradle
+++ b/build.gradle
@@ -26,16 +26,5 @@ allprojects {
     }
 }
 
-apply plugin: "com.github.ben-manes.versions"
+apply from: "gradle/versions.gradle"
 apply plugin: "com.vanniktech.android.junit.jacoco"
-
-dependencyUpdates {
-    def isNonStable = { String version ->
-        def stableKeyword = ["RELEASE", "FINAL", "GA"].any { qualifier -> version.toUpperCase().contains(qualifier) }
-        def regex = /^[0-9,.v-]+(-r)?$/
-        return !stableKeyword && !(version ==~ regex)
-    }
-    rejectVersionIf {
-        return isNonStable(it.candidate.version)
-    }
-}

--- a/gradle/sonarqube.gradle
+++ b/gradle/sonarqube.gradle
@@ -1,3 +1,7 @@
+// SonarQube Gradle Plugin
+
+apply plugin: "org.sonarqube"
+
 sonarqube {
     properties {
         property "sonar.host.url", "https://sonarcloud.io"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,0 +1,16 @@
+// Gradle Versions Plugin
+
+apply plugin: "com.github.ben-manes.versions"
+
+dependencyUpdates {
+    def isNonStable = { String version ->
+        def stableKeyword = ["RELEASE", "FINAL", "GA"].any {
+            qualifier -> version.toUpperCase().contains(qualifier)
+        }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+    rejectVersionIf {
+        return isNonStable(it.candidate.version)
+    }
+}


### PR DESCRIPTION
# Description
- Encapsulate _gradle-versions-plugin_ setup in its own file.
- Move _sonarqube-gradle-plugin_ setup into `gradle` folder.
