### PR TITLE
Automatically hide schedule update notifications when schedule changes screen is opened.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -21,6 +21,7 @@ import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
 import nerd.tuxmobil.fahrplan.congress.models.Meta;
 import nerd.tuxmobil.fahrplan.congress.models.Session;
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper;
 
 import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
 
@@ -115,6 +116,12 @@ public class ChangeListFragment extends AbstractListFragment {
         mListView.setAdapter(mAdapter);
 
         return view;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        new NotificationHelper(requireContext()).cancelScheduleUpdateNotification();
     }
 
     @MainThread

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -63,6 +63,12 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
         notificationManager.notify(id, notification)
     }
 
+    /**
+     * Cancels all existing schedule update notifications.
+     */
+    fun cancelScheduleUpdateNotification() {
+        notificationManager.cancel(SCHEDULE_UPDATE_ID)
+    }
 
     private fun createNotificationChannel(id: String, name: String, descriptionText: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
# Description
- Notifications are _"marked as read"_ and are **hidden** as soon as the user visits the schedule changes screen.
- This avoid that users have to swipe away the notification themselves.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)

# Related
- [Issue #104: Provide option to disable update notifications](https://github.com/EventFahrplan/EventFahrplan/issues/104)