### PR TITLE
Revise PendingIntent composition

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -46,7 +46,6 @@ public final class AlarmReceiver extends BroadcastReceiver {
         if (intent.getAction().equals(ALARM_SESSION)) {
             String sessionId = intent.getStringExtra(BundleKeys.ALARM_SESSION_ID);
             Log.d(LOG_TAG, "sessionId = " + sessionId + ", intent = " + intent);
-            int lid = Integer.parseInt(sessionId);
             int day = intent.getIntExtra(BundleKeys.ALARM_DAY, 1);
             long when = intent
                     .getLongExtra(BundleKeys.ALARM_START_TIME, System.currentTimeMillis());
@@ -56,7 +55,7 @@ public final class AlarmReceiver extends BroadcastReceiver {
             int uniqueNotificationId = appRepository.createSessionAlarmNotificationId(sessionId);
             Intent launchIntent = MainActivity.createLaunchIntent(context, sessionId, day, uniqueNotificationId);
             PendingIntent contentIntent = PendingIntent
-                    .getActivity(context, lid, launchIntent, PendingIntent.FLAG_ONE_SHOT);
+                    .getActivity(context, DEFAULT_REQUEST_CODE, launchIntent, PendingIntent.FLAG_ONE_SHOT);
 
             NotificationHelper notificationHelper = new NotificationHelper(context);
             Uri soundUri = appRepository.readAlarmToneUri();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -6,6 +6,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.ColorDrawable;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
@@ -551,8 +552,10 @@ public class MainActivity extends BaseActivity implements
     }
 
     /**
-     * Returns an intent to be used to launch this activity.
+     * Returns a unique intent to be used to launch this activity.
      * The given parameters {@code sessionId} and {@code dayIndex} are passed along as bundle extras.
+     * The {@code sessionId} is also used to ensure this intent is unique by definition of
+     * {@link Intent#filterEquals(Intent)}.
      */
     public static Intent createLaunchIntent(
             @NonNull Context context,
@@ -561,6 +564,7 @@ public class MainActivity extends BaseActivity implements
             int notificationId
     ) {
         Intent intent = new Intent(context, MainActivity.class);
+        intent.setData(Uri.parse("fake://" + sessionId));
         intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_SESSION_ID, sessionId);
         intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_DAY_INDEX, dayIndex);
         intent.putExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_NOTIFICATION_ID, notificationId);

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -22,11 +22,9 @@ class AlarmServicesTest {
 
     @Test
     fun `scheduleSessionAlarm invokes "cancel" then "set" when "discardExisting" is "true"`() {
-        val onPendingIntentBroadcast: PendingIntentCallback = { context, requestCode, intent, flags ->
+        val onPendingIntentBroadcast: PendingIntentCallback = { context, intent ->
             assertThat(context).isEqualTo(mockContext)
-            assertThat(requestCode).isEqualTo(alarm.sessionId.toInt())
             assertIntentExtras(intent, AlarmReceiver.ALARM_SESSION)
-            assertThat(flags).isEqualTo(0)
             pendingIntent
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
@@ -37,11 +35,9 @@ class AlarmServicesTest {
 
     @Test
     fun `scheduleSessionAlarm only invokes "set" when "discardExisting" is "false"`() {
-        val onPendingIntentBroadcast: PendingIntentCallback = { context, requestCode, intent, flags ->
+        val onPendingIntentBroadcast: PendingIntentCallback = { context, intent ->
             assertThat(context).isEqualTo(mockContext)
-            assertThat(requestCode).isEqualTo(alarm.sessionId.toInt())
             assertIntentExtras(intent, AlarmReceiver.ALARM_SESSION)
-            assertThat(flags).isEqualTo(0)
             pendingIntent
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
@@ -52,11 +48,9 @@ class AlarmServicesTest {
 
     @Test
     fun `discardSessionAlarm invokes "cancel"`() {
-        val onPendingIntentBroadcast: PendingIntentCallback = { context, requestCode, intent, flags ->
+        val onPendingIntentBroadcast: PendingIntentCallback = { context, intent ->
             assertThat(context).isEqualTo(mockContext)
-            assertThat(requestCode).isEqualTo(alarm.sessionId.toInt())
             assertIntentExtras(intent, AlarmReceiver.ALARM_DELETE)
-            assertThat(flags).isEqualTo(0)
             pendingIntent
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)
@@ -67,12 +61,10 @@ class AlarmServicesTest {
 
     @Test
     fun `discardAutoUpdateAlarm invokes "cancel"`() {
-        val onPendingIntentBroadcast: PendingIntentCallback = { context, requestCode, intent, flags ->
+        val onPendingIntentBroadcast: PendingIntentCallback = { context, intent ->
             assertThat(context).isEqualTo(mockContext)
-            assertThat(requestCode).isEqualTo(0)
             assertThat(intent.component!!.className).isEqualTo(AlarmReceiver::class.java.name)
             assertThat(intent.action).isEqualTo(AlarmReceiver.ALARM_UPDATE)
-            assertThat(flags).isEqualTo(0)
             pendingIntent
         }
         val alarmServices = AlarmServices(alarmManager, onPendingIntentBroadcast)


### PR DESCRIPTION
# Description
- Stop composing `PendingIntent` with an unneeded unique `requestCode` value.
- Use `Intent#data` field to make the wrapping `PendingIntent` unique.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
