### PR TITLE
Fix loading Engelsystem shifts / enhance error showing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'),
                     'proguard-rules/proguard-project.txt',
+                    'proguard-rules/moshi.pro',
                     'proguard-rules/okhttp3.pro',
                     'proguard-rules/okio.pro'
         }

--- a/app/proguard-rules/moshi.pro
+++ b/app/proguard-rules/moshi.pro
@@ -1,0 +1,61 @@
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* <methods>;
+}
+
+-keep @com.squareup.moshi.JsonQualifier interface *
+
+# Enum field names are used by the integrated EnumJsonAdapter.
+# values() is synthesized by the Kotlin compiler and is used by EnumJsonAdapter indirectly
+# Annotate enums with @JsonClass(generateAdapter = false) to use them with Moshi.
+-keepclassmembers @com.squareup.moshi.JsonClass class * extends java.lang.Enum {
+    <fields>;
+    **[] values();
+}
+
+# The name of @JsonClass types is used to look up the generated adapter.
+-keepnames @com.squareup.moshi.JsonClass class *
+
+# Retain generated target class's synthetic defaults constructor and keep DefaultConstructorMarker's
+# name. We will look this up reflectively to invoke the type's constructor.
+#
+# We can't _just_ keep the defaults constructor because Proguard/R8's spec doesn't allow wildcard
+# matching preceding parameters.
+-keepnames class kotlin.jvm.internal.DefaultConstructorMarker
+-keepclassmembers @kotlin.Metadata @com.squareup.moshi.JsonClass class * {
+    synthetic <init>(...);
+}
+
+# Retain generated JsonAdapters if annotated type is retained.
+-if @com.squareup.moshi.JsonClass class *
+-keep class <1>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*
+-keep class <1>_<2>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*
+-keep class <1>_<2>_<3>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*
+-keep class <1>_<2>_<3>_<4>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>JsonAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.squareup.moshi.JsonClass class **$*$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>_<6>JsonAdapter {
+    <init>(...);
+    <fields>;
+}

--- a/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepository.kt
+++ b/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepository.kt
@@ -1,7 +1,6 @@
 package info.metadude.android.eventfahrplan.engelsystem
 
 import info.metadude.android.eventfahrplan.engelsystem.loading.ShiftsLoading.awaitShiftsResult
-import info.metadude.android.eventfahrplan.engelsystem.models.EngelsystemUri
 import info.metadude.android.eventfahrplan.engelsystem.models.ShiftsResult
 import info.metadude.android.eventfahrplan.engelsystem.utils.UriParser
 import info.metadude.kotlin.library.engelsystem.ApiModule
@@ -14,16 +13,15 @@ class EngelsystemNetworkRepository(
 
 ) {
 
-    suspend fun load(okHttpClient: OkHttpClient, url: String): ShiftsResult {
-        val uri: EngelsystemUri
-        try {
-            uri = uriParser.parseUri(url)
-        } catch (e: URISyntaxException) {
-            return ShiftsResult.Exception(e)
-        }
+    suspend fun load(okHttpClient: OkHttpClient, url: String) = try {
+        val uri = uriParser.parseUri(url)
         val service = ApiModule.provideEngelsystemService(uri.baseUrl, okHttpClient)
         val call = service.getShifts(uri.pathPart, uri.apiKey)
-        return call.awaitShiftsResult()
+        call.awaitShiftsResult()
+    } catch (e: URISyntaxException) {
+        ShiftsResult.Exception(e)
+    } catch (e: IllegalArgumentException) {
+        ShiftsResult.Exception(e)
     }
 
 }


### PR DESCRIPTION
# Description
- Fix loading _Engelsystem_ shifts.
  - Due to a version increase of _Moshi_ from 1.9.3 to 1.11.0 in ef53203d3e73e92f0947387e0b1e4253aca01726 and the fact that _ProGuard_ rules are auto-generated as of _Moshi_ 1.10.0 the generated `ShiftJsonAdapter` class was _suddenly_ missing.
  - This commit adds the [formerly provided _ProGuard_ rules](https://raw.githubusercontent.com/square/moshi/moshi-parent-1.9.3/moshi/src/main/resources/META-INF/proguard/moshi.pro). These can be removed once the _Engelsystem_ library uses _Moshi_ 1.10.0+ itself.
- Show error message (Toast) when loading _Engelsystem_ shifts fails.

# Successfully tested on
with `ccc36c3` flavor, `release` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)

---

Resolves #338

---

:+1: Thanks to @ZacSweers for [the perfect hint](https://github.com/square/moshi/issues/1266#issuecomment-720770201)!