### PR TITLE
Fix showing all session alarm notifications

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -46,7 +46,8 @@ public final class AlarmReceiver extends BroadcastReceiver {
 
             AppRepository appRepository = AppRepository.INSTANCE;
 
-            Intent launchIntent = MainActivity.createLaunchIntent(context, sessionId, day);
+            int uniqueNotificationId = appRepository.createSessionAlarmNotificationId(sessionId);
+            Intent launchIntent = MainActivity.createLaunchIntent(context, sessionId, day, uniqueNotificationId);
             PendingIntent contentIntent = PendingIntent
                     .getActivity(context, lid, launchIntent, PendingIntent.FLAG_ONE_SHOT);
 
@@ -55,7 +56,7 @@ public final class AlarmReceiver extends BroadcastReceiver {
             NotificationCompat.Builder builder = notificationHelper.getSessionAlarmNotificationBuilder(contentIntent, title, when, soundUri);
             boolean isInsistentAlarmsEnabled = appRepository.readInsistentAlarmsEnabled();
             MyApp.LogDebug(LOG_TAG, "Preference 'isInsistentAlarmsEnabled' = " + isInsistentAlarmsEnabled + ".");
-            notificationHelper.notify(NotificationHelper.SESSION_ALARM_ID, builder, isInsistentAlarmsEnabled);
+            notificationHelper.notify(uniqueNotificationId, builder, isInsistentAlarmsEnabled);
 
             appRepository.deleteAlarmForSessionId(sessionId);
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -21,7 +21,7 @@ class AlarmServices @JvmOverloads constructor(
 ) {
 
     /**
-     * Schedules the given [alarm] via the [android.app.AlarmManager].
+     * Schedules the given [alarm] via the [AlarmManager].
      * Existing alarms for the associated session are discarded if configured via [discardExisting].
      */
     @JvmOverloads
@@ -44,7 +44,7 @@ class AlarmServices @JvmOverloads constructor(
     }
 
     /**
-     * Discards the given [alarm] via the [android.app.AlarmManager].
+     * Discards the given [alarm] via the [AlarmManager].
      */
     fun discardSessionAlarm(context: Context, alarm: SchedulableAlarm) {
         val intent = AlarmReceiver.AlarmIntentBuilder()
@@ -61,7 +61,7 @@ class AlarmServices @JvmOverloads constructor(
     }
 
     /**
-     * Discards an internal alarm used for automatic schedule updates via the [android.app.AlarmManager].
+     * Discards an internal alarm used for automatic schedule updates via the [AlarmManager].
      */
     fun discardAutoUpdateAlarm(context: Context) {
         val intent = Intent(context, AlarmReceiver::class.java)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -17,6 +17,8 @@ public interface BundleKeys {
             "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_SESSION_ID";
     String BUNDLE_KEY_SESSION_ALARM_DAY_INDEX =
             "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_DAY_INDEX";
+    String BUNDLE_KEY_SESSION_ALARM_NOTIFICATION_ID =
+            "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_NOTIFICATION_ID";
 
     // Session details
     String SESSION_ID =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -117,7 +117,6 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
     companion object {
         private const val SESSION_ALARM_CHANNEL_ID = "SESSION_ALARM_CHANNEL"
         private const val SCHEDULE_UPDATE_CHANNEL_ID = "SCHEDULE_UPDATE_CHANNEL"
-        const val SESSION_ALARM_ID = 1
         const val SCHEDULE_UPDATE_ID = 2
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -32,13 +32,15 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
             contentIntent: PendingIntent,
             contentTitle: String,
             occurredAt: Long,
-            sound: Uri?
+            sound: Uri?,
+            deleteIntent: PendingIntent
     ): NotificationCompat.Builder =
             getNotificationBuilder(SESSION_ALARM_CHANNEL_ID, contentIntent, sessionAlarmContentText, sound)
                     .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setContentTitle(contentTitle)
                     .setDefaults(Notification.DEFAULT_LIGHTS or Notification.DEFAULT_VIBRATE)
                     .setWhen(occurredAt)
+                    .setDeleteIntent(deleteIntent)
 
     fun getScheduleUpdateNotificationBuilder(
             contentIntent: PendingIntent,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import android.content.Context
 import android.net.Uri
+import info.metadude.android.eventfahrplan.commons.extensions.onFailure
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.database.extensions.toContentValues
@@ -377,6 +378,24 @@ object AppRepository {
         val sessionsDatabaseModel = sessions.toSessionsDatabaseModel()
         val list = sessionsDatabaseModel.map { it.toContentValues() }
         sessionsDatabaseRepository.insert(list)
+    }
+
+    /**
+     * Returns a unique session alarm notification ID for the given [session ID][sessionId].
+     */
+    fun createSessionAlarmNotificationId(sessionId: String): Int {
+        val values = sessionId.toContentValues()
+        return sessionsDatabaseRepository.insertSessionId(values)
+    }
+
+    /**
+     * Deletes data associated with the given session alarm [notificationId] and
+     * returns a boolean value indicating the success or failure of this operation.
+     */
+    fun deleteSessionAlarmNotificationId(notificationId: Int): Boolean {
+        return (sessionsDatabaseRepository.deleteSessionIdByNotificationId(notificationId) > 0).onFailure {
+            logging.e(javaClass.simpleName, "Failure deleting sessionId for notificationId = $notificationId")
+        }
     }
 
     fun readMeta() =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -76,6 +76,7 @@ public class MainActivity extends BaseActivity implements
         ConfirmationDialog.OnConfirmationDialogClicked {
 
     private static final String LOG_TAG = "MainActivity";
+    private static final int INVALID_NOTIFICATION_ID = -1;
 
     private ProgressDialog progress = null;
 
@@ -153,6 +154,8 @@ public class MainActivity extends BaseActivity implements
         }
 
         Engagements.initUserEngagement(this);
+
+        onSessionAlarmNotificationTapped(getIntent());
     }
 
     @Override
@@ -160,6 +163,14 @@ public class MainActivity extends BaseActivity implements
         super.onNewIntent(intent);
         MyApp.LogDebug(LOG_TAG, "onNewIntent");
         setIntent(intent);
+        onSessionAlarmNotificationTapped(intent);
+    }
+
+    private void onSessionAlarmNotificationTapped(@NonNull Intent intent) {
+        int notificationId = intent.getIntExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_NOTIFICATION_ID, INVALID_NOTIFICATION_ID);
+        if (notificationId != INVALID_NOTIFICATION_ID) {
+            appRepository.deleteSessionAlarmNotificationId(notificationId);
+        }
     }
 
     public void onGotResponse(@NonNull FetchScheduleResult fetchScheduleResult) {
@@ -546,11 +557,13 @@ public class MainActivity extends BaseActivity implements
     public static Intent createLaunchIntent(
             @NonNull Context context,
             @NonNull String sessionId,
-            int dayIndex
+            int dayIndex,
+            int notificationId
     ) {
         Intent intent = new Intent(context, MainActivity.class);
         intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_SESSION_ID, sessionId);
         intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_DAY_INDEX, dayIndex);
+        intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_NOTIFICATION_ID, notificationId);
         intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
         return intent;
     }

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -27,4 +27,5 @@ dependencies {
 
     testImplementation Libs.junit
     testImplementation Libs.assertjAndroid
+    testImplementation Libs.truth
 }

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensions.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensions.kt
@@ -1,0 +1,14 @@
+@file:JvmName("StandardExtensions")
+
+package info.metadude.android.eventfahrplan.commons.extensions
+
+/**
+ * Calls the specified function [block] with `this` value as its argument if [the receiver][this]
+ * is `false` and returns `this` value.
+ */
+inline fun <Boolean> Boolean.onFailure(block: (Boolean) -> Unit): Boolean {
+    if (this == false) {
+        block(this)
+    }
+    return this
+}

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensionsTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensionsTest.kt
@@ -1,0 +1,28 @@
+package info.metadude.android.eventfahrplan.commons.extensions
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class StandardExtensionsTest {
+
+    @Test
+    fun `onFailure invokes the passed lambda if the boolean receiver is false`() {
+        var invoked = false
+        val returnValue = false.onFailure {
+            invoked = true
+        }
+        assertThat(returnValue).isFalse()
+        assertThat(invoked).isTrue()
+    }
+
+    @Test
+    fun `onFailure does not invoke the passed lambda if the boolean receiver is true`() {
+        var invoked = false
+        val returnValue = true.onFailure {
+            invoked = true
+        }
+        assertThat(returnValue).isTrue()
+        assertThat(invoked).isFalse()
+    }
+
+}

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -71,6 +71,18 @@ public interface FahrplanContract {
 
     }
 
+    interface SessionByNotificationIdTable {
+
+        String NAME = "session_by_notification_id";
+
+        interface Columns extends BaseColumns {
+
+            /* 00 */ String SESSION_ID = "session_id";
+
+        }
+
+    }
+
     interface SessionsTable {
 
         String NAME = "lectures"; // Keep table name to avoid database migration.

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
@@ -1,6 +1,8 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
+import android.content.ContentValues
 import androidx.core.content.contentValuesOf
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionByNotificationIdTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ABSTRACT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_DURATION
@@ -75,4 +77,11 @@ fun Session.toContentValues() = contentValuesOf(
         CHANGED_TIME to changedTime,
         CHANGED_TITLE to changedTitle,
         CHANGED_TRACK to changedTrack
+)
+
+/**
+ * Converts a session ID into [ContentValues].
+ */
+fun String.toContentValues() = contentValuesOf(
+        SessionByNotificationIdTable.Columns.SESSION_ID to this
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import androidx.core.database.sqlite.transaction
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionByNotificationIdTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.*
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Values.REC_OPT_OUT_OFF
@@ -27,6 +28,29 @@ class SessionsDatabaseRepository(
                 insert(SessionsTable.NAME, contentValues)
             }
         }
+    }
+
+    /**
+     * Inserts the session ID into the [SessionByNotificationIdTable] and returns
+     * the newly generated notification ID which is associated with the session ID.
+     *
+     * Notification IDs are incremented automatically.
+     *
+     * [sessionIdContentValues] is expected to be composed from
+     * [SessionByNotificationIdTable.Columns.SESSION_ID] and the session ID value.
+     *
+     * See also: [android.database.sqlite.SQLiteDatabase.insert]
+     */
+    fun insertSessionId(sessionIdContentValues: ContentValues) = with(sqLiteOpenHelper) {
+        writableDatabase.insert(SessionByNotificationIdTable.NAME, sessionIdContentValues)
+    }.toInt()
+
+    /**
+     * Deletes the [SessionByNotificationIdTable] row associated with the given unique [notificationId].
+     * Returns the number of affected rows.
+     */
+    fun deleteSessionIdByNotificationId(notificationId: Int) = with(sqLiteOpenHelper) {
+        writableDatabase.delete(SessionByNotificationIdTable.NAME, SessionByNotificationIdTable.Columns._ID, "$notificationId")
     }
 
     fun querySessionBySessionId(sessionId: String): Session {


### PR DESCRIPTION
# Description
- This pull request fixes that notifications for all session alarm are shown when these were scheduled for the same time. In the example screenshot there are three session alarms scheduled for 11:30.
  ![Screenshot showing a schedule with 3 alarms set for 11:30](https://user-images.githubusercontent.com/144518/98037068-52fa0780-1e1b-11eb-89bc-6f79a5ea3ff5.png)
- Before only one notification was shown in such a scenario.
- Notification data is removed from the database when the notification
  - is consumed by tapping on it
  - is discarded by swiping it away


# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 device, Android 7.1.1
- :heavy_check_mark: Pixel 2 device, Android 10

# Before
- One notification is shown for 11:30 although three alarms were fired.
![One notification is shown for 11:30 although three alarms were fired](https://user-images.githubusercontent.com/144518/98037135-6907c800-1e1b-11eb-8090-21ce580f09f4.png)


# After
- Three notifications are shown for 11:30 because three alarms were fired.
![Three notifications are shown for 11:30 because three alarms were fired](https://user-images.githubusercontent.com/144518/98037149-6d33e580-1e1b-11eb-81c4-a189de602c78.png)