### PR TITLE
Normalize time column minutes which do not fit the time grid.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.java
@@ -3,20 +3,34 @@ package nerd.tuxmobil.fahrplan.congress.schedule;
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 
+/**
+ * Represents a segment in the time column of the main schedule view.
+ */
 class TimeSegment {
 
+    // TODO Merge definition with usage in FahrplanFragment
+    private static final int TIME_GRID_MINIMUM_SEGMENT_HEIGHT = 5;
     private static final int MINUTES_PER_HOUR = 60;
 
     private final int hour;
     private final int minute;
     private final int minutesOfTheDay;
 
+    /**
+     * The given {@code minutesOfTheDay} are normalized. The minutes value is rounded to fit
+     * into the time grid determined by {@code TIME_GRID_MINIMUM_SEGMENT_HEIGHT}.
+     */
     TimeSegment(int minutesOfTheDay) {
         hour = minutesOfTheDay / MINUTES_PER_HOUR;
         minute = minutesOfTheDay % MINUTES_PER_HOUR;
-        this.minutesOfTheDay = minutesOfTheDay;
+        int remainder = minutesOfTheDay % TIME_GRID_MINIMUM_SEGMENT_HEIGHT;
+        this.minutesOfTheDay = minutesOfTheDay - remainder;
     }
 
+    /**
+     * Returns the normalized and formatted text representing the given minutes of the day.
+     * This text is ready to be displayed in the time column.
+     */
     String getFormattedText() {
         Moment moment = Moment.now().startOfDay().plusMinutes(minutesOfTheDay);
         return DateFormatter.newInstance().getFormattedTime24Hour(moment);

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
@@ -1,0 +1,41 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.util.TimeZone
+
+@RunWith(Parameterized::class)
+class TimeSegmentFormattedTextTest(
+
+        private val minutesOfTheDay: Int,
+        private val expectedFormattedText: String
+
+) {
+
+    companion object {
+
+        val DEFAULT_TIME_ZONE: TimeZone = TimeZone.getTimeZone("GMT+1")
+
+        private fun scenarioOf(minutesOfTheDay: Int, expectedFormattedText: String) =
+                arrayOf(minutesOfTheDay, expectedFormattedText)
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: minutes = {0} -> formattedText = {1}")
+        fun data() = listOf(
+                scenarioOf(minutesOfTheDay = 0, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 120, expectedFormattedText = "03:00"),
+                scenarioOf(minutesOfTheDay = 660, expectedFormattedText = "12:00"),
+                scenarioOf(minutesOfTheDay = 1425, expectedFormattedText = "00:45")
+        )
+    }
+
+    @Test
+    fun formattedText() {
+        TimeZone.setDefault(DEFAULT_TIME_ZONE)
+        val segment = TimeSegment(minutesOfTheDay)
+        assertThat(segment.formattedText).isEqualTo(expectedFormattedText)
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
@@ -25,6 +25,16 @@ class TimeSegmentFormattedTextTest(
         @Parameterized.Parameters(name = "{index}: minutes = {0} -> formattedText = {1}")
         fun data() = listOf(
                 scenarioOf(minutesOfTheDay = 0, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 1, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 2, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 3, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 4, expectedFormattedText = "01:00"),
+                scenarioOf(minutesOfTheDay = 5, expectedFormattedText = "01:05"),
+                scenarioOf(minutesOfTheDay = 6, expectedFormattedText = "01:05"),
+                scenarioOf(minutesOfTheDay = 7, expectedFormattedText = "01:05"),
+                scenarioOf(minutesOfTheDay = 8, expectedFormattedText = "01:05"),
+                scenarioOf(minutesOfTheDay = 9, expectedFormattedText = "01:05"),
+                scenarioOf(minutesOfTheDay = 10, expectedFormattedText = "01:10"),
                 scenarioOf(minutesOfTheDay = 120, expectedFormattedText = "03:00"),
                 scenarioOf(minutesOfTheDay = 660, expectedFormattedText = "12:00"),
                 scenarioOf(minutesOfTheDay = 1425, expectedFormattedText = "00:45")

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.java
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.java
@@ -14,38 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TimeSegmentTest {
 
     @Test
-    public void getFormattedTextWith0() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"));
-
-        TimeSegment segment = new TimeSegment(0);
-        assertThat(segment.getFormattedText()).isEqualTo("01:00");
-    }
-
-    @Test
-    public void getFormattedTextWith120() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"));
-
-        TimeSegment segment = new TimeSegment(120);
-        assertThat(segment.getFormattedText()).isEqualTo("03:00");
-    }
-
-    @Test
-    public void getFormattedTextWith660() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"));
-
-        TimeSegment segment = new TimeSegment(660);
-        assertThat(segment.getFormattedText()).isEqualTo("12:00");
-    }
-
-    @Test
-    public void getFormattedTextWith1425() {
-        TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"));
-
-        TimeSegment segment = new TimeSegment(1425);
-        assertThat(segment.getFormattedText()).isEqualTo("00:45");
-    }
-
-    @Test
     public void isMatched() {
         int minute = 25;
         int msOfMinute = minute * 60 * 1000;


### PR DESCRIPTION
# Description
- It happened that the first session started at an "off" time such as 06:58. This caused the time column to render its time segments accordingly "wrong" starting with 06:58, 07:13, 07:28, ...
- Make it easier to extend `TimeSegmentFormattedTextTest`.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)

# Before
- Time column with "off" times.
![Time column with "off" times](https://user-images.githubusercontent.com/144518/103233936-a467d400-493e-11eb-9bb9-e0f66dd52a79.png)


# After
- Time column with normalized times.
![Time column with normalized times](https://user-images.githubusercontent.com/144518/103233980-c95c4700-493e-11eb-8495-c69d1ca73855.png)
