### PR TITLE
Adjust clock icon position

### DIFF
--- a/app/src/main/res/layout/session_detailbar.xml
+++ b/app/src/main/res/layout/session_detailbar.xml
@@ -16,6 +16,7 @@
         android:layout_marginLeft="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
+        android:drawablePadding="@dimen/session_detailbar_icon_padding"
         android:ellipsize="end"
         android:fontFamily="sans-serif-light"
         android:gravity="center"

--- a/app/src/main/res/layout/session_detailbar_large.xml
+++ b/app/src/main/res/layout/session_detailbar_large.xml
@@ -16,6 +16,7 @@
         android:layout_marginLeft="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
+        android:drawablePadding="@dimen/session_detailbar_icon_padding"
         android:ellipsize="end"
         android:fontFamily="sans-serif-light"
         android:gravity="center"


### PR DESCRIPTION
Issue #318 

# Description
- The clock icon in the session details screen looks somewhat odd positioned.
- Device Pixel4 - API 28 and Nexus10 - API 29 emulators.

# Before
![Before on mobile](https://i.ibb.co/NLJYWtt/before-mobile.png "Before on mobile")
![Before on tablet](https://i.ibb.co/9Td7Pb1/before-tablet.png "Before on tablet")

# After
- Add missing `android:drawablePadding` to clock icon to fixed it.

![After on mobile](https://i.ibb.co/G3DtgZX/after-mobile.png "After on mobile")
![After on tablet](https://i.ibb.co/Fkp6dWM/after-tablet.png "After on tablet")