### PR TITLE
Update German translation and English strings

### DIFF
--- a/app/src/main/res/values-de/placeholder.xml
+++ b/app/src/main/res/values-de/placeholder.xml
@@ -90,6 +90,9 @@
     <string name="placeholder_session_date">
         27.12.13 11:45 VORM. - SAAL 1
     </string>
+    <string name="placeholder_session_location">
+        SEHR LANGER RAUM
+    </string>
     <string name="placeholder_session_id">
         ID: 5610
     </string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -35,7 +35,7 @@
 
     <!-- CustomHttpClient -->
     <string name="dlg_err_connection_failed">Verbindungsfehler</string>
-    <string name="dlg_err_failed_unknown_host">Unbekannte Adresse:\n%s</string>
+    <string name="dlg_err_failed_unknown_host">Unbekannte Adresse:\n<xliff:g example="http://example.com" id="url">%s</xliff:g></string>
     <string name="dlg_err_failed_wrong_http_credentials">Ungültige HTTP Authentifizierung</string>
     <string name="dlg_err_failed_timeout">Server antwortet nicht (Zeitüberschreitung).</string>
     <string name="dlg_err_failed_connect_failure">Unbekannter Verbindungsfehler</string>
@@ -51,12 +51,12 @@
     <string name="schedule_changes_dialog_changed_new_cancelled_text">\u0020aktualisiert. Es gibt Änderungen in <xliff:g example="3 Vorträgen" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 sind" id="num_new">%2$s</xliff:g> neu, <xliff:g example="1 ist" id="num_canceled">%3$s</xliff:g> gestrichen.</string>
     <string name="schedule_changes_dialog_affected_text">Die Änderungen betreffen <xliff:g example="2" id="num_marked">%1$d</xliff:g> der favorisierten Vorträge.</string>
     <plurals name="schedule_changes_dialog_number_of_sessions">
-        <item quantity="one">%d Vortrag</item>
-        <item quantity="other">%d Vorträgen</item>
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> Vortrag</item>
+        <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> Vorträgen</item>
     </plurals>
     <plurals name="schedule_changes_dialog_being">
-        <item quantity="one">%d ist</item>
-        <item quantity="other">%d sind</item>
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> ist</item>
+        <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> sind</item>
     </plurals>
     <string name="schedule_changes_dialog_browse">Ansehen</string>
     <string name="schedule_changes_dialog_later">Später</string>
@@ -67,7 +67,7 @@
     <string name="choose_day">Tag wählen</string>
     <string name="day">Tag</string>
     <string name="fahrplan">Fahrplan</string>
-    <string name="appVersion">App Version %s</string>
+    <string name="appVersion">App Version <xliff:g example="1.40.2" id="appVersion">%s</xliff:g></string>
     <string name="schedule_updated_to">
         Aktualisiert auf <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g>
     </string>
@@ -93,7 +93,7 @@
 	</string>
     <string name="today">heute</string>
     <string name="schedule_parsing_error_generic">Unbekannter Fehler beim Parsen des Fahrplans</string>
-    <string name="schedule_parsing_error_with_version">Fehler beim Parsen der Fahrplan-Version %s</string>
+    <string name="schedule_parsing_error_with_version">Fehler beim Parsen der Fahrplan-Version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>
     <string name="engelsystem_shifts_parsing_error_generic">Unbekannter Fehler beim Parsen der Engelsystem-Schichten</string>
     <string name="engelsystem_shifts_parsing_error_forbidden">Ungültiger API-Schlüssel für Engelsystem-Schichten</string>
     <string name="engelsystem_shifts_parsing_error_not_found">Falsche URL für Engelsystem-Schichten</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -204,4 +204,18 @@
     <string name="session_list_item_video_content_description">Mit Videoaufzeichnung</string>
     <string name="session_list_item_without_video_content_description">Ohne Videoaufzeichnung</string>
 
+    <!-- Validation errors -->
+    <string name="validation_error_invalid_url">
+        Ungültige <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL.
+    </string>
+    <string name="validation_error_url_without_query">
+        <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL ohne Query-Teil.
+    </string>
+    <string name="validation_error_url_with_incomplete_query">
+        <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL mit unvollständigem Query-Teil.
+    </string>
+    <string name="validation_error_url_without_api_key">
+        <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL ohne API-Schlüssel.
+    </string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,7 +37,7 @@
 
     <!-- CustomHttpClient -->
     <string name="dlg_err_connection_failed">Connection failure</string>
-    <string name="dlg_err_failed_unknown_host">Unknown address:\n%s</string>
+    <string name="dlg_err_failed_unknown_host">Unknown address:\n<xliff:g example="http://example.com" id="url">%s</xliff:g></string>
     <string name="dlg_err_failed_wrong_http_credentials">Invalid HTTP Authentication</string>
     <string name="dlg_err_failed_timeout">Server doesn\'t respond (Timeout).</string>
     <string name="dlg_err_failed_connect_failure">Unknown connection failure</string>
@@ -53,12 +53,12 @@
     <string name="schedule_changes_dialog_changed_new_cancelled_text">. There are changes in <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> new, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancelled.</string>
     <string name="schedule_changes_dialog_affected_text">The changes affect <xliff:g example="2" id="num_marked">%1$d</xliff:g> of your favored lectures.</string>
     <plurals name="schedule_changes_dialog_number_of_sessions">
-        <item quantity="one">%d lecture</item>
-        <item quantity="other">%d lectures</item>
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> lecture</item>
+        <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> lectures</item>
     </plurals>
     <plurals name="schedule_changes_dialog_being">
-        <item quantity="one">%d is</item>
-        <item quantity="other">%d are</item>
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> is</item>
+        <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> are</item>
     </plurals>
     <string name="schedule_changes_dialog_browse">Browse</string>
     <string name="schedule_changes_dialog_later">Later</string>
@@ -69,7 +69,7 @@
     <string name="choose_day">Choose day</string>
     <string name="day">Day</string>
     <string name="fahrplan">Schedule</string>
-    <string name="appVersion">App Version %s</string>
+    <string name="appVersion">App Version <xliff:g example="1.40.2" id="appVersion">%s</xliff:g></string>
     <string name="schedule_updated_to">
         Updated to <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g>
     </string>
@@ -104,7 +104,7 @@
 	</string>
     <string name="today">today</string>
     <string name="schedule_parsing_error_generic">Unknown error while parsing schedule</string>
-    <string name="schedule_parsing_error_with_version">Parsing error for schedule version %s</string>
+    <string name="schedule_parsing_error_with_version">Parsing error for schedule version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>
     <string name="engelsystem_shifts_parsing_error_generic">Unknown error while parsing Engelsystem shifts</string>
     <string name="engelsystem_shifts_parsing_error_forbidden">Invalid API key for Engelsystem shifts</string>
     <string name="engelsystem_shifts_parsing_error_not_found">Wrong URL for Engelsystem shifts</string>


### PR DESCRIPTION
# Description
- Add missing German strings.
- Add missing German placeholder string.
- Add missing xliff markup in English and German resource files.

# Successfully tested on
with `ccc36c3` flavor, `release` build
- :heavy_check_mark: Pixel 2 device, Android 10.0 (API 29)