### PR TITLE
Fix room column to be expanded to the same width as the room title column.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -285,12 +285,12 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
         int roomCount = scheduleData.getRoomCount();
         horizontalScroller.setRoomsCount(roomCount);
-        addRoomColumns(horizontalScroller, scheduleData, forceReload);
 
         HorizontalScrollView roomScroller = layoutRoot.findViewById(R.id.roomScroller);
         LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
         int columnWidth = horizontalScroller.getColumnWidth();
         addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.getRoomNames());
+        addRoomColumns(horizontalScroller, columnWidth, scheduleData, forceReload);
 
         MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
             scrollToCurrent(boxHeight);
@@ -316,6 +316,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
      */
     private void addRoomColumns(
             @NonNull HorizontalSnapScrollView horizontalScroller,
+            int columnWidth,
             @NonNull ScheduleData scheduleData,
             boolean forceReload
     ) {
@@ -349,7 +350,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
             columnRecyclerView.setFadingEdgeLength(0);
             columnRecyclerView.setNestedScrollingEnabled(false); // enables flinging
             columnRecyclerView.setLayoutManager(new LinearLayoutManager(context));
-            columnRecyclerView.setLayoutParams(new RecyclerView.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            columnRecyclerView.setLayoutParams(new RecyclerView.LayoutParams(columnWidth, ViewGroup.LayoutParams.WRAP_CONTENT));
             List<Session> roomSessions = roomData.getSessions();
             SessionViewColumnAdapter adapter = new SessionViewColumnAdapter(roomSessions, layoutParamsBySession, sessionViewDrawer, this);
             columnRecyclerView.setAdapter(adapter);


### PR DESCRIPTION
# Description
+ Room columns showed up either too narrow or too wide after selecting a different conference day. The calculated column width is now used both for the room title and each _RecyclerView_.
+ This also fixes a similar layout issue reported for the _Engelshifts_ room which can be enabled by users at runtime. See issue #285.
+ Related commit: 75da59ec6c65592af02a14f93cec6c00656731fe.

# Successfully tested on
with `ccc36c3`, `froscon2020`, debug builds, with _Engelsystem_ shifts
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)

---

Resolves #285.