### PR TITLE
Use compileSdkVersion & targetSdkVersion 29 (Android 10).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     # Note that the tools section appears twice on purpose as it’s required
     # to get the newest Android SDK tools. Source: Travis CI docs.
     - build-tools-29.0.3
-    - android-28
+    - android-29
 
     # The libraries we can't get from Maven Central or similar
     - extra

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -4,9 +4,9 @@ package nerd.tuxmobil.fahrplan.congress
 
 object Android {
     const val buildToolsVersion = "29.0.3"
-    const val compileSdkVersion = 28
+    const val compileSdkVersion = 29
     const val minSdkVersion = 14
-    const val targetSdkVersion = 28
+    const val targetSdkVersion = 29
 }
 
 private const val kotlinVersion = "1.3.72"


### PR DESCRIPTION
# Description
- Use compileSdkVersion 29.
- Use targetSdkVersion 29.

# Successfully tested on
with `ccc36c3` flavor, `release` build
- :heavy_check_mark: Nexus 5X emulator, Android 4.1.2 (API 16)
- :heavy_check_mark: Nexus 5 emulator, Android 9.0 (API 28)

Resolves #273.