### PR TITLE
Enhance text link colors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,6 +154,7 @@ dependencies {
     implementation project(":engelsystem")
 
     implementation Libs.appCompat
+    implementation Libs.betterLinkMovementMethod
     implementation Libs.constraintLayout
     implementation Libs.coreKtx
     implementation Libs.emailIntentBuilder

--- a/app/src/ccc36c3/res/values/colors.xml
+++ b/app/src/ccc36c3/res/values/colors.xml
@@ -6,9 +6,7 @@
     <color name="colorAccent">#00bb31</color>
     <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#231f20</color>
-    <color name="text_link_color">@color/colorAccent</color>
     <color name="multi_choice_background">#fec700</color>
-    <color name="text_link_color_dark">@color/colorAccent</color>
     <color name="alarm_list_icon_default_fill_color">@android:color/transparent</color>
     <color name="alarm_list_icon_default_stroke_color">@color/colorAccent</color>
     <color name="alarm_list_icon_text_color">@color/colorAccent</color>

--- a/app/src/cccamp2019/res/values/colors.xml
+++ b/app/src/cccamp2019/res/values/colors.xml
@@ -6,9 +6,7 @@
     <color name="colorAccent">#d39a00</color>
     <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#1a1a1a</color>
-    <color name="text_link_color">@color/colorAccent</color>
     <color name="multi_choice_background">#ffc600</color>
-    <color name="text_link_color_dark">@color/colorAccent</color>
     <color name="alarm_list_icon_default_fill_color">@color/colorAccent</color>
     <color name="alarm_list_icon_default_stroke_color">#8FAD3C</color>
     <color name="alarm_list_icon_text_color">#000000</color>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="nerd.tuxmobil.fahrplan.congress">
+          package="nerd.tuxmobil.fahrplan.congress"
+          xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- Force minSdkVersion defined by this project, see LinkMovementMethodCompat. -->
+    <uses-sdk tools:overrideLibrary="me.saket.bettermovementmethod" />
 
     <application
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -97,7 +97,7 @@ public class AboutDialog extends DialogFragment {
         //noinspection ConstantConditions
         appDisclaimer.setVisibility(BuildConfig.SHOW_APP_DISCLAIMER ? View.VISIBLE : View.GONE);
 
-        int linkTextColor = ContextCompat.getColor(view.getContext(), R.color.text_link_color_dark);
+        int linkTextColor = ContextCompat.getColor(view.getContext(), R.color.text_link_on_dark);
         MovementMethod movementMethod = LinkMovementMethod.getInstance();
 
         TextView logoCopyright = view.findViewById(R.id.about_copyright_logo_view);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.about;
 
 import android.os.Bundle;
-import android.text.method.LinkMovementMethod;
 import android.text.method.MovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +15,7 @@ import androidx.fragment.app.DialogFragment;
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
+import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat;
 
 public class AboutDialog extends DialogFragment {
 
@@ -98,7 +98,7 @@ public class AboutDialog extends DialogFragment {
         appDisclaimer.setVisibility(BuildConfig.SHOW_APP_DISCLAIMER ? View.VISIBLE : View.GONE);
 
         int linkTextColor = ContextCompat.getColor(view.getContext(), R.color.text_link_on_dark);
-        MovementMethod movementMethod = LinkMovementMethod.getInstance();
+        MovementMethod movementMethod = LinkMovementMethodCompat.getInstance();
 
         TextView logoCopyright = view.findViewById(R.id.about_copyright_logo_view);
         logoCopyright.setText(Strings.toSpanned(getString(R.string.copyright_logo)));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -185,7 +185,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     private fun TextView.applyHtml(typeface: Typeface, text: String) {
         this.typeface = typeface
         this.setText(text.toSpanned(), TextView.BufferType.SPANNABLE)
-        this.setLinkTextColor(ContextCompat.getColor(context, R.color.text_link_color))
+        this.setLinkTextColor(ContextCompat.getColor(context, R.color.text_link_on_light))
         this.movementMethod = LinkMovementMethod()
         this.isVisible = true
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.graphics.Typeface
 import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
-import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -32,6 +31,7 @@ import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
+import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
 class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHandler {
@@ -186,7 +186,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
         this.typeface = typeface
         this.setText(text.toSpanned(), TextView.BufferType.SPANNABLE)
         this.setLinkTextColor(ContextCompat.getColor(context, R.color.text_link_on_light))
-        this.movementMethod = LinkMovementMethod()
+        this.movementMethod = LinkMovementMethodCompat.getInstance()
         this.isVisible = true
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LinkMovementMethodCompat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LinkMovementMethodCompat.kt
@@ -1,0 +1,23 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import android.os.Build
+import android.text.method.LinkMovementMethod
+import android.text.method.MovementMethod
+import me.saket.bettermovementmethod.BetterLinkMovementMethod
+
+object LinkMovementMethodCompat {
+
+    /**
+     * Returns an instance of [BetterLinkMovementMethod] on devices running
+     * Android 4.1.x Jelly Bean (API 16) or newer. [LinkMovementMethod] is
+     * returned for devices running an older Android version.
+     */
+    @JvmStatic
+    fun getInstance(): MovementMethod =
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+                LinkMovementMethod.getInstance()
+            } else {
+                BetterLinkMovementMethod.getInstance()
+            }
+
+}

--- a/app/src/main/res/drawable/separator_bottom_line.xml
+++ b/app/src/main/res/drawable/separator_bottom_line.xml
@@ -3,6 +3,6 @@
     android:shape="line">
     <stroke
         android:width="1dp"
-        android:color="@color/text_link_color"/>
+        android:color="@color/text_link_on_light"/>
     <size android:height="3dp"/>
 </shape>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -86,7 +86,7 @@
     <string name="usage">Hinweis:\n\nLange auf Vortrag tippen, um einen Alarm einzustellen.</string>
     <string name="libraries">
 		Die Anwendung nutzt folgende Bibliotheken:
-		Kotlin, Google Support Library, Email Intent Builder,
+		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
     <string name="about_data_privacy_statement">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -55,7 +55,7 @@
     <string name="session_list_item_no_video_content_description">Sin grabación de vídeo</string>
     <string name="session_list_item_video_content_description">Con grabación de vídeo</string>
     <string name="session_list_item_without_video_content_description">Sin grabación de vídeo</string>
-    <string name="libraries">Esta aplicación utiliza las siguientes bibliotecas: Kotlin, Google Support Library, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
+    <string name="libraries">Esta aplicación utiliza las siguientes bibliotecas: Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
     <string name="menu_item_title_about">Información</string>
     <string name="menu_item_title_add_to_calendar">Agregar al calendario</string>
     <string name="menu_item_title_alarms">Alarmas</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -105,7 +105,7 @@
     <string name="alternative_highlight">Mise en évidence alternative</string>
     <string name="add_to_calendar_failed">L’ajout de l’évènement au calendrier a échoué.</string>
     <string name="alarms_empty">Il n’y a aucun rappel à afficher. Veuillez noter que vous pouvez définir des rappels individuels pour chaque élément dans le programme. Appuyez simplement sur l’icône du rappel dans la barre d’action.</string>
-    <string name="libraries">Cette application utilise les librairies suivantes : Kotlin, Google Support Library, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
+    <string name="libraries">Cette application utilise les librairies suivantes : Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
     <string name="usage">Note :
 \n
 \nAppuyez longuement sur une conférence pour définir un rappel.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -56,7 +56,7 @@
     <string name="session_list_item_no_video_content_description">Senza registrazione video</string>
     <string name="session_list_item_video_content_description">Con registrazione video</string>
     <string name="session_list_item_without_video_content_description">Senza registrazione video</string>
-    <string name="libraries">Questa applicazione usa le librerie seguenti: Kotlin, Google Support Library, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
+    <string name="libraries">Questa applicazione usa le librerie seguenti: Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid</string>
     <string name="load_data">Caricare</string>
     <string name="menu_item_title_about">Info</string>
     <string name="menu_item_title_add_to_calendar">Aggiungere al calendario</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -82,7 +82,7 @@
     <string name="usage">Tip:\n\nLang indrukken op een evenement om een alarm aan te zetten.</string>
     <string name="libraries">
 		Deze applicatie gebruikt de volgende software-bibliotheken:
-		Kotlin, Google Support Library, Email Intent Builder,
+		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
     <string name="about_data_privacy_statement">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -83,7 +83,7 @@
     <string name="usage">Dica:\n\nMantenha pressionado na palestra para ajustar um alerta.</string>
     <string name="libraries">
 		Este aplicativo usa as seguintes bibliotecas:
-		Kotlin, Google Support Library, Email Intent Builder,
+		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Espresso, OkHttp, SnackEngage e TraceDroid
 	</string>
     <string name="about_data_privacy_statement">

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -87,7 +87,7 @@
     <string name="usage">Примечание:\n\nДолгое нажатие на лекцию установит напоминание.</string>
     <string name="libraries">
         Это приложение использует следующие библиотеки:
-        Kotlin, Google Support Library, Email Intent Builder,
+        Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
         Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
     </string>
     <string name="about_data_privacy_statement">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,8 @@
     <color name="popupBackground">@color/colorPrimaryDark</color>
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
+    <color name="text_link_pressed_background_on_light">#aafec700</color>
+    <color name="text_link_pressed_background_on_dark">#33fec700</color>
     <color name="alarm_list_icon_default_fill_color">#ddd</color>
     <color name="alarm_list_icon_default_stroke_color">#003339</color>
     <color name="alarm_list_icon_text_color">#000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,8 +3,8 @@
 
     <color name="windowBackground">#003339</color>
     <color name="popupBackground">@color/colorPrimaryDark</color>
-    <color name="text_link_color">@color/colorAccent</color>
-    <color name="text_link_color_dark">@color/colorAccent</color>
+    <color name="text_link_on_light">@color/colorAccent</color>
+    <color name="text_link_on_dark">@color/colorAccent</color>
     <color name="alarm_list_icon_default_fill_color">#ddd</color>
     <color name="alarm_list_icon_default_stroke_color">#003339</color>
     <color name="alarm_list_icon_text_color">#000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,7 +3,8 @@
 
     <color name="windowBackground">#003339</color>
     <color name="popupBackground">@color/colorPrimaryDark</color>
-    <color name="text_link_color">#33b5e5</color>
+    <color name="text_link_color">@color/colorAccent</color>
+    <color name="text_link_color_dark">@color/colorAccent</color>
     <color name="alarm_list_icon_default_fill_color">#ddd</color>
     <color name="alarm_list_icon_default_stroke_color">#003339</color>
     <color name="alarm_list_icon_text_color">#000000</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,7 +93,7 @@
     <string name="usage">Note:\n\nLong-press on a lecture to set an alarm.</string>
     <string name="libraries">
 		This application uses the following libraries:
-		Kotlin, Google Support Library, Email Intent Builder,
+		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
     <string name="about_data_privacy_statement">

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -130,7 +130,7 @@
 
     <style name="ScheduleListSeparator" parent="@android:style/TextAppearance.Small">
         <item name="android:textStyle">bold</item>
-        <item name="android:textColor">@color/text_link_color</item>
+        <item name="android:textColor">@color/text_link_on_light</item>
         <item name="android:textAllCaps">true</item>
     </style>
 
@@ -143,7 +143,7 @@
     </style>
 
     <style name="TextViewLinks">
-        <item name="android:textColorLink">@color/text_link_color</item>
+        <item name="android:textColorLink">@color/text_link_on_light</item>
     </style>
 
     <!-- Session details -->

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -29,6 +29,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <!-- The rest of your attributes -->
+        <item name="android:textColorHighlight">@color/text_link_pressed_background_on_light</item>
         <item name="actionOverflowMenuStyle">@style/PopupMenuOverflowStyle</item>
         <item name="android:contextPopupMenuStyle" tools:targetApi="N">@style/ContextPopupMenuStyle</item>
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
@@ -49,6 +50,7 @@
         <item name="colorAccent">@color/colorAccent</item>
 
         <!-- The rest of your attributes -->
+        <item name="android:textColorHighlight">@color/text_link_pressed_background_on_light</item>
         <item name="actionOverflowMenuStyle">@style/PopupMenuOverflowStyle</item>
         <item name="android:contextPopupMenuStyle" tools:targetApi="N">@style/ContextPopupMenuStyle</item>
         <item name="android:spinnerItemStyle">@style/SpinnerItemStyle</item>
@@ -71,6 +73,7 @@
 
     <style name="Dialog" parent="Theme.AppCompat.Dialog">
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
+        <item name="android:textColorHighlight">@color/text_link_pressed_background_on_dark</item>
         <item name="android:windowBackground">@color/windowBackground</item>
     </style>
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -35,6 +35,7 @@ object Libs {
         const val annotation = "1.1.0"
         const val appCompat = "1.2.0"
         const val assertjAndroid = "1.2.0"
+        const val betterLinkMovementMethod = "2.2.0" // minSdkVersion 16, see AndroidManifest
         const val constraintLayout = "1.1.3"
         const val coreKtx = "1.3.1"
         const val emailIntentBuilder = "2.0.0"
@@ -59,6 +60,7 @@ object Libs {
     const val annotation = "androidx.annotation:annotation:${Versions.annotation}"
     const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompat}"
     const val assertjAndroid = "com.squareup.assertj:assertj-android:${Versions.assertjAndroid}"
+    const val betterLinkMovementMethod = "me.saket:better-link-movement-method:${Versions.betterLinkMovementMethod}"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:${Versions.constraintLayout}"
     const val coreKtx = "androidx.core:core-ktx:${Versions.coreKtx}"
     const val emailIntentBuilder = "de.cketti.mailto:email-intent-builder:${Versions.emailIntentBuilder}"


### PR DESCRIPTION
# Description
- Avoid unnecessary text link color overwrites in flavors.
- Improve naming for text link color resources.
- Enhance visual touch feedback of links in details and about screens.
  - Use [`better-link-movement-method:2.2.0`](https://github.com/saket/Better-Link-Movement-Method) on devices running Android 4.1.x or newer. On devices running an older Android version links are not enhanced.
  - Add _BetterLinkMovementMethod_ to libraries on "About" screen.
- Affected screens:
  - Details
  - About

# Successfully tested on
with `ccc36c3` and `camp2019` flavors, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 5X emulator, Android 4.1.2 (API 16)

# Before
- Links without visual touch feedback.
![36c3-details-before](https://user-images.githubusercontent.com/144518/90549471-df871900-e18e-11ea-9500-b1a7b59db4cb.png)
![36c3-about-before](https://user-images.githubusercontent.com/144518/90549485-e3b33680-e18e-11ea-9135-5a0ccf62d807.png)
![camp-details-before](https://user-images.githubusercontent.com/144518/90549507-e9a91780-e18e-11ea-9e93-f611ceafe52b.png)
![camp-about-before](https://user-images.githubusercontent.com/144518/90549517-eca40800-e18e-11ea-8d93-a93beae626fc.png)

# After
- Links with visual touch feedback.
![36c3-details-after](https://user-images.githubusercontent.com/144518/90549549-f463ac80-e18e-11ea-80bd-2dea01ef199d.png)
![36c3-about-after](https://user-images.githubusercontent.com/144518/90549558-f6c60680-e18e-11ea-83e0-6c16c1d4d336.png)
![camp-details-after](https://user-images.githubusercontent.com/144518/90549567-f9c0f700-e18e-11ea-9e6c-fe098223e24a.png)
![camp-about-after](https://user-images.githubusercontent.com/144518/90549578-fc235100-e18e-11ea-9270-96770a9e011b.png)