### PR TITLE
Fix showing canceled sessions of former schedule updates in schedule changes screen. 

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -170,7 +170,7 @@ object AppRepository {
                     if (scheduleChanges.foundChanges) {
                         resetChangesSeenFlag()
                     }
-                    updateSessions(scheduleChanges.sessionsWithChangeFlags)
+                    updateSessions(scheduleChanges.sessionsWithChangeFlags, scheduleChanges.oldCanceledSessions)
                 },
                 onUpdateMeta = { meta ->
                     val validMeta = meta.validate()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -396,10 +396,11 @@ object AppRepository {
     fun readDateInfos() =
             readSessionsOrderedByDateUtc().toDateInfos()
 
-    private fun updateSessions(sessions: List<Session>) {
-        val sessionsDatabaseModel = sessions.toSessionsDatabaseModel()
-        val list = sessionsDatabaseModel.map { it.sessionId to it.toContentValues() }.toTypedArray()
-        sessionsDatabaseRepository.upsertSessions(*list)
+    private fun updateSessions(toBeUpdatedSessions: List<Session>, toBeDeletedSessions: List<Session> = emptyList()) {
+        val toBeUpdatedSessionsDatabaseModel = toBeUpdatedSessions.toSessionsDatabaseModel()
+        val toBeUpdated = toBeUpdatedSessionsDatabaseModel.map { it.sessionId to it.toContentValues() }
+        val toBeDeleted = toBeDeletedSessions.map { it.sessionId }
+        sessionsDatabaseRepository.updateSessions(toBeUpdated, toBeDeleted)
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -50,7 +50,7 @@ import nerd.tuxmobil.fahrplan.congress.net.ParseResult
 import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
 import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
-import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.computeSessionsWithChangeFlags
+import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.Companion.computeSessionsWithChangeFlags
 import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
 import okhttp3.OkHttpClient
@@ -166,11 +166,11 @@ object AppRepository {
                 onUpdateSessions = { sessions ->
                     val oldSessions = loadSessionsForAllDays(true)
                     val newSessions = sessions.toSessionsAppModel2().sanitize()
-                    val (sessionsWithChangeFlags, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-                    if (foundChanges) {
+                    val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+                    if (scheduleChanges.foundChanges) {
                         resetChangesSeenFlag()
                     }
-                    updateSessions(sessionsWithChangeFlags)
+                    updateSessions(scheduleChanges.sessionsWithChangeFlags)
                 },
                 onUpdateMeta = { meta ->
                     val validMeta = meta.validate()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -5,6 +5,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session as SessionAppModel
 data class ScheduleChanges private constructor(
 
         val sessionsWithChangeFlags: List<SessionAppModel>,
+        val oldCanceledSessions: List<SessionAppModel>,
         val foundChanges: Boolean
 
 ) {
@@ -29,10 +30,11 @@ data class ScheduleChanges private constructor(
             var foundChanges = false
             if (oldSessions.isEmpty()) {
                 // Do not flag sessions as "new" when sessions are loaded for the first time.
-                return ScheduleChanges(newSessions, foundChanges)
+                return ScheduleChanges(newSessions, emptyList(), foundChanges)
             }
 
             val oldNotCanceledSessions = oldSessions.filterNot { it.changedIsCanceled }.toMutableList()
+            val oldCanceledSessions = oldSessions.filter { it.changedIsCanceled }
             val sessionsWithChangeFlags = mutableListOf<SessionAppModel>()
 
             var sessionIndex = 0
@@ -117,7 +119,7 @@ data class ScheduleChanges private constructor(
                 foundChanges = true
             }
 
-            return ScheduleChanges(sessionsWithChangeFlags.toList(), foundChanges)
+            return ScheduleChanges(sessionsWithChangeFlags.toList(), oldCanceledSessions, foundChanges)
         }
 
         private data class SessionChange(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -2,143 +2,152 @@ package nerd.tuxmobil.fahrplan.congress.serialization
 
 import nerd.tuxmobil.fahrplan.congress.models.Session as SessionAppModel
 
-object ScheduleChanges {
+data class ScheduleChanges private constructor(
 
-    /**
-     * Returns a pair of a new list of sessions and a boolean flag indicating whether changes have
-     * been found. Each session is flagged as ["new"][SessionAppModel.changedIsNew],
-     * ["canceled"][SessionAppModel.changedIsCanceled] or according to the changes detected when
-     * comparing it to its equivalent from the [oldSessions] list.
-     *
-     * This function does not modify the given lists nor any of its elements.
-     */
-    fun computeSessionsWithChangeFlags(
+        val sessionsWithChangeFlags: List<SessionAppModel>,
+        val foundChanges: Boolean
 
-            newSessions: List<SessionAppModel>,
-            oldSessions: List<SessionAppModel>
+) {
 
-    ): Pair<List<SessionAppModel>, /* foundChanges */ Boolean> {
+    companion object {
 
-        var foundChanges = false
-        if (oldSessions.isEmpty()) {
-            // Do not flag sessions as "new" when sessions are loaded for the first time.
-            return newSessions to foundChanges
-        }
+        /**
+         * Returns a pair of a new list of sessions and a boolean flag indicating whether changes have
+         * been found. Each session is flagged as ["new"][SessionAppModel.changedIsNew],
+         * ["canceled"][SessionAppModel.changedIsCanceled] or according to the changes detected when
+         * comparing it to its equivalent from the [oldSessions] list.
+         *
+         * This function does not modify the given lists nor any of its elements.
+         */
+        fun computeSessionsWithChangeFlags(
 
-        val oldNotCanceledSessions = oldSessions.filterNot { it.changedIsCanceled }.toMutableList()
-        val sessionsWithChangeFlags = mutableListOf<SessionAppModel>()
+                newSessions: List<SessionAppModel>,
+                oldSessions: List<SessionAppModel>
 
-        var sessionIndex = 0
-        while (sessionIndex < newSessions.size) {
-            val newSession = newSessions[sessionIndex]
-            val oldSession = oldNotCanceledSessions.singleOrNull { oldNotCanceledSession -> newSession.sessionId == oldNotCanceledSession.sessionId }
-            if (oldSession == null) {
-                sessionsWithChangeFlags += SessionAppModel(newSession).apply { changedIsNew = true }
-                foundChanges = true
-                sessionIndex++
-                continue
+        ): ScheduleChanges {
+
+            var foundChanges = false
+            if (oldSessions.isEmpty()) {
+                // Do not flag sessions as "new" when sessions are loaded for the first time.
+                return ScheduleChanges(newSessions, foundChanges)
             }
-            if (oldSession.equalsSession(newSession)) {
-                sessionsWithChangeFlags += newSession
+
+            val oldNotCanceledSessions = oldSessions.filterNot { it.changedIsCanceled }.toMutableList()
+            val sessionsWithChangeFlags = mutableListOf<SessionAppModel>()
+
+            var sessionIndex = 0
+            while (sessionIndex < newSessions.size) {
+                val newSession = newSessions[sessionIndex]
+                val oldSession = oldNotCanceledSessions.singleOrNull { oldNotCanceledSession -> newSession.sessionId == oldNotCanceledSession.sessionId }
+                if (oldSession == null) {
+                    sessionsWithChangeFlags += SessionAppModel(newSession).apply { changedIsNew = true }
+                    foundChanges = true
+                    sessionIndex++
+                    continue
+                }
+                if (oldSession.equalsSession(newSession)) {
+                    sessionsWithChangeFlags += newSession
+                    oldNotCanceledSessions -= oldSession
+                    sessionIndex++
+                    continue
+                }
+
+                val sessionChange = SessionChange()
+
+                if (newSession.title != oldSession.title) {
+                    sessionChange.changedTitle = true
+                    foundChanges = true
+                }
+                if (newSession.subtitle != oldSession.subtitle) {
+                    sessionChange.changedSubtitle = true
+                    foundChanges = true
+                }
+                if (newSession.speakers != oldSession.speakers) {
+                    sessionChange.changedSpeakers = true
+                    foundChanges = true
+                }
+                if (newSession.lang != oldSession.lang) {
+                    sessionChange.changedLanguage = true
+                    foundChanges = true
+                }
+                if (newSession.room != oldSession.room) {
+                    sessionChange.changedRoom = true
+                    foundChanges = true
+                }
+                if (newSession.track != oldSession.track) {
+                    sessionChange.changedTrack = true
+                    foundChanges = true
+                }
+                if (newSession.recordingOptOut != oldSession.recordingOptOut) {
+                    sessionChange.changedRecordingOptOut = true
+                    foundChanges = true
+                }
+                if (newSession.day != oldSession.day) {
+                    sessionChange.changedDayIndex = true
+                    foundChanges = true
+                }
+                if (newSession.startTime != oldSession.startTime) {
+                    sessionChange.changedStartTime = true
+                    foundChanges = true
+                }
+                if (newSession.duration != oldSession.duration) {
+                    sessionChange.changedDuration = true
+                    foundChanges = true
+                }
+                sessionsWithChangeFlags += SessionAppModel(newSession).apply {
+                    changedTitle = sessionChange.changedTitle
+                    changedSubtitle = sessionChange.changedSubtitle
+                    changedSpeakers = sessionChange.changedSpeakers
+                    changedLanguage = sessionChange.changedLanguage
+                    changedRoom = sessionChange.changedRoom
+                    changedTrack = sessionChange.changedTrack
+                    changedRecordingOptOut = sessionChange.changedRecordingOptOut
+                    changedDay = sessionChange.changedDayIndex
+                    changedTime = sessionChange.changedStartTime
+                    changedDuration = sessionChange.changedDuration
+                }
                 oldNotCanceledSessions -= oldSession
                 sessionIndex++
-                continue
             }
 
-            val sessionChange = SessionChange()
+            if (oldNotCanceledSessions.isNotEmpty()) {
+                // Flag all "old" sessions which are not present in the "new" set as canceled
+                // and append them to the "new" set.
+                sessionsWithChangeFlags += oldNotCanceledSessions.map { it.toCanceledSession() }
+                foundChanges = true
+            }
 
-            if (newSession.title != oldSession.title) {
-                sessionChange.changedTitle = true
-                foundChanges = true
-            }
-            if (newSession.subtitle != oldSession.subtitle) {
-                sessionChange.changedSubtitle = true
-                foundChanges = true
-            }
-            if (newSession.speakers != oldSession.speakers) {
-                sessionChange.changedSpeakers = true
-                foundChanges = true
-            }
-            if (newSession.lang != oldSession.lang) {
-                sessionChange.changedLanguage = true
-                foundChanges = true
-            }
-            if (newSession.room != oldSession.room) {
-                sessionChange.changedRoom = true
-                foundChanges = true
-            }
-            if (newSession.track != oldSession.track) {
-                sessionChange.changedTrack = true
-                foundChanges = true
-            }
-            if (newSession.recordingOptOut != oldSession.recordingOptOut) {
-                sessionChange.changedRecordingOptOut = true
-                foundChanges = true
-            }
-            if (newSession.day != oldSession.day) {
-                sessionChange.changedDayIndex = true
-                foundChanges = true
-            }
-            if (newSession.startTime != oldSession.startTime) {
-                sessionChange.changedStartTime = true
-                foundChanges = true
-            }
-            if (newSession.duration != oldSession.duration) {
-                sessionChange.changedDuration = true
-                foundChanges = true
-            }
-            sessionsWithChangeFlags += SessionAppModel(newSession).apply {
-                changedTitle = sessionChange.changedTitle
-                changedSubtitle = sessionChange.changedSubtitle
-                changedSpeakers = sessionChange.changedSpeakers
-                changedLanguage = sessionChange.changedLanguage
-                changedRoom = sessionChange.changedRoom
-                changedTrack = sessionChange.changedTrack
-                changedRecordingOptOut = sessionChange.changedRecordingOptOut
-                changedDay = sessionChange.changedDayIndex
-                changedTime = sessionChange.changedStartTime
-                changedDuration = sessionChange.changedDuration
-            }
-            oldNotCanceledSessions -= oldSession
-            sessionIndex++
+            return ScheduleChanges(sessionsWithChangeFlags.toList(), foundChanges)
         }
 
-        if (oldNotCanceledSessions.isNotEmpty()) {
-            // Flag all "old" sessions which are not present in the "new" set as canceled
-            // and append them to the "new" set.
-            sessionsWithChangeFlags += oldNotCanceledSessions.map { it.toCanceledSession() }
-            foundChanges = true
+        private data class SessionChange(
+                var changedTitle: Boolean = false,
+                var changedSubtitle: Boolean = false,
+                var changedSpeakers: Boolean = false,
+                var changedLanguage: Boolean = false,
+                var changedRoom: Boolean = false,
+                var changedDayIndex: Boolean = false,
+                var changedTrack: Boolean = false,
+                var changedRecordingOptOut: Boolean = false,
+                var changedStartTime: Boolean = false,
+                var changedDuration: Boolean = false
+        )
+
+        private fun SessionAppModel.toCanceledSession() = SessionAppModel(this).apply { cancel() }
+
+        private fun SessionAppModel.equalsSession(session: SessionAppModel): Boolean {
+            return title == session.title &&
+                    subtitle == session.subtitle &&
+                    speakers == session.speakers &&
+                    lang == session.lang &&
+                    room == session.room &&
+                    track == session.track &&
+                    recordingOptOut == session.recordingOptOut &&
+                    day == session.day &&
+                    startTime == session.startTime &&
+                    duration == session.duration
         }
 
-        return sessionsWithChangeFlags.toList() to foundChanges
-    }
-
-    private data class SessionChange(
-            var changedTitle: Boolean = false,
-            var changedSubtitle: Boolean = false,
-            var changedSpeakers: Boolean = false,
-            var changedLanguage: Boolean = false,
-            var changedRoom: Boolean = false,
-            var changedDayIndex: Boolean = false,
-            var changedTrack: Boolean = false,
-            var changedRecordingOptOut: Boolean = false,
-            var changedStartTime: Boolean = false,
-            var changedDuration: Boolean = false
-    )
-
-    private fun SessionAppModel.toCanceledSession() = SessionAppModel(this).apply { cancel() }
-
-    private fun SessionAppModel.equalsSession(session: SessionAppModel): Boolean {
-        return title == session.title &&
-                subtitle == session.subtitle &&
-                speakers == session.speakers &&
-                lang == session.lang &&
-                room == session.room &&
-                track == session.track &&
-                recordingOptOut == session.recordingOptOut &&
-                day == session.day &&
-                startTime == session.startTime &&
-                duration == session.duration
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.serialization
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.computeSessionsWithChangeFlags
+import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.Companion.computeSessionsWithChangeFlags
 import org.junit.Test
 
 class ScheduleChangesTest {
@@ -11,27 +11,27 @@ class ScheduleChangesTest {
     fun `computeSessionsWithChangeFlags returns new sessions and false if there are no sessions`() {
         val oldSessions = emptyList<Session>()
         val newSessions = emptyList<Session>()
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(newSessions)
-        assertThat(foundChanges).isFalse()
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(newSessions)
+        assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags returns new sessions and false if old sessions are canceled`() {
         val oldSessions = listOf(createSession { changedIsCanceled = true })
         val newSessions = emptyList<Session>()
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(newSessions)
-        assertThat(foundChanges).isFalse()
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(newSessions)
+        assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if new session is present`() {
         val oldSessions = listOf(createSession(sessionId = "canceled") { changedIsCanceled = true })
         val newSessions = listOf(createSession(sessionId = "new") { changedIsCanceled = false })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession(sessionId = "new") { changedIsNew = true }))
-        assertThat(foundChanges).isTrue()
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession(sessionId = "new") { changedIsNew = true }))
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
@@ -50,141 +50,141 @@ class ScheduleChangesTest {
 
         val oldSessions = createSessions()
         val newSessions = createSessions()
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(createSessions())
-        assertThat(foundChanges).isFalse()
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(createSessions())
+        assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if title has changed`() {
         val oldSessions = listOf(createSession { title = "Old title" })
         val newSessions = listOf(createSession { title = "New title" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             title = "New title"
             changedTitle = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if subtitle has changed`() {
         val oldSessions = listOf(createSession { subtitle = "Old subtitle" })
         val newSessions = listOf(createSession { subtitle = "New subtitle" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             subtitle = "New subtitle"
             changedSubtitle = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if speakers has changed`() {
         val oldSessions = listOf(createSession { speakers = "Old speakers" })
         val newSessions = listOf(createSession { speakers = "New speakers" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             speakers = "New speakers"
             changedSpeakers = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if language has changed`() {
         val oldSessions = listOf(createSession { lang = "Old language" })
         val newSessions = listOf(createSession { lang = "New language" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             lang = "New language"
             changedLanguage = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if room has changed`() {
         val oldSessions = listOf(createSession { room = "Old room" })
         val newSessions = listOf(createSession { room = "New room" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             room = "New room"
             changedRoom = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if track has changed`() {
         val oldSessions = listOf(createSession { track = "Old track" })
         val newSessions = listOf(createSession { track = "New track" })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             track = "New track"
             changedTrack = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if recordingOptOut has changed`() {
         val oldSessions = listOf(createSession { recordingOptOut = false })
         val newSessions = listOf(createSession { recordingOptOut = true })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             recordingOptOut = true
             changedRecordingOptOut = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if dayIndex has changed`() {
         val oldSessions = listOf(createSession { day = 1 })
         val newSessions = listOf(createSession { day = 2 })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             day = 2
             changedDay = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if startTime has changed`() {
         val oldSessions = listOf(createSession { startTime = 100 })
         val newSessions = listOf(createSession { startTime = 200 })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             startTime = 200
             changedTime = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and true if duration has changed`() {
         val oldSessions = listOf(createSession { duration = 45 })
         val newSessions = listOf(createSession { duration = 60 })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             duration = 60
             changedDuration = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
     fun `computeSessionsWithChangeFlags flags new and canceled sessions, returns them and true`() {
         val oldSessions = listOf(createSession(sessionId = "s1"))
         val newSessions = listOf(createSession(sessionId = "s2"))
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(
                 createSession(sessionId = "s2") { changedIsNew = true },
                 createSession(sessionId = "s1") { changedIsCanceled = true }
         ))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     @Test
@@ -234,8 +234,8 @@ class ScheduleChangesTest {
             changedTime = false
             changedDuration = false
         })
-        val (sessions, foundChanges) = computeSessionsWithChangeFlags(newSessions, oldSessions)
-        assertThat(sessions).isEqualTo(listOf(createSession {
+        val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
+        assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             title = "New title"
             subtitle = "New subtitle"
             speakers = "New speakers"
@@ -257,7 +257,7 @@ class ScheduleChangesTest {
             changedTime = true
             changedDuration = true
         }))
-        assertThat(foundChanges).isTrue()
+        assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
     private fun createSession(sessionId: String = "1", block: Session.() -> Unit = {}) = Session(sessionId).apply(block)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -13,24 +13,27 @@ class ScheduleChangesTest {
         val newSessions = emptyList<Session>()
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(newSessions)
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
     @Test
-    fun `computeSessionsWithChangeFlags returns new sessions and false if old sessions are canceled`() {
+    fun `computeSessionsWithChangeFlags returns new sessions, canceled sessions and false if old sessions are canceled`() {
         val oldSessions = listOf(createSession { changedIsCanceled = true })
         val newSessions = emptyList<Session>()
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(newSessions)
+        assertThat(scheduleChanges.oldCanceledSessions).isEqualTo(listOf(createSession { changedIsCanceled = true }))
         assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
     @Test
-    fun `computeSessionsWithChangeFlags flags and returns new sessions and true if new session is present`() {
+    fun `computeSessionsWithChangeFlags flags and returns new sessions, canceled sessions and true if new session is present`() {
         val oldSessions = listOf(createSession(sessionId = "canceled") { changedIsCanceled = true })
         val newSessions = listOf(createSession(sessionId = "new") { changedIsCanceled = false })
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession(sessionId = "new") { changedIsNew = true }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEqualTo(listOf(createSession(sessionId = "canceled") { changedIsCanceled = true }))
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -52,6 +55,7 @@ class ScheduleChangesTest {
         val newSessions = createSessions()
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(createSessions())
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isFalse()
     }
 
@@ -64,6 +68,7 @@ class ScheduleChangesTest {
             title = "New title"
             changedTitle = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -76,6 +81,7 @@ class ScheduleChangesTest {
             subtitle = "New subtitle"
             changedSubtitle = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -88,6 +94,7 @@ class ScheduleChangesTest {
             speakers = "New speakers"
             changedSpeakers = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -100,6 +107,7 @@ class ScheduleChangesTest {
             lang = "New language"
             changedLanguage = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -112,6 +120,7 @@ class ScheduleChangesTest {
             room = "New room"
             changedRoom = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -124,6 +133,7 @@ class ScheduleChangesTest {
             track = "New track"
             changedTrack = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -136,6 +146,7 @@ class ScheduleChangesTest {
             recordingOptOut = true
             changedRecordingOptOut = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -148,6 +159,7 @@ class ScheduleChangesTest {
             day = 2
             changedDay = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -160,6 +172,7 @@ class ScheduleChangesTest {
             startTime = 200
             changedTime = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -172,6 +185,7 @@ class ScheduleChangesTest {
             duration = 60
             changedDuration = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -184,6 +198,7 @@ class ScheduleChangesTest {
                 createSession(sessionId = "s2") { changedIsNew = true },
                 createSession(sessionId = "s1") { changedIsCanceled = true }
         ))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 
@@ -257,6 +272,7 @@ class ScheduleChangesTest {
             changedTime = true
             changedDuration = true
         }))
+        assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundChanges).isTrue()
     }
 


### PR DESCRIPTION
# Description
- This fixes a bug introduced in af8c16aa9338397835d307ff029c21e9f2813532 which causes that canceled session of the last schedule update are not removed from the database. Because of this they showed up in the schedule changes screen consistently.
- See #349.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)