### PR TITLE
Improvements for rC3

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -164,5 +164,14 @@ fun Session.sanitize(): Session {
     if (!lang.isNullOrEmpty()) {
         lang = lang.toLowerCase()
     }
+    if (("Sendezentrum-Bühne" == track || "Sendezentrum Bühne" == track) && !type.isNullOrEmpty()) {
+        track = type
+    }
+    if ("rC3 Lounge" == room) {
+        track = "Music"
+    }
+    if (track.isNullOrEmpty() && !type.isNullOrEmpty()) {
+        track = type
+    }
     return this
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -12,7 +12,8 @@ class SessionUrlComposer @JvmOverloads constructor(
         private val serverBackEndType: String = BuildConfig.SERVER_BACKEND_TYPE,
         private val specialRoomNames: Set<String> = setOf(
                 AppRepository.ENGELSYSTEM_ROOM_NAME,
-                "ChaosTrawler" // rc3 2020
+                "ChaosTrawler", // rc3 2020
+                "rC3 Lounge", // rc3 2020
         )
 
 ) {

--- a/app/src/rc3/res/values/colors_congress.xml
+++ b/app/src/rc3/res/values/colors_congress.xml
@@ -20,12 +20,15 @@
     <color name="track_background_default_mon_r3s_rhein_vhs">#2C4EBF</color>
     <color name="track_background_default_muc_about_future">#BF3671</color>
     <color name="track_background_default_muc_hacc_about_future">#BF3671</color>
-    <color name="track_background_default_music">#334040</color>
+    <color name="track_background_default_music">#004D40</color>
+    <color name="track_background_default_podcast">#851414</color>
     <color name="track_background_default_queer">#6B2447</color>
     <color name="track_background_default_resilience">#566299</color>
     <color name="track_background_default_science">#86578C</color>
     <color name="track_background_default_security">#914452</color>
-    <color name="track_background_default_self_organized_sessions">#3056bf</color>
+    <color name="track_background_default_self_organized_sessions">#233F8C</color>
+    <color name="track_background_default_talk">#B34D00</color>
+    <color name="track_background_default_workshop">#33691E</color>
     <color name="track_background_default_zuerich_bitwaescherei">#9188BF</color>
 
     <!-- Highlight state -->
@@ -45,12 +48,15 @@
     <color name="track_background_highlight_mon_r3s_rhein_vhs">#3862F1</color>
     <color name="track_background_highlight_muc_about_future">#F1448E</color>
     <color name="track_background_highlight_muc_hacc_about_future">#F1448E</color>
-    <color name="track_background_highlight_music">#708C8C</color>
+    <color name="track_background_highlight_music">#00997F</color>
+    <color name="track_background_highlight_podcast">#B71C1C</color>
     <color name="track_background_highlight_queer">#B83E78</color>
     <color name="track_background_highlight_resilience">#8194e6</color>
     <color name="track_background_highlight_science">#cf87d9</color>
     <color name="track_background_highlight_security">#de697e</color>
     <color name="track_background_highlight_self_organized_sessions">#4174ff</color>
+    <color name="track_background_highlight_talk">#FF6F00</color>
+    <color name="track_background_highlight_workshop">#33691E</color>
     <color name="track_background_highlight_zuerich_bitwaescherei">#B7ACF1</color>
 
     <!-- Track color -->

--- a/app/src/rc3/res/xml/track_resource_names.xml
+++ b/app/src/rc3/res/xml/track_resource_names.xml
@@ -4,17 +4,25 @@
     <entry key="Art &amp; Culture">art_culture</entry>
     <entry key="B c-base">b_cbase</entry>
     <entry key="BAM franconian">bam_franconian</entry>
+    <entry key="Concert">music</entry>
     <entry key="CWTV">cwtv</entry>
     <!-- Defined in AppRepository.ENGELSYSTEM_ROOM_NAME -->
     <entry key="Engelshifts">engelshifts</entry>
     <entry key="Ethics, Society &amp; Politics">ethics_society_politics</entry>
+    <entry key="franconian.net cc music">music</entry>
+    <entry key="franconian.net talks">talk</entry>
     <entry key="HH ChaosTrawler">hh_chaostrawler</entry>
     <entry key="HH Kampnagel">hh_kampnagel</entry>
     <entry key="Hardware &amp; Making">hardware_making</entry>
+    <entry key="IT-Security">security</entry>
+    <entry key="Live-Podcast">podcast</entry>
     <entry key="MON r3s Rhein VHS">mon_r3s_rhein_vhs</entry>
     <entry key="Muc - about_future">muc_about_future</entry>
     <entry key="Muc hacc about:future">muc_hacc_about_future</entry>
+    <entry key="Music">music</entry>
     <entry key="Science">science</entry>
+    <entry key="Talk">talk</entry>
+    <entry key="Workshop">workshop</entry>
     <entry key="Zürich Bitwäscherei">zuerich_bitwaescherei</entry>
     <entry key=""></entry>
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -282,4 +282,17 @@ class SessionExtensionsTest {
         assertThat(session).isEqualTo(expected)
     }
 
+    @Test
+    fun sanitizeWithEmptyTrackAndNonEmptyType() {
+        val session = Session("").apply {
+            track = ""
+            type = "Workshop"
+        }.sanitize()
+        val expected = Session("").apply {
+            track = "Workshop"
+            type = "Workshop"
+        }
+        assertThat(session).isEqualTo(expected)
+    }
+
 }


### PR DESCRIPTION
# Description
- Prevent generation of invalid `session online` link if `url` is not present.
- Further customize session colors for `rC3`.


# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)