### PR TITLE
Replace deprecated lock screen flag with new method as of Android 8.1 (Oreo).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.View
-import android.view.WindowManager
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import nerd.tuxmobil.fahrplan.congress.MyApp
@@ -13,6 +12,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
 
 class SessionDetailsActivity : BaseActivity() {
 
@@ -31,7 +31,7 @@ class SessionDetailsActivity : BaseActivity() {
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED)
+        showWhenLockedCompat()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -12,7 +12,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
@@ -68,6 +67,8 @@ import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog;
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 import okhttp3.OkHttpClient;
 
+import static nerd.tuxmobil.fahrplan.congress.utils.LockScreenHelper.showWhenLockedCompat;
+
 public class MainActivity extends BaseActivity implements
         OnSidePaneCloseListener,
         AbstractListFragment.OnSessionListClick,
@@ -92,7 +93,7 @@ public class MainActivity extends BaseActivity implements
     @Override
     public void onAttachedToWindow() {
         super.onAttachedToWindow();
-        getWindow().addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED);
+        showWhenLockedCompat(this);
     }
 
     @Override

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LockScreenHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LockScreenHelper.kt
@@ -1,0 +1,20 @@
+@file:JvmName("LockScreenHelper")
+
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import android.app.Activity
+import android.os.Build
+import android.view.WindowManager
+
+/**
+ * Enables this [Activity][this] to be shown on top of the lock screen whenever the lock screen
+ * is up and the [Activity] is resumed.
+ */
+fun Activity.showWhenLockedCompat() {
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+        setShowWhenLocked(true)
+    } else {
+        @Suppress("DEPRECATION")
+        window.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED)
+    }
+}


### PR DESCRIPTION
# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 5X emulator, Android 4.1.2 (API 16)