### PR TITLE
Fix rare NullPointerException in UpdateService#onParseDone.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -43,7 +43,8 @@ public class UpdateService extends SafeJobIntentService {
     private final AppRepository appRepository = AppRepository.INSTANCE;
 
     public void onParseDone(@NonNull ParseResult result) {
-        MyApp.LogDebug(LOG_TAG, "parseDone: " + result.isSuccess() + " , numDays=" + MyApp.meta.getNumDays());
+        int numDays = appRepository.readMeta().getNumDays();
+        MyApp.LogDebug(LOG_TAG, "parseDone: " + result.isSuccess() + " , numDays=" + numDays);
         MyApp.task_running = TASKS.NONE;
         List<Session> changesList = appRepository.loadChangedSessions();
         if (!changesList.isEmpty() && result instanceof ParseScheduleResult) {


### PR DESCRIPTION
# Description
+ The `MyApp.meta` field has not been initialized.
+ Cannot be reproduced; likely to happen asynchronously.

# Stacktrace

``` java
Stacktrace: java.lang.NullPointerException: 
  Attempt to invoke virtual method 'int nerd.tuxmobil.fahrplan.congress.models.Meta.getNumDays()' 
  on a null object reference 
at nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService.onParseDone(UpdateService.java:46) 
at nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService.lambda$fetchFahrplan$1$UpdateService(UpdateService.java:109) 
at nerd.tuxmobil.fahrplan.congress.autoupdate.-$$Lambda$UpdateService$kZPd4_E39Ov2yhCTwHKMKeXuiPY.invoke(Unknown Source:4) 
at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository$parseSchedule$3.invoke(AppRepository.kt:151) 
at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository$parseSchedule$3.invoke(AppRepository.kt:31) 
at info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository$parseSchedule$1.onParseDone(ScheduleNetworkRepository.kt:31) 
at info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository$parseSchedule$1.onParseDone(ScheduleNetworkRepository.kt:28) 
at info.metadude.android.eventfahrplan.network.serialization.ParserTask.notifyActivity(FahrplanParser.java:102) 
at info.metadude.android.eventfahrplan.network.serialization.ParserTask.onPostExecute(FahrplanParser.java:111) 
at info.metadude.android.eventfahrplan.network.serialization.ParserTask.onPostExecute(FahrplanParser.java:60) 
at android.os.AsyncTask.finish(AsyncTask.java:755) 
at android.os.AsyncTask.access$900(AsyncTask.java:192) 
at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:772) 
at android.os.Handler.dispatchMessage(Handler.java:107) 
at android.os.Looper.loop(Looper.java:214) 
at android.app.ActivityThread.main(ActivityThread.java:7356) 
at java.lang.reflect.Method.invoke(Native Method) 
...
```

# Successfully tested on
with `ccc36c3`, debug build, triggering schedule updates every 30s
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)