### PR TITLE
Avoid using Intent.resolveActivity()

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
@@ -4,6 +4,7 @@ package nerd.tuxmobil.fahrplan.congress.extensions
 
 import android.app.AlarmManager
 import android.app.NotificationManager
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.view.LayoutInflater
@@ -16,9 +17,9 @@ fun Context.getLayoutInflater() = getSystemService<LayoutInflater>()!!
 fun Context.getNotificationManager() = getSystemService<NotificationManager>()!!
 
 fun Context.startActivity(intent: Intent, onActivityNotFound: () -> Unit) {
-    if (intent.resolveActivity(packageManager) == null) {
-        onActivityNotFound.invoke()
-    } else {
+    try {
         startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        onActivityNotFound.invoke()
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/reporting/TraceDroidEmailSender.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/reporting/TraceDroidEmailSender.java
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.reporting;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.widget.Toast;
 
@@ -36,8 +37,6 @@ public abstract class TraceDroidEmailSender {
                 R.string.trace_droid_button_title_later);
         final String buttonTitleNo = context.getString(
                 R.string.trace_droid_button_title_no);
-        final String sendMail = context.getString(
-                R.string.trace_droid_app_chooser_title);
         final int maximumStackTracesCount = context.getResources().getInteger(
                 R.integer.config_trace_droid_maximum_stack_traces_count);
 
@@ -47,10 +46,10 @@ public abstract class TraceDroidEmailSender {
                 .setPositiveButton(buttonTitleSend, (dialog, whichButton) -> {
                     Intent emailIntent = getEmailIntent(
                             context, emailAddress, maximumStackTracesCount);
-                    if (emailIntent.resolveActivity(context.getPackageManager()) != null) {
-                        context.startActivity(Intent.createChooser(emailIntent, sendMail));
+                    try {
+                        context.startActivity(emailIntent);
                         TraceDroid.deleteStacktraceFiles();
-                    } else {
+                    } catch (ActivityNotFoundException e) {
                         String message = context.getString(R.string.trace_droid_no_email_app);
                         Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
                     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -166,9 +166,6 @@
     <string name="trace_droid_button_title_later">
         Später
     </string>
-    <string name="trace_droid_app_chooser_title">
-        Entwurf öffnen mit &#8230;
-    </string>
 
     <!-- Notifications -->
     <string name="notifications_session_alarm_channel_description">

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,7 +99,6 @@
     <string name="snack_engage_rate_title">Todo bien?</string>
     <string name="starred_sessions">Favoritos</string>
     <string name="today">Hoy</string>
-    <string name="trace_droid_app_chooser_title">Abrir borrador con &#8230;</string>
     <string name="trace_droid_button_title_later">Quizás más tarde</string>
     <string name="trace_droid_button_title_no">No</string>
     <string name="trace_droid_button_title_send">Abrir e-mail</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -47,7 +47,6 @@
     <string name="alarm_time_title_5_minutes_before">5 minutes avant</string>
     <string name="notifications_session_alarm_content_text">Rappel pour un événement</string>
     <string name="notifications_session_alarm_channel_name">Rappels pour les événements</string>
-    <string name="trace_droid_app_chooser_title">Ouvrir le brouillon avec …</string>
     <string name="trace_droid_button_title_later">Peut-être plus tard</string>
     <string name="trace_droid_button_title_no">Non</string>
     <string name="trace_droid_no_email_app">Aucune application de messagerie compatible n’est installée.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -101,7 +101,6 @@
     <string name="snack_engage_rate_title">Tutto a posto?</string>
     <string name="starred_sessions">Preferiti</string>
     <string name="today">oggi</string>
-    <string name="trace_droid_app_chooser_title">Aprire la bozza con &#8230;</string>
     <string name="trace_droid_button_title_later">Forse più tardi</string>
     <string name="trace_droid_button_title_no">No</string>
     <string name="trace_droid_button_title_send">Aprire le email</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -158,9 +158,6 @@
     <string name="trace_droid_button_title_later">
         Later
     </string>
-    <string name="trace_droid_app_chooser_title">
-        Concept openen met &#8230;
-    </string>
 
     <!-- Notifications -->
     <string name="notifications_session_alarm_channel_description">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -159,9 +159,6 @@
     <string name="trace_droid_button_title_later">
         Talvez mais tarde
     </string>
-    <string name="trace_droid_app_chooser_title">
-        Abrir rascunho com &#8230;
-    </string>
 
     <!-- Notifications -->
     <string name="notifications_session_alarm_channel_description">

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -163,9 +163,6 @@
     <string name="trace_droid_button_title_later">
         Позже
     </string>
-    <string name="trace_droid_app_chooser_title">
-        Открытый черновик с &#8230;
-    </string>
 
     <!-- Notifications -->
     <string name="notifications_session_alarm_channel_description">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -183,9 +183,6 @@
     <string name="trace_droid_button_title_later">
         Maybe later
     </string>
-    <string name="trace_droid_app_chooser_title">
-        Open draft with &#8230;
-    </string>
 
     <!-- Notifications -->
     <string name="notifications_session_alarm_channel_description">


### PR DESCRIPTION
Prepare code for `targetSdkVersion 30` (Android 11) by avoiding calls to `Intent.resolveActivity()`. See https://cketti.de/2020/09/03/avoid-intent-resolveactivity/

The remaining call to `resolveActivity()` is removed by PR #309.