### PR TITLE
Retrieve non-null views where possible

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -17,6 +17,8 @@ import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 public class AboutDialog extends DialogFragment {
 
     private static final String BUNDLE_KEY_SCHEDULE_VERSION =
@@ -71,7 +73,7 @@ public class AboutDialog extends DialogFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        TextView text = view.findViewById(R.id.about_session_version_view);
+        TextView text = requireViewByIdCompat(view, R.id.about_session_version_view);
         if (scheduleVersionText.isEmpty()) {
             text.setVisibility(View.GONE);
         } else {
@@ -79,68 +81,68 @@ public class AboutDialog extends DialogFragment {
             String prefixedScheduleVersionText = getString(R.string.fahrplan) + " " + scheduleVersionText;
             text.setText(prefixedScheduleVersionText);
         }
-        text = view.findViewById(R.id.about_session_title_view);
+        text = requireViewByIdCompat(view, R.id.about_session_title_view);
         if (titleText.isEmpty()) {
             titleText = getString(R.string.app_name);
         }
         text.setText(titleText);
-        text = view.findViewById(R.id.about_session_subtitle_view);
+        text = requireViewByIdCompat(view, R.id.about_session_subtitle_view);
         if (subtitleText.isEmpty()) {
             subtitleText = getString(R.string.app_hardcoded_subtitle);
         }
         text.setText(subtitleText);
-        text = view.findViewById(R.id.about_app_version_view);
+        text = requireViewByIdCompat(view, R.id.about_app_version_view);
         String appVersionText = getString(R.string.appVersion, BuildConfig.VERSION_NAME);
         text.setText(appVersionText);
 
-        View appDisclaimer = view.findViewById(R.id.about_app_disclaimer_view);
+        View appDisclaimer = requireViewByIdCompat(view, R.id.about_app_disclaimer_view);
         //noinspection ConstantConditions
         appDisclaimer.setVisibility(BuildConfig.SHOW_APP_DISCLAIMER ? View.VISIBLE : View.GONE);
 
         int linkTextColor = ContextCompat.getColor(view.getContext(), R.color.text_link_on_dark);
         MovementMethod movementMethod = LinkMovementMethodCompat.getInstance();
 
-        TextView logoCopyright = view.findViewById(R.id.about_copyright_logo_view);
+        TextView logoCopyright = requireViewByIdCompat(view, R.id.about_copyright_logo_view);
         logoCopyright.setText(Strings.toSpanned(getString(R.string.copyright_logo)));
         logoCopyright.setLinkTextColor(linkTextColor);
         logoCopyright.setMovementMethod(movementMethod);
 
-        TextView conferenceUrl = view.findViewById(R.id.about_conference_url_view);
+        TextView conferenceUrl = requireViewByIdCompat(view, R.id.about_conference_url_view);
         conferenceUrl.setText(Strings.toSpanned(getString(R.string.conference_url)));
         conferenceUrl.setMovementMethod(movementMethod);
         conferenceUrl.setLinkTextColor(linkTextColor);
 
-        TextView sourceCode = view.findViewById(R.id.about_source_code_view);
+        TextView sourceCode = requireViewByIdCompat(view, R.id.about_source_code_view);
         sourceCode.setText(Strings.toSpanned(getString(R.string.source_code)));
         sourceCode.setMovementMethod(movementMethod);
         sourceCode.setLinkTextColor(linkTextColor);
 
-        TextView issues = view.findViewById(R.id.about_issues_view);
+        TextView issues = requireViewByIdCompat(view, R.id.about_issues_view);
         issues.setText(Strings.toSpanned(getString(R.string.issues)));
         issues.setMovementMethod(movementMethod);
         issues.setLinkTextColor(linkTextColor);
 
-        TextView googlePlayStore = view.findViewById(R.id.about_google_play_view);
+        TextView googlePlayStore = requireViewByIdCompat(view, R.id.about_google_play_view);
         googlePlayStore.setText(Strings.toSpanned(getString(R.string.google_play_store)));
         googlePlayStore.setMovementMethod(movementMethod);
         googlePlayStore.setLinkTextColor(linkTextColor);
 
-        TextView dataPrivacyStatement = view.findViewById(R.id.about_data_privacy_statement_view);
+        TextView dataPrivacyStatement = requireViewByIdCompat(view, R.id.about_data_privacy_statement_view);
         dataPrivacyStatement.setText(Strings.toSpanned(getString(R.string.about_data_privacy_statement)));
         dataPrivacyStatement.setMovementMethod(movementMethod);
         dataPrivacyStatement.setLinkTextColor(linkTextColor);
 
         // Build information
 
-        TextView buildTimeTextView = view.findViewById(R.id.build_time);
+        TextView buildTimeTextView = requireViewByIdCompat(view, R.id.build_time);
         String buildTimeText = getString(R.string.build_info_time, BuildConfig.BUILD_TIME);
         buildTimeTextView.setText(buildTimeText);
 
-        TextView versionCodeTextView = view.findViewById(R.id.build_version_code);
+        TextView versionCodeTextView = requireViewByIdCompat(view, R.id.build_version_code);
         String versionCodeText = getString(R.string.build_info_version_code, "" + BuildConfig.VERSION_CODE);
         versionCodeTextView.setText(versionCodeText);
 
-        TextView buildHashTextView = view.findViewById(R.id.build_hash);
+        TextView buildHashTextView = requireViewByIdCompat(view, R.id.build_hash);
         String buildHashText = getString(R.string.build_info_hash, BuildConfig.GIT_SHA);
         buildHashTextView.setText(buildHashText);
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmCursorAdapter.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmCursorAdapter.java
@@ -13,6 +13,8 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Al
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns;
 import nerd.tuxmobil.fahrplan.congress.R;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 public class AlarmCursorAdapter extends CursorAdapter {
 
     protected final LayoutInflater mInflater;
@@ -27,9 +29,9 @@ public class AlarmCursorAdapter extends CursorAdapter {
         ViewHolder holder = (ViewHolder) view.getTag();
         if (holder == null) {
             holder = new ViewHolder();
-            holder.alarmTimeInMin = view.findViewById(R.id.alarm_badge);
-            holder.title = view.findViewById(R.id.alarm_title);
-            holder.time = view.findViewById(R.id.alarm_start_time);
+            holder.alarmTimeInMin = requireViewByIdCompat(view, R.id.alarm_badge);
+            holder.title = requireViewByIdCompat(view, R.id.alarm_title);
+            holder.time = requireViewByIdCompat(view, R.id.alarm_start_time);
             view.setTag(holder);
         }
         int alarmTimeInMin = cursor.getInt(cursor.getColumnIndex(Columns.ALARM_TIME_IN_MIN));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java
@@ -23,6 +23,8 @@ import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 public class AlarmTimePickerFragment extends DialogFragment {
 
     private static final String FRAGMENT_TAG =
@@ -68,7 +70,7 @@ public class AlarmTimePickerFragment extends DialogFragment {
     }
 
     private void initializeSpinner(@NonNull View rootView) {
-        spinner = rootView.findViewById(R.id.spinner);
+        spinner = requireViewByIdCompat(rootView, R.id.spinner);
         ArrayAdapter<CharSequence> adapter = ArrayAdapter.createFromResource(
                 rootView.getContext(),
                 R.array.preference_entries_alarm_time_titles,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.base;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
+import android.view.View;
 
 import androidx.annotation.ContentView;
 import androidx.annotation.IdRes;
@@ -10,6 +11,7 @@ import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
@@ -110,6 +112,14 @@ public abstract class BaseActivity extends AppCompatActivity {
     @Nullable
     Fragment findFragment(@NonNull String fragmentTag) {
         return getSupportFragmentManager().findFragmentByTag(fragmentTag);
+    }
+
+    /**
+     * See {@link ActivityCompat#requireViewById}.
+     */
+    @NonNull
+    protected <T extends View> T requireViewByIdCompat(@IdRes int id) {
+        return ActivityCompat.requireViewById(this, id);
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
@@ -22,6 +22,8 @@ import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.Session;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 public abstract class SessionsAdapter extends ArrayAdapter<Session> {
 
     private static final int TYPE_ITEM = 0;
@@ -65,23 +67,23 @@ public abstract class SessionsAdapter extends ArrayAdapter<Session> {
                     rowView = localInflater.inflate(R.layout.session_list_item, parent, false);
                     viewHolder = new ViewHolder();
 
-                    viewHolder.title = rowView.findViewById(R.id.session_list_item_title_view);
-                    viewHolder.subtitle = rowView.findViewById(R.id.session_list_item_subtitle_view);
-                    viewHolder.speakers = rowView.findViewById(R.id.session_list_item_speakers_view);
-                    viewHolder.lang = rowView.findViewById(R.id.session_list_item_language_view);
-                    viewHolder.day = rowView.findViewById(R.id.session_list_item_day_view);
-                    viewHolder.time = rowView.findViewById(R.id.session_list_item_time_view);
-                    viewHolder.room = rowView.findViewById(R.id.session_list_item_room_view);
-                    viewHolder.duration = rowView.findViewById(R.id.session_list_item_duration_view);
-                    viewHolder.video = rowView.findViewById(R.id.session_list_item_video_view);
-                    viewHolder.noVideo = rowView.findViewById(R.id.session_list_item_no_video_view);
-                    viewHolder.withoutVideoRecording = rowView.findViewById(R.id.session_list_item_without_video_recording_view);
+                    viewHolder.title = requireViewByIdCompat(rowView, R.id.session_list_item_title_view);
+                    viewHolder.subtitle = requireViewByIdCompat(rowView, R.id.session_list_item_subtitle_view);
+                    viewHolder.speakers = requireViewByIdCompat(rowView, R.id.session_list_item_speakers_view);
+                    viewHolder.lang = requireViewByIdCompat(rowView, R.id.session_list_item_language_view);
+                    viewHolder.day = requireViewByIdCompat(rowView, R.id.session_list_item_day_view);
+                    viewHolder.time = requireViewByIdCompat(rowView, R.id.session_list_item_time_view);
+                    viewHolder.room = requireViewByIdCompat(rowView, R.id.session_list_item_room_view);
+                    viewHolder.duration = requireViewByIdCompat(rowView, R.id.session_list_item_duration_view);
+                    viewHolder.video = requireViewByIdCompat(rowView, R.id.session_list_item_video_view);
+                    viewHolder.noVideo = requireViewByIdCompat(rowView, R.id.session_list_item_no_video_view);
+                    viewHolder.withoutVideoRecording = requireViewByIdCompat(rowView, R.id.session_list_item_without_video_recording_view);
                     rowView.setTag(viewHolder);
                     break;
                 case TYPE_SEPARATOR:
                     rowView = localInflater.inflate(R.layout.session_list_separator, parent, false);
                     viewHolderSeparator = new ViewHolderSeparator();
-                    viewHolderSeparator.text = rowView.findViewById(R.id.session_list_separator_title_view);
+                    viewHolderSeparator.text = requireViewByIdCompat(rowView, R.id.session_list_separator_title_view);
                     rowView.setTag(viewHolderSeparator);
                     break;
                 default:

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.java
@@ -24,7 +24,7 @@ public class ChangeListActivity extends BaseActivity implements
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_list);
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        Toolbar toolbar = requireViewByIdCompat(R.id.toolbar);
         setSupportActionBar(toolbar);
         int actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(actionBarColor));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -21,6 +21,8 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.models.Meta;
 import nerd.tuxmobil.fahrplan.congress.models.Session;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 
 /**
  * A fragment representing a list of Items.
@@ -96,11 +98,11 @@ public class ChangeListFragment extends AbstractListFragment {
         View header;
         if (sidePane) {
             view = localInflater.inflate(R.layout.fragment_session_list_narrow, container, false);
-            mListView = view.findViewById(android.R.id.list);
+            mListView = requireViewByIdCompat(view, android.R.id.list);
             header = localInflater.inflate(R.layout.changes_header, null, false);
         } else {
             view = localInflater.inflate(R.layout.fragment_session_list, container, false);
-            mListView = view.findViewById(android.R.id.list);
+            mListView = requireViewByIdCompat(view, android.R.id.list);
             header = localInflater.inflate(R.layout.header_empty, null, false);
         }
         mListView.addHeaderView(header, null, false);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
@@ -22,6 +22,8 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 public class ChangesDialog extends DialogFragment {
 
     public static final String FRAGMENT_TAG = "changesDialog";
@@ -71,7 +73,7 @@ public class ChangesDialog extends DialogFragment {
 
         LayoutInflater inflater = activity.getLayoutInflater();
         View msgView = inflater.inflate(R.layout.changes_dialog, null);
-        TextView changes1 = msgView.findViewById(R.id.schedule_changes_dialog_updated_to_text_view);
+        TextView changes1 = requireViewByIdCompat(msgView, R.id.schedule_changes_dialog_updated_to_text_view);
         SpannableStringBuilder span = new SpannableStringBuilder();
         span.append(getString(R.string.schedule_changes_dialog_updated_to_text));
         int spanStart = span.length();
@@ -86,7 +88,7 @@ public class ChangesDialog extends DialogFragment {
                 resources.getQuantityString(R.plurals.schedule_changes_dialog_being, cancelled, cancelled)));
         changes1.setText(span);
 
-        TextView changes2 = msgView.findViewById(R.id.schedule_changes_dialog_changes_text_view);
+        TextView changes2 = requireViewByIdCompat(msgView, R.id.schedule_changes_dialog_changes_text_view);
         changes2.setText(getString(R.string.schedule_changes_dialog_affected_text, markedAffected));
         builder.setView(msgView);
         return builder.create();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -25,6 +25,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
 import nerd.tuxmobil.fahrplan.congress.calendar.addToCalendar
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
@@ -87,21 +88,21 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             val typefaceFactory = TypefaceFactory.getNewInstance(activity)
 
             // Detailbar
-            var textView: TextView = view.findViewById(R.id.session_detailbar_date_time_view)
+            var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
             textView.text = if (viewModel.hasDateUtc) viewModel.formattedDateUtc else ""
 
-            textView = view.findViewById(R.id.session_detailbar_location_view)
+            textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
             textView.text = viewModel.roomName
-            textView = view.findViewById(R.id.session_detailbar_session_id_view)
+            textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
             textView.text = if (viewModel.isSessionIdEmpty) "" else getString(R.string.session_details_session_id, viewModel.sessionId)
 
             // Title
-            textView = view.findViewById(R.id.session_details_content_title_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_title_view)
             var typeface = typefaceFactory.getTypeface(viewModel.titleFont)
             textView.applyText(typeface, viewModel.title)
 
             // Subtitle
-            textView = view.findViewById(R.id.session_details_content_subtitle_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_subtitle_view)
             if (viewModel.isSubtitleEmpty) {
                 textView.isVisible = false
             } else {
@@ -110,7 +111,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             }
 
             // Speakers
-            textView = view.findViewById(R.id.session_details_content_speakers_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_speakers_view)
             if (viewModel.isSpeakersEmpty) {
                 textView.isVisible = false
             } else {
@@ -119,7 +120,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             }
 
             // Abstract
-            textView = view.findViewById(R.id.session_details_content_abstract_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_abstract_view)
             if (viewModel.isAbstractEmpty) {
                 textView.isVisible = false
             } else {
@@ -128,7 +129,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             }
 
             // Description
-            textView = view.findViewById(R.id.session_details_content_description_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_description_view)
             if (viewModel.isDescriptionEmpty) {
                 textView.isVisible = false
             } else {
@@ -137,8 +138,8 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             }
 
             // Links
-            val linksView = view.findViewById<TextView>(R.id.session_details_content_links_section_view)
-            textView = view.findViewById(R.id.session_details_content_links_view)
+            val linksView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_links_section_view)
+            textView = view.requireViewByIdCompat(R.id.session_details_content_links_view)
             if (viewModel.isLinksEmpty) {
                 linksView.isVisible = false
                 textView.isVisible = false
@@ -152,10 +153,10 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             }
 
             // Session online
-            val sessionOnlineSectionView = view.findViewById<TextView>(R.id.session_details_content_session_online_section_view)
+            val sessionOnlineSectionView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_section_view)
             typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineSectionFont)
             sessionOnlineSectionView.typeface = typeface
-            val sessionOnlineLinkView = view.findViewById<TextView>(R.id.session_details_content_session_online_view)
+            val sessionOnlineLinkView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_view)
             if (viewModel.hasWikiLinks) {
                 sessionOnlineSectionView.isVisible = false
                 sessionOnlineLinkView.isVisible = false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
@@ -1,0 +1,13 @@
+@file:JvmName("ViewExtensions")
+
+package nerd.tuxmobil.fahrplan.congress.extensions
+
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.core.view.ViewCompat
+
+/**
+ * See [ViewCompat.requireViewById].
+ */
+fun <T : View> View.requireViewByIdCompat(@IdRes id: Int): T =
+        ViewCompat.requireViewById(this, id)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.java
@@ -27,7 +27,7 @@ public class StarredListActivity extends BaseActivity implements
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_change_list);
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        Toolbar toolbar = requireViewByIdCompat(R.id.toolbar);
         setSupportActionBar(toolbar);
         int actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(actionBarColor));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -38,6 +38,8 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat;
 import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper;
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog;
 
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
+
 
 /**
  * A fragment representing a list of Items.
@@ -110,11 +112,11 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
         View header;
         if (sidePane) {
             view = localInflater.inflate(R.layout.fragment_favorites_list_narrow, container, false);
-            mListView = view.findViewById(android.R.id.list);
+            mListView = requireViewByIdCompat(view, android.R.id.list);
             header = localInflater.inflate(R.layout.starred_header, null, false);
         } else {
             view = localInflater.inflate(R.layout.fragment_favorites_list, container, false);
-            mListView = view.findViewById(android.R.id.list);
+            mListView = requireViewByIdCompat(view, android.R.id.list);
             header = localInflater.inflate(R.layout.header_empty, null, false);
         }
         mListView.addHeaderView(header, null, false);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navSnack.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navSnack.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.TextView
 import com.google.android.material.snackbar.Snackbar
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import org.ligi.snackengage.SnackContext
 import org.ligi.snackengage.conditions.AfterNumberOfOpportunities
 import org.ligi.snackengage.conditions.NeverAgainWhenClickedOnce
@@ -30,7 +31,7 @@ class C3navSnack(private val context: Context) : OpenURLSnack(
 
     override fun createSnackBar(snackContext: SnackContext): Snackbar {
         val snackBar = super.createSnackBar(snackContext)
-        val textView = snackBar.view.findViewById<TextView>(com.google.android.material.R.id.snackbar_text)
+        val textView = snackBar.view.requireViewByIdCompat<TextView>(com.google.android.material.R.id.snackbar_text)
         textView.setCompoundDrawablesWithIntrinsicBounds(R.mipmap.c3nav, 0, 0, 0)
         val pixelOffset = context.resources.getDimensionPixelOffset(R.dimen.snack_engage_c3nav_pixel_offset)
         textView.compoundDrawablePadding = pixelOffset

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -69,6 +69,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc;
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory;
 
 import static nerd.tuxmobil.fahrplan.congress.extensions.Resource.getNormalizedBoxHeight;
+import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
 
 public class FahrplanFragment extends Fragment implements SessionViewEventsHandler {
 
@@ -174,16 +175,10 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
         Context context = view.getContext();
         scale = getResources().getDisplayMetrics().density;
-        HorizontalScrollView roomScroller =
-                view.findViewById(R.id.roomScroller);
-        if (roomScroller != null) {
-            HorizontalSnapScrollView snapScroller =
-                    view.findViewById(R.id.horizScroller);
-            if (snapScroller != null) {
-                snapScroller.setChildScroller(roomScroller);
-            }
-            roomScroller.setOnTouchListener((v, session) -> true);
-        }
+        HorizontalScrollView roomScroller = requireViewByIdCompat(view, R.id.roomScroller);
+        HorizontalSnapScrollView snapScroller = requireViewByIdCompat(view, R.id.horizScroller);
+        snapScroller.setChildScroller(roomScroller);
+        roomScroller.setOnTouchListener((v, session) -> true);
 
         mDay = appRepository.readDisplayDayIndex();
 
@@ -275,7 +270,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         View layoutRoot = getView();
         int boxHeight = getNormalizedBoxHeight(getResources(), scale, LOG_TAG);
 
-        HorizontalSnapScrollView horizontalScroller = layoutRoot.findViewById(R.id.horizScroller);
+        HorizontalSnapScrollView horizontalScroller = requireViewByIdCompat(layoutRoot, R.id.horizScroller);
         horizontalScroller.scrollTo(0, 0);
 
         loadSessions(appRepository, mDay, forceReload);
@@ -290,7 +285,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         int roomCount = scheduleData.getRoomCount();
         horizontalScroller.setRoomsCount(roomCount);
 
-        HorizontalScrollView roomScroller = layoutRoot.findViewById(R.id.roomScroller);
+        HorizontalScrollView roomScroller = requireViewByIdCompat(layoutRoot, R.id.roomScroller);
         LinearLayout roomTitlesRowLayout = (LinearLayout) roomScroller.getChildAt(0);
         int columnWidth = horizontalScroller.getColumnWidth();
         addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.getRoomNames());
@@ -463,7 +458,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         // Log.d(LOG_TAG, "scrolltoCurrent to " + scrollAmount);
 
         final int pos = scrollAmount;
-        final ScrollView scrollView = getView().findViewById(R.id.scrollView1);
+        final ScrollView scrollView = requireViewByIdCompat(getView(), R.id.scrollView1);
         scrollView.scrollTo(0, scrollAmount);
         scrollView.post(() -> scrollView.scrollTo(0, pos));
     }
@@ -490,7 +485,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     }
 
     private void scrollTo(@NonNull Session session) {
-        final ScrollView parent = getView().findViewById(R.id.scrollView1);
+        final ScrollView parent = requireViewByIdCompat(getView(), R.id.scrollView1);
         int height = getNormalizedBoxHeight(getResources(), scale, LOG_TAG);
         final int pos = (session.relStartTime - conference.getFirstSessionStartsAt()) / 5 * height;
         MyApp.LogDebug(LOG_TAG, "position is " + pos);
@@ -515,7 +510,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     private void fillTimes() {
         int time = conference.getFirstSessionStartsAt();
         int printTime = time;
-        LinearLayout timeTextColumn = getView().findViewById(R.id.times_layout);
+        LinearLayout timeTextColumn = requireViewByIdCompat(getView(), R.id.times_layout);
         timeTextColumn.removeAllViews();
         Moment nowMoment = new Moment();
         View timeTextView;
@@ -531,7 +526,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
             }
             timeTextView = inflater.inflate(timeTextLayout, null);
             timeTextColumn.addView(timeTextView, LayoutParams.MATCH_PARENT, timeTextViewHeight);
-            TextView title = timeTextView.findViewById(R.id.time);
+            TextView title = requireViewByIdCompat(timeTextView, R.id.time);
             title.setText(timeSegment.getFormattedText());
             time += FIFTEEN_MINUTES;
             printTime = time;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -106,8 +106,8 @@ public class MainActivity extends BaseActivity implements
         setContentView(R.layout.main_layout);
         appRepository = AppRepository.INSTANCE;
         keyguardManager = (KeyguardManager) getSystemService(KEYGUARD_SERVICE);
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        progressBar = findViewById(R.id.progress);
+        Toolbar toolbar = requireViewByIdCompat(R.id.toolbar);
+        progressBar = requireViewByIdCompat(R.id.progress);
         setSupportActionBar(toolbar);
 
         getSupportActionBar().setTitle(R.string.fahrplan);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -10,6 +10,7 @@ import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.Font
@@ -65,16 +66,16 @@ internal class SessionViewDrawer @JvmOverloads constructor(
     }
 
     fun updateSessionView(sessionView: View, session: Session) {
-        val bell = sessionView.findViewById<ImageView>(R.id.session_bell_view)
+        val bell = sessionView.requireViewByIdCompat<ImageView>(R.id.session_bell_view)
         bell.isVisible = session.hasAlarm
-        var title = sessionView.findViewById<TextView>(R.id.session_title_view)
+        var title = sessionView.requireViewByIdCompat<TextView>(R.id.session_title_view)
         title.typeface = boldCondensed
         title.text = session.title
-        title = sessionView.findViewById(R.id.session_subtitle_view)
+        title = sessionView.requireViewByIdCompat(R.id.session_subtitle_view)
         title.text = session.subtitle
-        title = sessionView.findViewById(R.id.session_speakers_view)
+        title = sessionView.requireViewByIdCompat(R.id.session_speakers_view)
         title.text = session.formattedSpeakers
-        title = sessionView.findViewById(R.id.session_track_view)
+        title = sessionView.requireViewByIdCompat(R.id.session_track_view)
         title.text = session.formattedTrackText
         title.contentDescription = session.getFormattedTrackContentDescription(sessionView.context)
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
@@ -129,9 +130,9 @@ internal class SessionViewDrawer @JvmOverloads constructor(
 
         @JvmStatic
         fun setSessionTextColor(session: Session, view: View) {
-            val title = view.findViewById<TextView>(R.id.session_title_view)
-            val subtitle = view.findViewById<TextView>(R.id.session_subtitle_view)
-            val speakers = view.findViewById<TextView>(R.id.session_speakers_view)
+            val title = view.requireViewByIdCompat<TextView>(R.id.session_title_view)
+            val subtitle = view.requireViewByIdCompat<TextView>(R.id.session_subtitle_view)
+            val speakers = view.requireViewByIdCompat<TextView>(R.id.session_speakers_view)
             val colorResId = if (session.highlight)
                 R.color.session_title_on_highlight_background
             else

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.kt
@@ -18,7 +18,7 @@ class SettingsActivity : BaseActivity(R.layout.settings) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
         supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))


### PR DESCRIPTION
# Description
- Here `ActivityCompat#requireViewById` and `ViewCompat#requireViewById` are used to retrieve non-null views.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Nexus 5 emulator, Android 4.1.2 (API 16)
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)