### PR TITLE
Fix scrolling to session when tapping session alarm notification.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -493,7 +493,12 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     private void scrollTo(@NonNull Session session) {
         final ScrollView parent = requireViewByIdCompat(getView(), R.id.scrollView1);
         int height = getNormalizedBoxHeight(getResources(), scale, LOG_TAG);
-        final int pos = (session.relStartTime - conference.getFirstSessionStartsAt()) / 5 * height;
+        // TODO Replace with proper Moment based implementation as soon as possible. See code review in https://github.com/EventFahrplan/EventFahrplan/pull/347
+        int startsAtMinuteUtc = session.relStartTime - conference.getFirstSessionStartsAt();
+        int systemOffsetMinutes = Moment.getSystemOffsetMinutes();
+        // Translate start time minutes from UTC to system time zone rendered to the user.
+        int startsAtMinuteSystem = startsAtMinuteUtc - systemOffsetMinutes;
+        final int pos = startsAtMinuteSystem / 5 * height;
         MyApp.LogDebug(LOG_TAG, "position is " + pos);
         parent.post(() -> parent.scrollTo(0, pos));
         final HorizontalSnapScrollView horiz = getView().findViewById(R.id.horizScroller);

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -4,6 +4,7 @@ import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.LocalTime
+import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.temporal.ChronoField
@@ -108,11 +109,28 @@ class Moment private constructor(private val time: Instant) {
     override fun toString(): String = time.toString()
 
     companion object {
+
+        /**
+         * 1 minute = 60 seconds
+         */
+        private const val SECONDS_OF_ONE_MINUTE: Int = 60
+
         /**
          * Creates a time zone neutral [Moment] instance of current system clock.
          */
         @JvmStatic
         fun now() = Moment(Instant.now())
+
+        /**
+         * Returns the amount of minutes between the UTC and the system default time zone.
+         */
+        @JvmStatic
+        fun getSystemOffsetMinutes(): Int {
+            val dateTime = LocalDateTime.now()
+            val utcDateTime = ZonedDateTime.of(dateTime, ZoneId.of("UTC"))
+            val systemDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault())
+            return systemDateTime.offset.totalSeconds / SECONDS_OF_ONE_MINUTE
+        }
 
         /**
          * Creates a time zone neutral [Moment] instance from given [milliseconds].

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -6,6 +6,7 @@ import org.junit.Test
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
+import java.util.TimeZone
 
 class MomentTest {
 
@@ -149,4 +150,27 @@ class MomentTest {
         val momentTwo = Moment.ofEpochMilli(0).minusMinutes(-1)
         assertThat(momentTwo.toMilliseconds()).isEqualTo(60 * 1000)
     }
+
+    @Test
+    fun getSystemOffsetMinutesWithGmtPlus1() = withTimeZone("GMT+1") {
+        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(60)
+    }
+
+    @Test
+    fun getSystemOffsetMinutesWithGmt() = withTimeZone("GMT") {
+        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(0)
+    }
+
+    @Test
+    fun getSystemOffsetMinutesWithGmtMinus1() = withTimeZone("GMT-1") {
+        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(-60)
+    }
+
+    private fun withTimeZone(temporaryTimeZoneId: String, block: () -> Unit) {
+        val systemTimezone = TimeZone.getDefault()
+        TimeZone.setDefault(TimeZone.getTimeZone(temporaryTimeZoneId))
+        block()
+        TimeZone.setDefault(systemTimezone)
+    }
+
 }


### PR DESCRIPTION
# Description
- The start time minutes calculated for the session are in UTC.
- Before the vertical scroll position is calculated the minutes must be translated into the system time zone because this is used for the time line column and for positioning the session.
- Add unit tests for time zone offset calculation.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)


Resolves #346.