### PR TITLE
Update Androidx material components

### DIFF
--- a/app/src/main/res/layout/header_empty.xml
+++ b/app/src/main/res/layout/header_empty.xml
@@ -4,7 +4,7 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <androidx.legacy.widget.Space
+    <Space
         android:layout_width="match_parent"
         android:layout_height="@dimen/header_height"
         />

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -49,7 +49,7 @@ object Libs {
         const val okhttp = "3.12.12"
         const val retrofit = "2.6.4"
         const val robolectric = "4.3_r2-robolectric-0"
-        const val snackengage = "0.24"
+        const val snackengage = "0.26"
         const val testExtJunit = "1.1.1"
         const val threeTenBp = "1.4.4"
         const val tracedroid = "1.4"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -42,7 +42,7 @@ object Libs {
         const val espresso = "3.2.0"
         const val junit = "4.13"
         const val kotlinCoroutines = "1.3.8"
-        const val material = "1.0.0"
+        const val material = "1.2.0"
         const val mockito = "3.4.0"
         const val mockitoKotlin = "2.2.0"
         const val moshi = "1.9.3"


### PR DESCRIPTION
# Description
- Prevent crash caused by unavailable deprecated `Space` class.
  - The deprecated `androidx.legacy.widget.Space` class is part of `androidx.legacy:legacy-support-core-ui:1.0.0` which is a transitive dependency of `com.google.android.material:material:1.0.0`.
  - This crashes as soon as `com.google.android.material:material:1.1.x` or newer is used because then the class is missing.
- Use `material` v.1.2.0.
- Use `snackengage-playrate` v.0.26.


# Successfully tested on
with `ccc36c3`, `divoc2020` flavor, `release` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)