### PR TITLE
Append time zone name if present when sharing a session or favorites.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
+import org.threeten.bp.ZoneId
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
 import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
@@ -9,6 +10,7 @@ fun MetaAppModel.toMetaNetworkModel() = MetaNetworkModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
+        timeZoneName = timeZoneId?.id,
         title = title,
         version = version
 )
@@ -17,6 +19,10 @@ fun MetaDatabaseModel.toMetaAppModel() = MetaAppModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
+        timeZoneId = timeZoneName?.let {
+            // Try/catch omitted here because this happened in MetaValidation.validate before.
+            ZoneId.of(it)
+        },
         title = title,
         version = version
 )
@@ -25,6 +31,7 @@ fun MetaNetworkModel.toMetaDatabaseModel() = MetaDatabaseModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
+        timeZoneName = timeZoneName,
         title = title,
         version = version
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
@@ -1,11 +1,11 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
-import nerd.tuxmobil.fahrplan.congress.models.Meta
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
+import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
 
 
-fun Meta.toMetaDatabaseModel() = MetaDatabaseModel(
+fun MetaAppModel.toMetaNetworkModel() = MetaNetworkModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
@@ -13,7 +13,7 @@ fun Meta.toMetaDatabaseModel() = MetaDatabaseModel(
         version = version
 )
 
-fun Meta.toMetaNetworkModel() = MetaNetworkModel(
+fun MetaDatabaseModel.toMetaAppModel() = MetaAppModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,
@@ -21,15 +21,7 @@ fun Meta.toMetaNetworkModel() = MetaNetworkModel(
         version = version
 )
 
-fun MetaDatabaseModel.toMetaAppModel() = Meta(
-        eTag = eTag,
-        numDays = numDays,
-        subtitle = subtitle,
-        title = title,
-        version = version
-)
-
-fun MetaNetworkModel.toMetaAppModel() = Meta(
+fun MetaNetworkModel.toMetaDatabaseModel() = MetaDatabaseModel(
         eTag = eTag,
         numDays = numDays,
         subtitle = subtitle,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -15,6 +15,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.StringUtils
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
+import org.threeten.bp.ZoneId
 
 class SessionDetailsViewModel @JvmOverloads constructor(
 
@@ -30,8 +31,8 @@ class SessionDetailsViewModel @JvmOverloads constructor(
         private val toFeedbackUrl: Session.(String) -> String = { urlTemplate ->
             FeedbackUrlComposer(this, urlTemplate).getFeedbackUrl()
         },
-        private val toPlainText: Session.() -> String = {
-            SimpleSessionFormat.format(this)
+        private val toPlainText: Session.(ZoneId?) -> String = { timeZoneId ->
+            SimpleSessionFormat.format(this, timeZoneId)
         },
         private val toJson: Session.() -> String = {
             JsonSessionFormat.format(this)
@@ -65,6 +66,8 @@ class SessionDetailsViewModel @JvmOverloads constructor(
 
     // Needs to be a "var" so it can be modified (highlight, hasAlarm).
     private var session: Session = repository.readSessionBySessionId(sessionId)
+
+    private val timeZoneId = repository.readMeta().timeZoneId
 
     val hasDateUtc get() = session.dateUTC > 0
     val formattedDateUtc get() = session.toFormattedDateUtc()
@@ -133,7 +136,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
         }
         R.id.menu_item_share_session,
         R.id.menu_item_share_session_text -> {
-            val formattedSession = session.toPlainText()
+            val formattedSession = session.toPlainText(timeZoneId)
             viewActionHandler.shareAsPlainText(formattedSession)
             true
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -23,6 +23,8 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
+import org.threeten.bp.ZoneId;
+
 import java.util.List;
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
@@ -333,7 +335,8 @@ public class StarredListFragment extends AbstractListFragment implements AbsList
     }
 
     private void shareSessions() {
-        String formattedSession = SimpleSessionFormat.format(starredList);
+        ZoneId timeZoneId = appRepository.readMeta().getTimeZoneId();
+        String formattedSession = SimpleSessionFormat.format(starredList, timeZoneId);
         if (formattedSession != null) {
             Context context = requireContext();
             SessionSharer.shareSimple(context, formattedSession);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.models
 
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable
+import org.threeten.bp.ZoneId
 
 data class Meta(
 
@@ -8,6 +9,7 @@ data class Meta(
         var eTag: String = "",
         var numDays: Int = MetasTable.Defaults.NUM_DAYS_DEFAULT,
         var subtitle: String = "",
+        var timeZoneId: ZoneId? = null,
         var title: String = "",
         var version: String = ""
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -15,6 +15,7 @@ import info.metadude.android.eventfahrplan.database.sqliteopenhelper.MetaDBOpenH
 import info.metadude.android.eventfahrplan.database.sqliteopenhelper.SessionsDBOpenHelper
 import info.metadude.android.eventfahrplan.engelsystem.EngelsystemNetworkRepository
 import info.metadude.android.eventfahrplan.engelsystem.models.ShiftsResult
+import info.metadude.android.eventfahrplan.network.models.Meta
 import info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository
 import info.metadude.kotlin.library.engelsystem.models.Shift
 import kotlinx.coroutines.Job
@@ -22,7 +23,6 @@ import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.dataconverters.*
 import nerd.tuxmobil.fahrplan.congress.exceptions.AppExceptionHandler
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
-import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.net.*
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
@@ -105,7 +105,7 @@ object AppRepository {
     ) {
         check(onFetchingDone != {}) { "Nobody registered to receive FetchScheduleResult." }
         // Fetching
-        val meta = readMeta()
+        val meta = readMeta().toMetaNetworkModel()
         scheduleNetworkRepository.fetchSchedule(okHttpClient, url, meta.eTag) { fetchScheduleResult ->
             val fetchResult = fetchScheduleResult.toAppFetchScheduleResult()
             onFetchingDone.invoke(fetchResult)
@@ -148,7 +148,7 @@ object AppRepository {
                     updateSessions(newSessions)
                 },
                 onUpdateMeta = { meta ->
-                    updateMeta(meta.toMetaAppModel())
+                    updateMeta(meta)
                 },
                 onParsingDone = { result: Boolean, version: String ->
                     onParsingDone(ParseScheduleResult(result, version))

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -26,9 +26,10 @@ import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.net.*
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
-import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
 import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges
+import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
+import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
 import okhttp3.OkHttpClient
 
 object AppRepository {
@@ -115,7 +116,8 @@ object AppRepository {
             }
 
             if (fetchResult.isSuccessful) {
-                updateMeta(meta.copy(eTag = fetchScheduleResult.eTag))
+                val validMeta = meta.copy(eTag = fetchScheduleResult.eTag).validate()
+                updateMeta(validMeta)
                 check(onParsingDone != {}) { "Nobody registered to receive ParseScheduleResult." }
                 // Parsing
                 parseSchedule(
@@ -148,7 +150,8 @@ object AppRepository {
                     updateSessions(newSessions)
                 },
                 onUpdateMeta = { meta ->
-                    updateMeta(meta)
+                    val validMeta = meta.validate()
+                    updateMeta(validMeta)
                 },
                 onParsingDone = { result: Boolean, version: String ->
                     onParsingDone(ParseScheduleResult(result, version))

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -38,6 +38,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import org.ligi.tracedroid.logging.Log;
 import org.threeten.bp.Duration;
+import org.threeten.bp.ZoneId;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -755,7 +756,8 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                     break;
                 }
             case CONTEXT_MENU_ITEM_ID_SHARE_TEXT:
-                String formattedSession = SimpleSessionFormat.format(session);
+                ZoneId timeZoneId = appRepository.readMeta().getTimeZoneId();
+                String formattedSession = SimpleSessionFormat.format(session, timeZoneId);
                 SessionSharer.shareSimple(context, formattedSession);
                 break;
             case CONTEXT_MENU_ITEM_ID_SHARE_JSON:

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
@@ -3,6 +3,8 @@ package nerd.tuxmobil.fahrplan.congress.sharing;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.threeten.bp.ZoneId;
+
 import java.util.List;
 
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
@@ -19,25 +21,25 @@ public class SimpleSessionFormat {
 
 
     @NonNull
-    public static String format(@NonNull Session session) {
+    public static String format(@NonNull Session session, @Nullable ZoneId timeZoneId) {
         StringBuilder builder = new StringBuilder();
-        appendSession(builder, session);
+        appendSession(builder, session, timeZoneId);
         return builder.toString();
     }
 
     @Nullable
-    public static String format(@NonNull List<Session> sessions) {
+    public static String format(@NonNull List<Session> sessions, @Nullable ZoneId timeZoneId) {
         if (sessions.isEmpty()) {
             return null;
         }
         int sessionsSize = sessions.size();
         if (sessionsSize == 1) {
-            return format(sessions.get(0));
+            return format(sessions.get(0), timeZoneId);
         }
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < sessionsSize; ++i) {
             Session session = sessions.get(i);
-            appendSession(builder, session);
+            appendSession(builder, session, timeZoneId);
             if (i < sessionsSize - 1) {
                 appendDivider(builder);
             }
@@ -45,9 +47,9 @@ public class SimpleSessionFormat {
         return builder.toString();
     }
 
-    private static void appendSession(StringBuilder builder, Session session) {
+    private static void appendSession(StringBuilder builder, Session session, ZoneId timeZoneId) {
         long startTime = session.getStartTimeMilliseconds();
-        String shareableStartTime = DateFormatter.newInstance().getFormattedShareable(startTime);
+        String shareableStartTime = DateFormatter.newInstance().getFormattedShareable(startTime, timeZoneId);
         builder.append(session.title);
         builder.append(LINE_BREAK);
         builder.append(shareableStartTime);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidation.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidation.kt
@@ -1,0 +1,32 @@
+package nerd.tuxmobil.fahrplan.congress.validation
+
+import info.metadude.android.eventfahrplan.network.models.Meta
+import org.threeten.bp.DateTimeException
+import org.threeten.bp.ZoneId
+import org.threeten.bp.zone.ZoneRulesException
+
+/**
+ * Validation routines to ensure that data received from the network contains values which can
+ * actually processed further.
+ */
+object MetaValidation {
+
+    /**
+     * Returns a [Meta] object which has its [timeZoneName][Meta.timeZoneName] successfully
+     * validated or set to `null`.
+     */
+    fun Meta.validate(): Meta {
+        val timeZoneNameIsValid = try {
+            ZoneId.of(timeZoneName)
+            true
+        } catch (e: NullPointerException) {
+            false
+        } catch (e: DateTimeException) {
+            false
+        } catch (e: ZoneRulesException) {
+            false
+        }
+        return if (timeZoneNameIsValid) this else copy(timeZoneName = null)
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -2,33 +2,49 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import info.metadude.android.eventfahrplan.database.models.Meta as DatabaseMeta
-import info.metadude.android.eventfahrplan.network.models.Meta as NetworkMeta
+import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
+import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
+import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
 
 class MetaExtensionsTest {
 
+    private val metaAppModel = MetaAppModel(
+            eTag = "abc123",
+            numDays = 23,
+            subtitle = "My subtitle",
+            title = "My title",
+            version = "v.9.9.9"
+    )
+
+    private val metaDatabaseModel = MetaDatabaseModel(
+            eTag = "abc123",
+            numDays = 23,
+            subtitle = "My subtitle",
+            title = "My title",
+            version = "v.9.9.9"
+    )
+
+    private val metaNetworkModel = MetaNetworkModel(
+            eTag = "abc123",
+            numDays = 23,
+            subtitle = "My subtitle",
+            title = "My title",
+            version = "v.9.9.9"
+    )
+
     @Test
-    fun databaseMeta_toMetaAppModel_toMetaDatabaseModel() {
-        val meta = DatabaseMeta(
-                eTag = "abc123",
-                numDays = 23,
-                subtitle = "My subtitle",
-                title = "My title",
-                version = "v.9.9.9"
-        )
-        assertThat(meta.toMetaAppModel().toMetaDatabaseModel()).isEqualTo(meta)
+    fun `toMetaNetworkModel converts an app into a network model`() {
+        assertThat(metaAppModel.toMetaNetworkModel()).isEqualTo(metaNetworkModel)
     }
 
     @Test
-    fun networkMeta_toMetaAppModel_toMetaNetworkModel() {
-        val meta = NetworkMeta(
-                eTag = "abc123",
-                numDays = 23,
-                subtitle = "My subtitle",
-                title = "My title",
-                version = "v.9.9.9"
-        )
-        assertThat(meta.toMetaAppModel().toMetaNetworkModel()).isEqualTo(meta)
+    fun `toMetaAppModel converts a database into an app model`() {
+        assertThat(metaDatabaseModel.toMetaAppModel()).isEqualTo(metaAppModel)
+    }
+
+    @Test
+    fun `toMetaDatabaseModel converts a network into a database model`() {
+        assertThat(metaNetworkModel.toMetaDatabaseModel()).isEqualTo(metaDatabaseModel)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.threeten.bp.ZoneId
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
 import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
@@ -12,6 +13,7 @@ class MetaExtensionsTest {
             eTag = "abc123",
             numDays = 23,
             subtitle = "My subtitle",
+            timeZoneId = ZoneId.of("Europe/Berlin"),
             title = "My title",
             version = "v.9.9.9"
     )
@@ -20,6 +22,7 @@ class MetaExtensionsTest {
             eTag = "abc123",
             numDays = 23,
             subtitle = "My subtitle",
+            timeZoneName = "Europe/Berlin",
             title = "My title",
             version = "v.9.9.9"
     )
@@ -28,6 +31,7 @@ class MetaExtensionsTest {
             eTag = "abc123",
             numDays = 23,
             subtitle = "My subtitle",
+            timeZoneName = "Europe/Berlin",
             title = "My title",
             version = "v.9.9.9"
     )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -7,11 +7,13 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
+import org.threeten.bp.ZoneId
 
 class SessionDetailsViewModelTest {
 
@@ -19,9 +21,11 @@ class SessionDetailsViewModelTest {
     private val actualSession = Session(ACTUAL_SESSION_ID)
     private val expectedSession = Session(EXPECTED_SESSION_ID)
     private val viewActionHandler = mock<SessionDetailsViewModel.ViewActionHandler>()
+    private val meta = mock<Meta>()
     private lateinit var defaultViewModel: SessionDetailsViewModel
 
     companion object {
+        private val NO_TIME_ZONE_ID = null
         private const val UNKNOWN_MENU_ITEM_ID = Int.MIN_VALUE
         private const val SAMPLE_URL = "http://example.com"
         private const val ACTUAL_SESSION_ID = "S1"
@@ -31,6 +35,8 @@ class SessionDetailsViewModelTest {
     @Before
     fun setUp() {
         whenever(repository.readSessionBySessionId(anyString())) doReturn actualSession
+        whenever(repository.readMeta()) doReturn meta
+        whenever(meta.timeZoneId) doReturn NO_TIME_ZONE_ID
         // ViewModel must be initialized after stubbing the repository.
         defaultViewModel = SessionDetailsViewModel(repository, ACTUAL_SESSION_ID, viewActionHandler)
     }
@@ -51,7 +57,7 @@ class SessionDetailsViewModelTest {
 
     @Test
     fun `onOptionsMenuItemSelected invokes shareAsPlainText with plain text`() {
-        val toPlainText: Session.() -> String = { "An example session" }
+        val toPlainText: Session.(ZoneId?) -> String = { "An example session" }
         val viewModel = SessionDetailsViewModel(repository, ACTUAL_SESSION_ID, viewActionHandler,
                 toPlainText = toPlainText)
         assertThat(viewModel.onOptionsMenuItemSelected(R.id.menu_item_share_session)).isTrue()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -1,0 +1,103 @@
+package nerd.tuxmobil.fahrplan.congress.sharing
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.*
+
+class SimpleSessionFormatTest {
+
+    private val systemTimezone = TimeZone.getDefault()
+    private val systemLocale = Locale.getDefault()
+
+    private val session1 = Session("S1").apply {
+        title = "A talk which changes your life"
+        room = "Yellow pavilion"
+        date = "2019-12-27T11:00:00+01:00"
+        url = "https://example.com/2019/LD3FX9.html"
+    }
+
+    private val session2 = Session("S2").apply {
+        title = "The most boring workshop ever"
+        room = "Dark cellar"
+        date = "2019-12-28T17:00:00+01:00"
+        url = "https://example.com/2019/U28VSA.html"
+    }
+
+    private val session3 = Session("S3").apply {
+        title = "Angel shifts planning"
+        room = "Main hall"
+        date = "2019-12-29T09:00:00+01:00"
+        links = "https://events.ccc.de/congress/2019/wiki/index.php/Session:A/V_Angel_Meeting"
+        url = "https://example.com/2019/U28VSA.html"
+    }
+
+    @Before
+    fun setUp() {
+        Locale.setDefault(Locale("de", "DE"))
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
+    }
+
+    @After
+    fun cleanUp() {
+        Locale.setDefault(systemLocale)
+        TimeZone.setDefault(systemTimezone)
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session`() {
+        assertThat(SimpleSessionFormat.format(session1)).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+
+                https://example.com/2019/LD3FX9.html
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a wiki session`() {
+        assertThat(SimpleSessionFormat.format(session3)).isEqualTo(
+                """
+                Angel shifts planning
+                Sonntag, 29. Dezember 2019 09:00 GMT+01:00, Main hall
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns null for an empty sessions list`() {
+        assertThat(SimpleSessionFormat.format(emptyList())).isNull()
+    }
+
+    @Test
+    fun `format returns separated multiline text for a single session`() {
+        assertThat(SimpleSessionFormat.format(listOf(session1))).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+
+                https://example.com/2019/LD3FX9.html
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns separated multiline text for multiple sessions`() {
+        assertThat(SimpleSessionFormat.format(listOf(session1, session2))).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+
+                https://example.com/2019/LD3FX9.html
+
+                ---
+
+                The most boring workshop ever
+                Samstag, 28. Dezember 2019 17:00 GMT+01:00, Dark cellar
+
+                https://example.com/2019/U28VSA.html
+                """.trimIndent())
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -5,9 +5,16 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import java.util.*
+import org.threeten.bp.ZoneId
+import java.util.Locale
+import java.util.TimeZone
 
 class SimpleSessionFormatTest {
+
+    private companion object {
+        val NO_TIME_ZONE_ID: ZoneId? = null
+        val TIME_ZONE_EUROPE_BERLIN: ZoneId = ZoneId.of("Europe/Berlin")
+    }
 
     private val systemTimezone = TimeZone.getDefault()
     private val systemLocale = Locale.getDefault()
@@ -34,6 +41,13 @@ class SimpleSessionFormatTest {
         url = "https://example.com/2019/U28VSA.html"
     }
 
+    private val session4 = Session("S4").apply {
+        title = "Central european summer time"
+        room = "Sunshine tent"
+        date = "2019-09-01T16:00:00+02:00"
+        url = "https://example.com/2019/U9SD23.html"
+    }
+
     @Before
     fun setUp() {
         Locale.setDefault(Locale("de", "DE"))
@@ -47,11 +61,22 @@ class SimpleSessionFormatTest {
     }
 
     @Test
-    fun `format returns formatted multiline text for a session`() {
-        assertThat(SimpleSessionFormat.format(session1)).isEqualTo(
+    fun `format returns formatted multiline text for a session without time zone name`() {
+        assertThat(SimpleSessionFormat.format(session1, NO_TIME_ZONE_ID)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+
+                https://example.com/2019/LD3FX9.html
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with time zone name`() {
+        assertThat(SimpleSessionFormat.format(session1, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019 11:00 MEZ (Europe/Berlin), Yellow pavilion
 
                 https://example.com/2019/LD3FX9.html
                 """.trimIndent())
@@ -59,24 +84,24 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a wiki session`() {
-        assertThat(SimpleSessionFormat.format(session3)).isEqualTo(
+        assertThat(SimpleSessionFormat.format(session3, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 Angel shifts planning
-                Sonntag, 29. Dezember 2019 09:00 GMT+01:00, Main hall
+                Sonntag, 29. Dezember 2019 09:00 MEZ (Europe/Berlin), Main hall
                 """.trimIndent())
     }
 
     @Test
     fun `format returns null for an empty sessions list`() {
-        assertThat(SimpleSessionFormat.format(emptyList())).isNull()
+        assertThat(SimpleSessionFormat.format(emptyList(), NO_TIME_ZONE_ID)).isNull()
     }
 
     @Test
     fun `format returns separated multiline text for a single session`() {
-        assertThat(SimpleSessionFormat.format(listOf(session1))).isEqualTo(
+        assertThat(SimpleSessionFormat.format(listOf(session1), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 A talk which changes your life
-                Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+                Freitag, 27. Dezember 2019 11:00 MEZ (Europe/Berlin), Yellow pavilion
 
                 https://example.com/2019/LD3FX9.html
                 """.trimIndent())
@@ -84,19 +109,30 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns separated multiline text for multiple sessions`() {
-        assertThat(SimpleSessionFormat.format(listOf(session1, session2))).isEqualTo(
+        assertThat(SimpleSessionFormat.format(listOf(session1, session2), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 A talk which changes your life
-                Freitag, 27. Dezember 2019 11:00 GMT+01:00, Yellow pavilion
+                Freitag, 27. Dezember 2019 11:00 MEZ (Europe/Berlin), Yellow pavilion
 
                 https://example.com/2019/LD3FX9.html
 
                 ---
 
                 The most boring workshop ever
-                Samstag, 28. Dezember 2019 17:00 GMT+01:00, Dark cellar
+                Samstag, 28. Dezember 2019 17:00 MEZ (Europe/Berlin), Dark cellar
 
                 https://example.com/2019/U28VSA.html
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session in central european summer time`() {
+        assertThat(SimpleSessionFormat.format(session4, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+                """
+                Central european summer time
+                Sonntag, 1. September 2019 16:00 MESZ (Europe/Berlin), Sunshine tent
+
+                https://example.com/2019/U9SD23.html
                 """.trimIndent())
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidationTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidationTest.kt
@@ -1,0 +1,36 @@
+package nerd.tuxmobil.fahrplan.congress.validation
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.network.models.Meta
+import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
+import org.junit.Test
+
+class MetaValidationTest {
+
+    @Test
+    fun `validate returns instance with default values`() {
+        assertThat(Meta().validate()).isEqualTo(Meta())
+    }
+
+    @Test
+    fun `validate returns timeZoneName = null if timeZoneName = null`() {
+        assertThat(Meta(timeZoneName = null).validate()).isEqualTo(Meta(timeZoneName = null))
+    }
+
+    @Test
+    fun `validate returns timeZoneName = null if timeZoneName is empty`() {
+        assertThat(Meta(timeZoneName = "").validate()).isEqualTo(Meta(timeZoneName = null))
+    }
+
+    @Test
+    fun `validate returns timeZoneName = null if timeZoneName is invalid`() {
+        assertThat(Meta(timeZoneName = "Berlin").validate()).isEqualTo(Meta(timeZoneName = null))
+    }
+
+    @Test
+    fun `validate returns timeZoneName value if timeZoneName is valid`() {
+        assertThat(Meta(timeZoneName = "Europe/Berlin").validate())
+                .isEqualTo(Meta(timeZoneName = "Europe/Berlin"))
+    }
+
+}

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -41,18 +41,24 @@ class DateFormatter private constructor() {
 
     /**
      * Returns a formatted string suitable for sharing it with people worldwide.
-     * It contains day, month, year and time in current system locale in long format
-     * and the associated time zone offset.
-     * E.g. Tuesday, January 22, 2019 1:00 AM GMT+01:00
+     * It consists of day, month, year, time, time zone offset in the time zone of the event or
+     * in current system time zone if the former is not provided.
+     *
+     * The human readable name '{area}/{city}' of the time zone ID is appended if available.
+     *
+     * Formatting example:
+     * Tuesday, January 22, 2019 1:00 AM GMT+01:00 (Europe/Berlin)
      */
-    fun getFormattedShareable(time: Long): String {
-        // TODO: Use time zone of the event rather than the device time zone.
-        val displayTimeZone = ZoneId.systemDefault()
+    fun getFormattedShareable(time: Long, timeZoneId: ZoneId?): String {
+        val displayTimeZone = timeZoneId ?: ZoneId.systemDefault()
         val sessionStartTime = Instant.ofEpochMilli(time)
         val timeZoneOffset = timeZoneOffsetFormatter.withZone(displayTimeZone).format(sessionStartTime)
-        // TODO Append time zone name once it is provided. See https://github.com/EventFahrplan/EventFahrplan/pull/296.
         val sessionDateTime = dateFullTimeShortFormatter.withZone(displayTimeZone).format(sessionStartTime)
-        return "$sessionDateTime $timeZoneOffset"
+        var shareableText = "$sessionDateTime $timeZoneOffset"
+        if (timeZoneId != null) {
+            shareableText += " (${displayTimeZone.id})"
+        }
+        return shareableText
     }
 
     /**

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -5,15 +5,13 @@ import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle
-import java.text.SimpleDateFormat
-import java.util.Date
 
 /**
  * Format timestamps according to system locale and system time zone.
  */
 class DateFormatter private constructor() {
-    private val timeShort = SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT)
     private val timeShortNumberOnly = DateTimeFormatter.ofPattern("HH:mm")
+    private val timeShortFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val dateShortFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
     private val dateShortTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.SHORT)
     private val dateFullTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
@@ -29,7 +27,9 @@ class DateFormatter private constructor() {
      * Returns 01:00 AM, 02:00 PM, 14:00 etc, depending on current system locale either
      * in 24 or 12 hour format. The latter featuring AM or PM postfixes.
      */
-    fun getFormattedTime(time: Long): String = timeShort.format(Date(time))
+    fun getFormattedTime(time: Long): String {
+        return timeShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    }
 
     /**
      * Returns day, month and year in current system locale.

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -14,7 +14,7 @@ import java.util.Date
 class DateFormatter private constructor() {
     private val timeShort = SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT)
     private val timeShortNumberOnly = DateTimeFormatter.ofPattern("HH:mm")
-    private val dateShort = SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT)
+    private val dateShortFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
     private val dateShortTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.SHORT)
     private val dateFullTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
     private val timeZoneOffsetFormatter = DateTimeFormatter.ofPattern("z")
@@ -32,10 +32,12 @@ class DateFormatter private constructor() {
     fun getFormattedTime(time: Long): String = timeShort.format(Date(time))
 
     /**
-     * Returns day month and year in current system locale.
+     * Returns day, month and year in current system locale.
      * E.g. 1/22/19 or 22.01.19
      */
-    fun getFormattedDate(time: Long): String = dateShort.format(Date(time))
+    fun getFormattedDate(time: Long): String {
+        return dateShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    }
 
     /**
      * Returns a formatted string suitable for sharing it with people worldwide.

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -10,7 +10,7 @@ import org.threeten.bp.format.FormatStyle
  * Format timestamps according to system locale and system time zone.
  */
 class DateFormatter private constructor() {
-    private val timeShortNumberOnly = DateTimeFormatter.ofPattern("HH:mm")
+    private val timeShortNumberOnlyFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val timeShortFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val dateShortFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
     private val dateShortTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.SHORT)
@@ -21,7 +21,7 @@ class DateFormatter private constructor() {
      * Returns 01:00, 14:00 etc. for all locales. Always without AM or PM postfix in 24 hour format.
      */
     fun getFormattedTime24Hour(moment: Moment): String =
-            timeShortNumberOnly.format(moment.toZonedDateTime(OffsetDateTime.now().offset))
+            timeShortNumberOnlyFormatter.format(moment.toZonedDateTime(OffsetDateTime.now().offset))
 
     /**
      * Returns 01:00 AM, 02:00 PM, 14:00 etc, depending on current system locale either

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -15,7 +15,7 @@ class DateFormatter private constructor() {
     private val timeShort = SimpleDateFormat.getTimeInstance(SimpleDateFormat.SHORT)
     private val timeShortNumberOnly = DateTimeFormatter.ofPattern("HH:mm")
     private val dateShort = SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT)
-    private val dateTimeShort = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.SHORT, SimpleDateFormat.SHORT)
+    private val dateShortTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.SHORT)
     private val dateFullTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
     private val timeZoneOffsetFormatter = DateTimeFormatter.ofPattern("z")
 
@@ -54,10 +54,12 @@ class DateFormatter private constructor() {
     }
 
     /**
-     * Returns day month, year and time in current system locale in short format.
+     * Returns day, month, year and time in current system locale in short format.
      * E.g. 1/22/19 1:00 AM
      */
-    fun getFormattedDateTimeShort(time: Long): String = dateTimeShort.format(Date(time))
+    fun getFormattedDateTimeShort(time: Long): String {
+        return dateShortTimeShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    }
 
     companion object {
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -4,6 +4,7 @@ import org.threeten.bp.Instant
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.format.FormatStyle
 import java.text.SimpleDateFormat
 import java.util.Date
 
@@ -15,7 +16,7 @@ class DateFormatter private constructor() {
     private val timeShortNumberOnly = DateTimeFormatter.ofPattern("HH:mm")
     private val dateShort = SimpleDateFormat.getDateInstance(SimpleDateFormat.SHORT)
     private val dateTimeShort = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.SHORT, SimpleDateFormat.SHORT)
-    private val dateTimeFull = SimpleDateFormat.getDateTimeInstance(SimpleDateFormat.FULL, SimpleDateFormat.SHORT)
+    private val dateFullTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
     private val timeZoneOffsetFormatter = DateTimeFormatter.ofPattern("z")
 
     /**
@@ -45,9 +46,11 @@ class DateFormatter private constructor() {
     fun getFormattedShareable(time: Long): String {
         // TODO: Use time zone of the event rather than the device time zone.
         val displayTimeZone = ZoneId.systemDefault()
-        val timeZoneOffset = timeZoneOffsetFormatter.withZone(displayTimeZone).format(Instant.ofEpochMilli(time))
+        val sessionStartTime = Instant.ofEpochMilli(time)
+        val timeZoneOffset = timeZoneOffsetFormatter.withZone(displayTimeZone).format(sessionStartTime)
         // TODO Append time zone name once it is provided. See https://github.com/EventFahrplan/EventFahrplan/pull/296.
-        return "${dateTimeFull.format(Date(time))} $timeZoneOffset"
+        val sessionDateTime = dateFullTimeShortFormatter.withZone(displayTimeZone).format(sessionStartTime)
+        return "$sessionDateTime $timeZoneOffset"
     }
 
     /**

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -4,10 +4,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.threeten.bp.ZoneId
 import java.util.Locale
 import java.util.TimeZone
 
 class DateFormatterTest {
+
+    private companion object {
+        val NO_TIME_ZONE_ID: ZoneId? = null
+        val TIME_ZONE_EUROPE_BERLIN: ZoneId = ZoneId.of("Europe/Berlin")
+    }
+
     private val systemTimezone = TimeZone.getDefault()
     private val systemLocale = Locale.getDefault()
     private val moment = Moment("2019-01-22")
@@ -69,12 +76,21 @@ class DateFormatterTest {
     @Test
     fun getFormattedShareable() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp))
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
                 .isEqualTo("Tuesday, January 22, 2019 1:00 AM GMT+01:00")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp))
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
                 .isEqualTo("Dienstag, 22. Januar 2019 01:00 GMT+01:00")
+
+        Locale.setDefault(Locale.US)
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
+                .isEqualTo("Tuesday, January 22, 2019 1:00 AM CET (Europe/Berlin)")
+
+        Locale.setDefault(Locale.GERMANY)
+        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
+                .isEqualTo("Dienstag, 22. Januar 2019 01:00 MEZ (Europe/Berlin)")
+
     }
 
     @Test

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
@@ -16,6 +16,7 @@ class MetaExtensionsTest {
                 eTag = "abc123",
                 numDays = 23,
                 subtitle = "My subtitle",
+                timeZoneName = "Europe/Berlin",
                 title = "My title",
                 version = "v.9.9.9"
         )
@@ -23,6 +24,7 @@ class MetaExtensionsTest {
         assertThat(values.getAsString(ETAG)).isEqualTo("abc123")
         assertThat(values.getAsInteger(NUM_DAYS)).isEqualTo(23)
         assertThat(values.getAsString(SUBTITLE)).isEqualTo("My subtitle")
+        assertThat(values.getAsString(TIME_ZONE_NAME)).isEqualTo("Europe/Berlin")
         assertThat(values.getAsString(TITLE)).isEqualTo("My title")
         assertThat(values.getAsString(VERSION)).isEqualTo("v.9.9.9")
     }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -17,6 +17,7 @@ public interface FahrplanContract {
             /* 4 */ // Zombie: Former "day_change_minute" column.
             /* 5 */ String ETAG = "etag";
             /* 6 */ String NUM_DAYS = "numdays";
+            /* 7 */ String TIME_ZONE_NAME = "time_zone_name";
         }
 
         interface Defaults {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
@@ -6,6 +6,7 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
 import android.database.Cursor
+import androidx.core.database.getStringOrNull
 
 /**
  * Returns the value of the requested column as an integer.
@@ -39,6 +40,17 @@ inline fun Cursor.getLong(columnName: String): Long = getLong(getColumnIndexOrTh
  * @see Cursor.getString
  */
 inline fun Cursor.getString(columnName: String): String = getString(getColumnIndexOrThrow(columnName))
+
+/**
+ * Returns the value of the requested column as a string or null.
+ *
+ * The result and whether this method throws an exception when the column type is not a string type
+ * is implementation-defined.
+ *
+ * @see Cursor.getColumnIndexOrThrow
+ * @see Cursor.getStringOrNull
+ */
+inline fun Cursor.getStringOrNull(columnName: String): String? = getStringOrNull(getColumnIndexOrThrow(columnName))
 
 /**
  * Returns a list containing the results of applying the given [transform] function to each row

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
@@ -4,6 +4,7 @@ import androidx.core.content.contentValuesOf
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SUBTITLE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.VERSION
 import info.metadude.android.eventfahrplan.database.models.Meta
@@ -12,6 +13,7 @@ fun Meta.toContentValues() = contentValuesOf(
         ETAG to eTag,
         NUM_DAYS to numDays,
         SUBTITLE to subtitle,
+        TIME_ZONE_NAME to timeZoneName,
         TITLE to title,
         VERSION to version
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
@@ -7,6 +7,7 @@ data class Meta(
         val eTag: String = "",
         val numDays: Int = NUM_DAYS_DEFAULT,
         val subtitle: String = "",
+        val timeZoneName: String? = null,
         val title: String = "",
         val version: String = ""
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/MetaDatabaseRepository.kt
@@ -8,6 +8,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 import info.metadude.android.eventfahrplan.database.extensions.delete
 import info.metadude.android.eventfahrplan.database.extensions.getInt
 import info.metadude.android.eventfahrplan.database.extensions.getString
+import info.metadude.android.eventfahrplan.database.extensions.getStringOrNull
 import info.metadude.android.eventfahrplan.database.extensions.insert
 import info.metadude.android.eventfahrplan.database.extensions.read
 import info.metadude.android.eventfahrplan.database.extensions.upsert
@@ -43,6 +44,7 @@ class MetaDatabaseRepository(
                 Meta(
                         numDays = cursor.getInt(NUM_DAYS),
                         version = cursor.getString(VERSION),
+                        timeZoneName = cursor.getStringOrNull(TIME_ZONE_NAME),
                         title = cursor.getString(TITLE),
                         subtitle = cursor.getString(SUBTITLE),
                         eTag = cursor.getString(ETAG)

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
@@ -12,7 +12,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 
 public class MetaDBOpenHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 5;
+    private static final int DATABASE_VERSION = 6;
 
     private static final String DATABASE_NAME = "meta";
 
@@ -22,7 +22,8 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
                     Columns.VERSION + " TEXT, " +
                     Columns.TITLE + " TEXT, " +
                     Columns.SUBTITLE + " TEXT, " +
-                    Columns.ETAG + " TEXT);";
+                    Columns.ETAG + " TEXT, " +
+                    Columns.TIME_ZONE_NAME + " TEXT);";
 
     public MetaDBOpenHelper(@NonNull Context context) {
         super(context.getApplicationContext(), DATABASE_NAME, null, DATABASE_VERSION);
@@ -38,6 +39,10 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
         if (oldVersion < 3 && newVersion >= 3) {
             db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
                     Columns.ETAG + " TEXT DEFAULT " + Defaults.ETAG_DEFAULT);
+        }
+        if (oldVersion < 6 && newVersion >= 6) {
+            db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
+                    Columns.TIME_ZONE_NAME + " TEXT");
         }
         if (oldVersion < 4) {
             // Clear database from 34C3.

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
@@ -6,6 +6,7 @@ data class Meta(
         var numDays: Int = 0,
         var subtitle: String = "",
         var title: String = "",
+        var timeZoneName: String? = null,
         var version: String = ""
 
 )

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -320,6 +320,10 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                             parser.next();
                                             dayChangeTime = Session.Companion.parseStartTime(XmlPullParsers.getSanitizedText(parser));
                                         }
+                                        if (name.equals("time_zone_name")) {
+                                            parser.next();
+                                            meta.setTimeZoneName(XmlPullParsers.getSanitizedText(parser));
+                                        }
                                         break;
                                 }
                                 if (confDone) {


### PR DESCRIPTION
# Description
- Append time zone name if present when sharing a session or favorites.
- Parse new `time_zone_name` XML node if available.
- Migrate `DateFormatter` implementation to `threetenbp` library.
- Unit test `SimpleSessionFormat` class.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2, Android 10

# Before
- Sharing a session without time zone name
![Sharing a session without time zone name](https://user-images.githubusercontent.com/144518/98159804-7c7b6780-1edd-11eb-8ec1-5378a8d9864f.png)

# After
- Sharing a session with time zone name (Europe/Berlin).
![Sharing a session with time zone name](https://user-images.githubusercontent.com/144518/98159816-81d8b200-1edd-11eb-8d31-353fa58adad2.png)

# Related
- [Pull request #296: Append time zone offset when sharing a session as plain text.](https://github.com/EventFahrplan/EventFahrplan/pull/296)

---

Resolves #316 