### PR TITLE
Ease maintaining links for various product flavors

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
         // Build configuration / feature flags
         buildConfigField "String", "SOURCE_CODE_URL", "\"https://github.com/EventFahrplan/EventFahrplan\""
         buildConfigField "String", "ISSUES_URL", "\"https://github.com/EventFahrplan/EventFahrplan/issues\""
+        buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", "\"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md\""
         buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
         buildConfigField "String", "ISSUES_URL", "\"https://github.com/EventFahrplan/EventFahrplan/issues\""
         buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", "\"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md\""
         resValue("string", "preference_hint_engelsystem_json_export_url", "\"\"")
-        buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
+        buildConfigField "String", "C3NAV_URL", "\"\""
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"
         buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "false"
@@ -102,6 +102,7 @@ android {
             buildConfigField "int", "SCHEDULE_LAST_DAY_END_DAY", "31"
             buildConfigField "boolean", "SHOW_APP_DISCLAIMER", "false"
             buildConfigField "boolean", "ENGAGE_C3NAV_APP_INSTALLATION", "true"
+            buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ android {
             dimension defaultDimension
             applicationId "info.metadude.android.cccamp.schedule"
             versionName "1.48.2-CCCamp-Edition"
+            buildConfigField "String", "GOOGLE_PLAY_URL", '"https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule"'
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/camp2019/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"http://events.ccc.de/camp/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"http://events.ccc.de/camp/2019/"'
@@ -85,6 +86,7 @@ android {
         ccc36c3 {
             dimension defaultDimension
             applicationId "info.metadude.android.congress.schedule"
+            buildConfigField "String", "GOOGLE_PLAY_URL", '"https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule"'
             buildConfigField "String", "SCHEDULE_URL", '"https://raw.githubusercontent.com/voc/36C3_schedule/master/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://events.ccc.de/congress/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"https://events.ccc.de/congress/2019/wiki"'
@@ -107,6 +109,7 @@ android {
             dimension defaultDimension
             applicationId "info.metadude.android.rc3.schedule"
             versionName "1.48.2-rC3-Edition"
+            buildConfigField "String", "GOOGLE_PLAY_URL", '"https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule"'
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/rC3/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://fahrplan.events.ccc.de/rc3/2020/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"https://rc3.world"'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ android {
         buildConfigField "String", "SOURCE_CODE_URL", "\"https://github.com/EventFahrplan/EventFahrplan\""
         buildConfigField "String", "ISSUES_URL", "\"https://github.com/EventFahrplan/EventFahrplan/issues\""
         buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", "\"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md\""
+        resValue("string", "preference_hint_engelsystem_json_export_url", "\"\"")
         buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"
@@ -104,6 +105,7 @@ android {
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
+            resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.de/36c3/shifts-json-export?key=YOUR_KEY\"")
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+36c3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/36C3/public/events/%s/feedback/new"'
         }
@@ -127,6 +129,7 @@ android {
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
+            resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.de/rc3/shifts-json-export?key=YOUR_KEY\"")
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+rc3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/rc3/public/events/%s/feedback/new"'
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,7 @@ android {
         resValue("string", "git_sha", "\"${gitSha()}\"")
 
         // Build configuration / feature flags
+        buildConfigField "String", "SOURCE_CODE_URL", "\"https://github.com/EventFahrplan/EventFahrplan\""
         buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -66,6 +66,7 @@ android {
             versionName "1.48.2-CCCamp-Edition"
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/camp2019/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"http://events.ccc.de/camp/2019/Fahrplan/events/%1$s.html"'
+            buildConfigField "String", "EVENT_WEBSITE_URL", '"http://events.ccc.de/camp/2019/"'
             buildConfigField "String", "SERVER_BACKEND_TYPE", '"frab"'
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_YEAR", "2019"
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_MONTH", "8"
@@ -85,6 +86,7 @@ android {
             applicationId "info.metadude.android.congress.schedule"
             buildConfigField "String", "SCHEDULE_URL", '"https://raw.githubusercontent.com/voc/36C3_schedule/master/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://events.ccc.de/congress/2019/Fahrplan/events/%1$s.html"'
+            buildConfigField "String", "EVENT_WEBSITE_URL", '"https://events.ccc.de/congress/2019/wiki"'
             buildConfigField "String", "SERVER_BACKEND_TYPE", '"frab"'
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_YEAR", "2019"
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_MONTH", "12"
@@ -106,6 +108,7 @@ android {
             versionName "1.48.2-rC3-Edition"
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/rC3/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://fahrplan.events.ccc.de/rc3/2020/Fahrplan/events/%1$s.html"'
+            buildConfigField "String", "EVENT_WEBSITE_URL", '"https://rc3.world"'
             buildConfigField "String", "SERVER_BACKEND_TYPE", '"frab"'
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_YEAR", "2020"
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_MONTH", "12"
@@ -147,11 +150,14 @@ android {
 
 unMock {
     keepStartingWith "libcore."
+    keepStartingWith "org.ccil.cowan.tagsoup."
     keep "android.content.ComponentName"
     keep "android.content.Intent"
     keep "android.net.Uri"
+    keepStartingWith "android.text."
     keep "android.os.Bundle"
     keep "android.util.Patterns"
+    keep "com.android.internal.util.ArrayUtils"
     keepAndRename "java.nio.charset.Charsets" to "xjava.nio.charset.Charsets"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ android {
 
         // Build configuration / feature flags
         buildConfigField "String", "SOURCE_CODE_URL", "\"https://github.com/EventFahrplan/EventFahrplan\""
+        buildConfigField "String", "ISSUES_URL", "\"https://github.com/EventFahrplan/EventFahrplan/issues\""
         buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"

--- a/app/src/ccc36c3/res/values-de/strings.xml
+++ b/app/src/ccc36c3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2019, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Eintrag im Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design von <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-de/strings.xml
+++ b/app/src/ccc36c3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2019, Leipzig, Leipziger Messe</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-de/strings.xml
+++ b/app/src/ccc36c3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2019, Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Eintrag im Google PlayStore</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-es/strings.xml
+++ b/app/src/ccc36c3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2019. Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Listado de Google PlayStore </a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Diseño por <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-es/strings.xml
+++ b/app/src/ccc36c3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2019. Leipzig, Leipziger Messe</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-es/strings.xml
+++ b/app/src/ccc36c3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2019. Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Listado de Google PlayStore </a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-fr/strings.xml
+++ b/app/src/ccc36c3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du 36C3</string>
-    <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Exhaustion de ressource. Conçu par <a href="http://bleeptrack.de">bleeptrack</a>]]></string>
     <string name="about_logo_content_description">36C3: logo d\'exhaustion de ressource</string>
     <string name="app_hardcoded_subtitle">27–30 décembre 2019, Leipzig, Leipziger Messe</string>

--- a/app/src/ccc36c3/res/values-fr/strings.xml
+++ b/app/src/ccc36c3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du 36C3</string>
-    <string name="conference_url"><![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]></string>
     <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Code source</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Exhaustion de ressource. Conçu par <a href="http://bleeptrack.de">bleeptrack</a>]]></string>

--- a/app/src/ccc36c3/res/values-fr/strings.xml
+++ b/app/src/ccc36c3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du 36C3</string>
-    <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Code source</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Exhaustion de ressource. Conçu par <a href="http://bleeptrack.de">bleeptrack</a>]]></string>
     <string name="about_logo_content_description">36C3: logo d\'exhaustion de ressource</string>

--- a/app/src/ccc36c3/res/values-ja/strings.xml
+++ b/app/src/ccc36c3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">2019年12月27日〜30日, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Resource exhaustion.  <a href="http://bleeptrack.de">bleeptrack</a>]]>によるデザイン</string>
     <string name="about_logo_content_description">36C3: Resource exhaustionのロゴ</string>
 </resources>

--- a/app/src/ccc36c3/res/values-ja/strings.xml
+++ b/app/src/ccc36c3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">2019年12月27日〜30日, Leipzig, Leipziger Messe</string>
-    <string name="conference_url"><![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]></string>
     <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Resource exhaustion.  <a href="http://bleeptrack.de">bleeptrack</a>]]>によるデザイン</string>

--- a/app/src/ccc36c3/res/values-ja/strings.xml
+++ b/app/src/ccc36c3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">2019年12月27日〜30日, Leipzig, Leipziger Messe</string>
-    <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[36C3: Resource exhaustion.  <a href="http://bleeptrack.de">bleeptrack</a>]]>によるデザイン</string>
     <string name="about_logo_content_description">36C3: Resource exhaustionのロゴ</string>

--- a/app/src/ccc36c3/res/values-nl/strings.xml
+++ b/app/src/ccc36c3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore vermelding</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Ontwerp door <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-nl/strings.xml
+++ b/app/src/ccc36c3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Bron-code</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-nl/strings.xml
+++ b/app/src/ccc36c3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Bron-code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore vermelding</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-pt/strings.xml
+++ b/app/src/ccc36c3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2019, Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Listagem da Play Store</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-pt/strings.xml
+++ b/app/src/ccc36c3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2019, Leipzig, Leipziger Messe</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-pt/strings.xml
+++ b/app/src/ccc36c3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2019, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Listagem da Play Store</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design por <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-ru/strings.xml
+++ b/app/src/ccc36c3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2019, Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Запись в Google PlayStore</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-ru/strings.xml
+++ b/app/src/ccc36c3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2019, Leipzig, Leipziger Messe</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-ru/strings.xml
+++ b/app/src/ccc36c3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание 36C3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2019, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Запись в Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion дизайн от <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-sv/strings.xml
+++ b/app/src/ccc36c3/res/values-sv/strings.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Schedule</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    "</string>
     <string name="app_hardcoded_subtitle">27–30 december 2019, Leipzig, Leipziger Messe</string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Källkod</a>]]>

--- a/app/src/ccc36c3/res/values-sv/strings.xml
+++ b/app/src/ccc36c3/res/values-sv/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">27–30 december 2019, Leipzig, Leipziger Messe</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design av <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-sv/strings.xml
+++ b/app/src/ccc36c3/res/values-sv/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">27–30 december 2019, Leipzig, Leipziger Messe</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Källkod</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values/strings.xml
+++ b/app/src/ccc36c3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
     <string name="conference_name" translatable="false">36C3</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore listing</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design by <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values/strings.xml
+++ b/app/src/ccc36c3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
     <string name="conference_name" translatable="false">36C3</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule">Google PlayStore listing</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values/strings.xml
+++ b/app/src/ccc36c3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">36C3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
     <string name="conference_name" translatable="false">36C3</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://events.ccc.de/congress/2019/wiki">https://events.ccc.de/congress/2019/wiki</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-de/strings.xml
+++ b/app/src/cccamp2019/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Eintrag im Google PlayStore</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-de/strings.xml
+++ b/app/src/cccamp2019/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-de/strings.xml
+++ b/app/src/cccamp2019/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Eintrag im Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[Design von <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-ja/strings.xml
+++ b/app/src/cccamp2019/res/values-ja/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-ja/strings.xml
+++ b/app/src/cccamp2019/res/values-ja/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStoreのリスト</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[ <a href="http://www.graphorama.de">Sven Sedivy</a>によるデザイン]]>
     </string>

--- a/app/src/cccamp2019/res/values-ja/strings.xml
+++ b/app/src/cccamp2019/res/values-ja/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStoreのリスト</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-nl/strings.xml
+++ b/app/src/cccamp2019/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Broncode</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-nl/strings.xml
+++ b/app/src/cccamp2019/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStore vermelding</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[Design by <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-nl/strings.xml
+++ b/app/src/cccamp2019/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Broncode</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStore vermelding</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-pt/strings.xml
+++ b/app/src/cccamp2019/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Acampamento 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Listagem da Play Store</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[Design por <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-pt/strings.xml
+++ b/app/src/cccamp2019/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Acampamento 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-pt/strings.xml
+++ b/app/src/cccamp2019/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Acampamento 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Listagem da Play Store</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-ru/strings.xml
+++ b/app/src/cccamp2019/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Запись в Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[Дизайн от <a href="http://www.graphorama.de">Свена Седивы</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-ru/strings.xml
+++ b/app/src/cccamp2019/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values-ru/strings.xml
+++ b/app/src/cccamp2019/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Запись в Google PlayStore</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values/strings.xml
+++ b/app/src/cccamp2019/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
     <string name="conference_name" translatable="false">Camp 2019</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStore listing</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[Design by <a href="http://www.graphorama.de">Sven Sedivy</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values/strings.xml
+++ b/app/src/cccamp2019/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
     <string name="conference_name" translatable="false">Camp 2019</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule">Google PlayStore listing</a>]]>
     </string>

--- a/app/src/cccamp2019/res/values/strings.xml
+++ b/app/src/cccamp2019/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">Camp 2019</string>
     <string name="app_hardcoded_subtitle"/>
     <string name="conference_name" translatable="false">Camp 2019</string>
-    <string name="conference_url">
-        <![CDATA[<a href="http://events.ccc.de/camp/2019/">http://events.ccc.de/camp/2019/</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
     </string>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -16,6 +16,7 @@ import androidx.fragment.app.DialogFragment;
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.extensions.Strings;
+import nerd.tuxmobil.fahrplan.congress.extensions.TextViewExtensions;
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat;
 
 import static nerd.tuxmobil.fahrplan.congress.extensions.ViewExtensions.requireViewByIdCompat;
@@ -110,9 +111,8 @@ public class AboutDialog extends DialogFragment {
         logoCopyright.setMovementMethod(movementMethod);
 
         TextView conferenceUrl = requireViewByIdCompat(view, R.id.about_conference_url_view);
-        conferenceUrl.setText(Strings.toSpanned(getString(R.string.conference_url)));
-        conferenceUrl.setMovementMethod(movementMethod);
-        conferenceUrl.setLinkTextColor(linkTextColor);
+        String websiteUrl = BuildConfig.EVENT_WEBSITE_URL;
+        TextViewExtensions.setLinkText(conferenceUrl, websiteUrl, movementMethod, linkTextColor);
 
         TextView sourceCode = requireViewByIdCompat(view, R.id.about_source_code_view);
         sourceCode.setText(Strings.toSpanned(getString(R.string.source_code)));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -125,9 +125,9 @@ public class AboutDialog extends DialogFragment {
         issues.setLinkTextColor(linkTextColor);
 
         TextView googlePlayStore = requireViewByIdCompat(view, R.id.about_google_play_view);
-        googlePlayStore.setText(Strings.toSpanned(getString(R.string.google_play_store)));
-        googlePlayStore.setMovementMethod(movementMethod);
-        googlePlayStore.setLinkTextColor(linkTextColor);
+        String googlePlayUrl = BuildConfig.GOOGLE_PLAY_URL;
+        String googlePlayListingTitle = getString(R.string.about_google_play_listing);
+        TextViewExtensions.setLinkText(googlePlayStore, googlePlayUrl, googlePlayListingTitle, movementMethod, linkTextColor);
 
         TextView dataPrivacyStatement = requireViewByIdCompat(view, R.id.about_data_privacy_statement_view);
         dataPrivacyStatement.setText(Strings.toSpanned(getString(R.string.about_data_privacy_statement)));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -130,9 +130,9 @@ public class AboutDialog extends DialogFragment {
         TextViewExtensions.setLinkText(googlePlayStore, googlePlayUrl, googlePlayListingTitle, movementMethod, linkTextColor);
 
         TextView dataPrivacyStatement = requireViewByIdCompat(view, R.id.about_data_privacy_statement_view);
-        dataPrivacyStatement.setText(Strings.toSpanned(getString(R.string.about_data_privacy_statement)));
-        dataPrivacyStatement.setMovementMethod(movementMethod);
-        dataPrivacyStatement.setLinkTextColor(linkTextColor);
+        String dataPrivacyStatementGermanUrl = BuildConfig.DATA_PRIVACY_STATEMENT_DE_URL;
+        String dataPrivacyStatementGermanTitle = getString(R.string.about_data_privacy_statement_german);
+        TextViewExtensions.setLinkText(dataPrivacyStatement, dataPrivacyStatementGermanUrl, dataPrivacyStatementGermanTitle, movementMethod, linkTextColor);
 
         // Build information
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -115,9 +115,9 @@ public class AboutDialog extends DialogFragment {
         TextViewExtensions.setLinkText(conferenceUrl, websiteUrl, movementMethod, linkTextColor);
 
         TextView sourceCode = requireViewByIdCompat(view, R.id.about_source_code_view);
-        sourceCode.setText(Strings.toSpanned(getString(R.string.source_code)));
-        sourceCode.setMovementMethod(movementMethod);
-        sourceCode.setLinkTextColor(linkTextColor);
+        String sourceCodeUrl = BuildConfig.SOURCE_CODE_URL;
+        String sourceCodeTitle = getString(R.string.about_source_code);
+        TextViewExtensions.setLinkText(sourceCode, sourceCodeUrl, sourceCodeTitle, movementMethod, linkTextColor);
 
         TextView issues = requireViewByIdCompat(view, R.id.about_issues_view);
         issues.setText(Strings.toSpanned(getString(R.string.issues)));

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -120,9 +120,9 @@ public class AboutDialog extends DialogFragment {
         TextViewExtensions.setLinkText(sourceCode, sourceCodeUrl, sourceCodeTitle, movementMethod, linkTextColor);
 
         TextView issues = requireViewByIdCompat(view, R.id.about_issues_view);
-        issues.setText(Strings.toSpanned(getString(R.string.issues)));
-        issues.setMovementMethod(movementMethod);
-        issues.setLinkTextColor(linkTextColor);
+        String issuesUrl = BuildConfig.ISSUES_URL;
+        String issuesTitle = getString(R.string.about_issues_or_feature_requests);
+        TextViewExtensions.setLinkText(issues, issuesUrl, issuesTitle, movementMethod, linkTextColor);
 
         TextView googlePlayStore = requireViewByIdCompat(view, R.id.about_google_play_view);
         String googlePlayUrl = BuildConfig.GOOGLE_PLAY_URL;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensions.kt
@@ -1,6 +1,13 @@
+@file:JvmName("TextViewExtensions")
+
 package nerd.tuxmobil.fahrplan.congress.extensions
 
+import android.text.method.MovementMethod
+import android.text.style.URLSpan
 import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.core.text.set
+import androidx.core.text.toSpannable
 import androidx.core.view.isVisible
 
 /**
@@ -17,3 +24,20 @@ var TextView.textOrHide: CharSequence
             isVisible = true
         }
     }
+
+/**
+ * Sets the given [plainLinkUrl] and the optional [urlTitle] as a clickable link to this [TextView].
+ */
+@JvmOverloads
+fun TextView.setLinkText(
+        plainLinkUrl: String,
+        urlTitle: String? = null,
+        movementMethod: MovementMethod,
+        @ColorInt linkTextColor: Int,
+) {
+    val title = urlTitle ?: plainLinkUrl
+    val linkText = title.toSpannable().apply { set(0, title.length, URLSpan(plainLinkUrl)) }
+    setText(linkText, TextView.BufferType.SPANNABLE)
+    setMovementMethod(movementMethod)
+    setLinkTextColor(linkTextColor)
+}

--- a/app/src/main/res/layout-port/about_dialog.xml
+++ b/app/src/main/res/layout-port/about_dialog.xml
@@ -141,7 +141,7 @@
                 android:paddingTop="10dp"
                 android:singleLine="false"
                 style="@style/TextViewLinks"
-                tools:text="@string/source_code"/>
+                tools:text="https://github.com/EventFahrplan/EventFahrplan"/>
 
         <TextView
                 android:id="@+id/about_issues_view"

--- a/app/src/main/res/layout-port/about_dialog.xml
+++ b/app/src/main/res/layout-port/about_dialog.xml
@@ -196,7 +196,7 @@
                 android:paddingTop="10dp"
                 android:singleLine="false"
                 style="@style/TextViewLinks"
-                android:text="@string/about_data_privacy_statement"/>
+                android:text="@string/about_data_privacy_statement_german"/>
 
         <include
                 layout="@layout/horizontal_line"/>

--- a/app/src/main/res/layout/about_dialog_land.xml
+++ b/app/src/main/res/layout/about_dialog_land.xml
@@ -140,7 +140,7 @@
                 android:paddingTop="10dp"
                 android:singleLine="false"
                 style="@style/TextViewLinks"
-                tools:text="@string/source_code"/>
+                tools:text="https://github.com/EventFahrplan/EventFahrplan"/>
 
         <TextView
                 android:id="@+id/about_issues_view"

--- a/app/src/main/res/layout/about_dialog_land.xml
+++ b/app/src/main/res/layout/about_dialog_land.xml
@@ -195,7 +195,7 @@
                 android:paddingTop="10dp"
                 android:singleLine="false"
                 style="@style/TextViewLinks"
-                android:text="@string/about_data_privacy_statement"/>
+                android:text="@string/about_data_privacy_statement_german"/>
 
         <include
                 layout="@layout/horizontal_line"/>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
 	</string>
+    <string name="about_source_code">Quellcode</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>
 	</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
 	</string>
+    <string name="about_google_play_listing">Eintrag bei Google Play</string>
     <string name="about_source_code">Quellcode</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,9 +85,7 @@
 		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
-	</string>
+    <string name="about_data_privacy_statement_german">Datenschutzerklärung</string>
     <string name="about_google_play_listing">Eintrag bei Google Play</string>
     <string name="about_issues_or_feature_requests">Fehlermeldungen und Wünsche</string>
     <string name="about_source_code">Quellcode</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,10 +89,8 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
 	</string>
     <string name="about_google_play_listing">Eintrag bei Google Play</string>
+    <string name="about_issues_or_feature_requests">Fehlermeldungen und Wünsche</string>
     <string name="about_source_code">Quellcode</string>
-    <string name="issues">
-		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>
-	</string>
     <string name="today">heute</string>
     <string name="schedule_parsing_error_generic">Unbekannter Fehler beim Parsen des Fahrplans</string>
     <string name="schedule_parsing_error_with_version">Fehler beim Parsen der Fahrplan-Version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,6 +109,7 @@
     <string name="usage">Nota: Presione unos segundos en una conferencia para poner alarma</string>
     <string name="OK">De acuerdo</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaración de privacidad de datos (Alemán)</a>]]></string>
+    <string name="about_google_play_listing">Listado de Google Play</string>
     <string name="about_source_code">Source code</string>
     <string name="menu_item_title_share_session_text">como texto</string>
     <string name="menu_item_title_share_session_json">como JSON (por Chaosflix)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -107,7 +107,7 @@
     <string name="uptodate">El calendario está actualizado</string>
     <string name="usage">Nota: Presione unos segundos en una conferencia para poner alarma</string>
     <string name="OK">De acuerdo</string>
-    <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaración de privacidad de datos (Alemán)</a>]]></string>
+    <string name="about_data_privacy_statement_german">Declaración de privacidad de datos (Alemán)</string>
     <string name="about_google_play_listing">Listado de Google Play</string>
     <string name="about_issues_or_feature_requests">Problemas o sugerencias</string>
     <string name="about_source_code">Source code</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -109,6 +109,7 @@
     <string name="usage">Nota: Presione unos segundos en una conferencia para poner alarma</string>
     <string name="OK">De acuerdo</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaración de privacidad de datos (Alemán)</a>]]></string>
+    <string name="about_source_code">Source code</string>
     <string name="menu_item_title_share_session_text">como texto</string>
     <string name="menu_item_title_share_session_json">como JSON (por Chaosflix)</string>
     <string name="share_as_text">Compartir como texto</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -41,7 +41,6 @@
     <string name="certificate_error_title">No se pudo agregar el certificado</string>
     <string name="session_duration"><xliff:g example="45" id="duration">%1$d</xliff:g> min.</string>
     <string name="invalid_url">URL no válida</string>
-    <string name="issues"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problemas o sugerencias</a>]]></string>
     <string name="session_list_item_language_portuguese_content_description">Portugués</string>
     <string name="session_list_item_language_english_content_description">Inglés</string>
     <string name="session_list_item_language_german_content_description">Alemán</string>
@@ -110,6 +109,7 @@
     <string name="OK">De acuerdo</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaración de privacidad de datos (Alemán)</a>]]></string>
     <string name="about_google_play_listing">Listado de Google Play</string>
+    <string name="about_issues_or_feature_requests">Problemas o sugerencias</string>
     <string name="about_source_code">Source code</string>
     <string name="menu_item_title_share_session_text">como texto</string>
     <string name="menu_item_title_share_session_json">como JSON (por Chaosflix)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,6 +68,7 @@
     <string name="general_settings">Général</string>
     <string name="no_favorites">Aucune conférence dans les favoris</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Déclaration de protection des données (en allemand)</a>]]></string>
+    <string name="about_source_code">Code source</string>
     <string name="choose_alarm_time">Choisissez l’heure du rappel</string>
     <string name="session_details_section_title_links">Liens</string>
     <string name="session_details_section_title_session_online">Événement en ligne</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,7 +67,7 @@
     <string name="starred_sessions">Favoris</string>
     <string name="general_settings">Général</string>
     <string name="no_favorites">Aucune conférence dans les favoris</string>
-    <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Déclaration de protection des données (en allemand)</a>]]></string>
+    <string name="about_data_privacy_statement_german">Déclaration de protection des données (en allemand)</string>
     <string name="about_google_play_listing">Page sur le Play Google</string>
     <string name="about_issues_or_feature_requests">Problèmes ou demande de fonctionnalités</string>
     <string name="about_source_code">Code source</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,6 +68,7 @@
     <string name="general_settings">Général</string>
     <string name="no_favorites">Aucune conférence dans les favoris</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Déclaration de protection des données (en allemand)</a>]]></string>
+    <string name="about_google_play_listing">Page sur le Play Google</string>
     <string name="about_source_code">Code source</string>
     <string name="choose_alarm_time">Choisissez l’heure du rappel</string>
     <string name="session_details_section_title_links">Liens</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -69,6 +69,7 @@
     <string name="no_favorites">Aucune conférence dans les favoris</string>
     <string name="about_data_privacy_statement"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Déclaration de protection des données (en allemand)</a>]]></string>
     <string name="about_google_play_listing">Page sur le Play Google</string>
+    <string name="about_issues_or_feature_requests">Problèmes ou demande de fonctionnalités</string>
     <string name="about_source_code">Code source</string>
     <string name="choose_alarm_time">Choisissez l’heure du rappel</string>
     <string name="session_details_section_title_links">Liens</string>
@@ -144,5 +145,4 @@
     <string name="validation_error_url_without_query">URL <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> sans la partie requête.</string>
     <string name="validation_error_url_with_incomplete_query">URL <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> avec partie requête incomplète.</string>
     <string name="validation_error_url_without_api_key">URL <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> sans clé API.</string>
-    <string name="issues"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problèmes ou demande de fonctionnalités</a>]]></string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="OK">OK</string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Informativa sulla protezione dei dati (Tedesco)</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">Informativa sulla protezione dei dati (Tedesco)</string>
     <string name="about_issues_or_feature_requests">Assistenza o suggerimento di nuove funzionalità</string>
     <string name="add_to_calendar_failed">Impossibile aggiungere un evento al calendario</string>
     <string name="alarm_time_title_10_minutes_before">10 minuti prima</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -4,6 +4,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Informativa sulla protezione dei dati (Tedesco)</a>]]>
     </string>
+    <string name="about_issues_or_feature_requests">Assistenza o suggerimento di nuove funzionalità</string>
     <string name="add_to_calendar_failed">Impossibile aggiungere un evento al calendario</string>
     <string name="alarm_time_title_10_minutes_before">10 minuti prima</string>
     <string name="alarm_time_title_15_minutes_before">15 minuti prima</string>
@@ -43,7 +44,6 @@
     <string name="fahrplan">Programma</string>
     <string name="general_settings">Generale</string>
     <string name="invalid_url">URL erroneo</string>
-    <string name="issues"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Assistenza o suggerimento di nuove funzionalità</a>]]></string>
     <string name="session_list_item_language_english_content_description">Inglese</string>
     <string name="session_list_item_language_german_content_description">Tedesco</string>
     <string name="session_list_item_language_removed_content_description">L\'informazione sulla lingua è stata rimossa</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -86,6 +86,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">データプライバシーステートメント（ドイツ語）</a>]]>
     </string>
+    <string name="about_google_play_listing">Google Playのリスト</string>
     <string name="about_source_code">ソースコード</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">問題または機能のリクエスト</a>]]>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -83,9 +83,7 @@
         Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
         Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
     </string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">データプライバシーステートメント（ドイツ語）</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">データプライバシーステートメント（ドイツ語）</string>
     <string name="about_google_play_listing">Google Playのリスト</string>
     <string name="about_issues_or_feature_requests">問題または機能のリクエスト</string>
     <string name="about_source_code">ソースコード</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -87,10 +87,8 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">データプライバシーステートメント（ドイツ語）</a>]]>
     </string>
     <string name="about_google_play_listing">Google Playのリスト</string>
+    <string name="about_issues_or_feature_requests">問題または機能のリクエスト</string>
     <string name="about_source_code">ソースコード</string>
-    <string name="issues">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">問題または機能のリクエスト</a>]]>
-    </string>
     <string name="today">今日</string>
     <string name="schedule_parsing_error_generic">スケジュールの解析中に不明なエラーが発生しました</string>
     <string name="schedule_parsing_error_with_version">スケジュールバージョン％sの解析エラー %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -86,6 +86,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">データプライバシーステートメント（ドイツ語）</a>]]>
     </string>
+    <string name="about_source_code">ソースコード</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">問題または機能のリクエスト</a>]]>
     </string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -84,6 +84,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
 	</string>
+    <string name="about_source_code">Bron-code</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>
 	</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -84,6 +84,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
 	</string>
+    <string name="about_google_play_listing">Google Play vermelding</string>
     <string name="about_source_code">Bron-code</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -86,9 +86,6 @@
 	</string>
     <string name="about_google_play_listing">Google Play vermelding</string>
     <string name="about_source_code">Bron-code</string>
-    <string name="issues">
-		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Fehlermeldungen und Wünsche</a>]]>
-	</string>
     <string name="today">vandaag</string>
     <string name="schedule_parsing_error_generic">Onbekende fout tijdens verwerken tijdschema</string>
     <string name="schedule_parsing_error_with_version">Verwerkings fout voor tijdschema versie %s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -81,9 +81,6 @@
 		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Datenschutzerklärung</a>]]>
-	</string>
     <string name="about_google_play_listing">Google Play vermelding</string>
     <string name="about_source_code">Bron-code</string>
     <string name="today">vandaag</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -85,9 +85,7 @@
 		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage e TraceDroid
 	</string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaração de privacidade (Alemão)</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">Declaração de privacidade (Alemão)</string>
     <string name="about_google_play_listing">Listagem da Google Play</string>
     <string name="about_issues_or_feature_requests">Problemas ou pedidos de funcionalidades</string>
     <string name="about_source_code">Código fonte</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaração de privacidade (Alemão)</a>]]>
     </string>
+    <string name="about_source_code">Código fonte</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problemas ou pedidos de funcionalidades</a>]]>
 	</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -89,10 +89,8 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaração de privacidade (Alemão)</a>]]>
     </string>
     <string name="about_google_play_listing">Listagem da Google Play</string>
+    <string name="about_issues_or_feature_requests">Problemas ou pedidos de funcionalidades</string>
     <string name="about_source_code">Código fonte</string>
-    <string name="issues">
-		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problemas ou pedidos de funcionalidades</a>]]>
-	</string>
     <string name="today">hoje</string>
     <string name="schedule_parsing_error_generic">Erro desconhecido ao processar cronograma</string>
     <string name="schedule_parsing_error_with_version">Erro ao processar versão do cronograma %s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Declaração de privacidade (Alemão)</a>]]>
     </string>
+    <string name="about_google_play_listing">Listagem da Google Play</string>
     <string name="about_source_code">Código fonte</string>
     <string name="issues">
 		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problemas ou pedidos de funcionalidades</a>]]>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -85,9 +85,7 @@
         Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
         Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
     </string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Политика конфиденциальности (German)</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">Политика конфиденциальности (German)</string>
     <string name="about_google_play_listing">Запись в Google Play</string>
     <string name="about_issues_or_feature_requests">Сообщить о проблеме или запросить функционал</string>
     <string name="about_source_code">Исходный код</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Политика конфиденциальности (German)</a>]]>
     </string>
+    <string name="about_google_play_listing">Запись в Google Play</string>
     <string name="about_source_code">Исходный код</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Сообщить о проблеме или запросить функционал</a>]]>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -88,6 +88,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Политика конфиденциальности (German)</a>]]>
     </string>
+    <string name="about_source_code">Исходный код</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Сообщить о проблеме или запросить функционал</a>]]>
     </string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -89,10 +89,8 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Политика конфиденциальности (German)</a>]]>
     </string>
     <string name="about_google_play_listing">Запись в Google Play</string>
+    <string name="about_issues_or_feature_requests">Сообщить о проблеме или запросить функционал</string>
     <string name="about_source_code">Исходный код</string>
-    <string name="issues">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Сообщить о проблеме или запросить функционал</a>]]>
-    </string>
     <string name="today">сегодня</string>
     <string name="schedule_parsing_error_generic">Неизвестная ошибка при разборе расписания</string>
     <string name="schedule_parsing_error_with_version">Ошибка разбора для версии расписания %s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -102,9 +102,7 @@
     <string name="schedule_updated_to">
         Uppdaterade till <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g>
     </string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Sekretesspolicy (Tyska)</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">Sekretesspolicy (Tyska)</string>
     <string name="about_google_play_listing">Google Play</string>
     <string name="about_issues_or_feature_requests">Problem eller funktionsförfrågningar</string>
     <string name="about_source_code">Källkod</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -105,6 +105,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Sekretesspolicy (Tyska)</a>]]>
     </string>
+    <string name="about_google_play_listing">Google Play</string>
     <string name="about_source_code">Källkod</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problem eller funktionsförfrågningar</a>]]>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -106,10 +106,8 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Sekretesspolicy (Tyska)</a>]]>
     </string>
     <string name="about_google_play_listing">Google Play</string>
+    <string name="about_issues_or_feature_requests">Problem eller funktionsförfrågningar</string>
     <string name="about_source_code">Källkod</string>
-    <string name="issues">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problem eller funktionsförfrågningar</a>]]>
-    </string>
     <string name="today">Idag</string>
     <string name="alarms_empty">
         Det finns inga alarm att visa. Vänligen notera att du

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -105,6 +105,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Sekretesspolicy (Tyska)</a>]]>
     </string>
+    <string name="about_source_code">Källkod</string>
     <string name="issues">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Problem eller funktionsförfrågningar</a>]]>
     </string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -89,9 +89,6 @@
         preference_key_engelsystem_json_export_url
     </string>
     <string name="preference_default_value_engelsystem_json_export_url" translatable="false"/>
-    <string name="preference_hint_engelsystem_json_export_url" translatable="false">
-        https://engelsystem.de/rc3/shifts-json-export?key=YOUR_KEY
-    </string>
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[In order to see your shifts please enter your <u>personal</u> URL here.<br/><br/>
         1. Login to your Engelsystem account.<br/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Data privacy statement (German)</a>]]>
     </string>
     <string name="about_google_play_listing">Google Play listing</string>
+    <string name="about_issues_or_feature_requests">Issues or feature requests</string>
     <string name="about_source_code">Source code</string>
     <string name="copyright_notes" translatable="false">
         Copyright 2013-2021 johnjohndoe.
@@ -101,9 +102,6 @@
         \nContributions from 0x5ubt13, Adriano Pereira Junior, Akarsh Seggemu, Andrea Marziali, Andy Scherzinger, Andreas Schildbach, Animesh Verma, bashtian, bjoernb, Björn Olsson Jarl, ButterflyOfFire, cacarrara, Caio Volpato, cketti, codingcatgirl, entropynil, ideadapt, Joergi, koelnkalkverbot, Larissa Yasin, ligi, Mateus Baptista, Matthias Hunstock, MichaelRocks, Nghiem Xuan Hien, NiciDieNase, Noemis, Omicron, Poschi, Sjors van Mierlo, Stefan Medack, SubOptimal, Teeranai.P, Torsten Grote, Victor Herasme, Vladimir Alabov, Yanicka.
         \nPortions Copyright 2008-2011 The K-9 Dog Walkers and 2006-2013 the Android Open Source Project.
     </string>
-    <string name="issues">
-		<![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/issues">Issues or feature requests</a>]]>
-	</string>
     <string name="today">today</string>
     <string name="schedule_parsing_error_generic">Unknown error while parsing schedule</string>
     <string name="schedule_parsing_error_with_version">Parsing error for schedule version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Data privacy statement (German)</a>]]>
     </string>
+    <string name="about_google_play_listing">Google Play listing</string>
     <string name="about_source_code">Source code</string>
     <string name="copyright_notes" translatable="false">
         Copyright 2013-2021 johnjohndoe.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="about_data_privacy_statement">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Data privacy statement (German)</a>]]>
     </string>
+    <string name="about_source_code">Source code</string>
     <string name="copyright_notes" translatable="false">
         Copyright 2013-2021 johnjohndoe.
         \nCopyright 2011-2015 Daniel Dorau.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,9 +90,7 @@
 		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, OkHttp, SnackEngage, TraceDroid
 	</string>
-    <string name="about_data_privacy_statement">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md">Data privacy statement (German)</a>]]>
-    </string>
+    <string name="about_data_privacy_statement_german">Data privacy statement (German)</string>
     <string name="about_google_play_listing">Google Play listing</string>
     <string name="about_issues_or_feature_requests">Issues or feature requests</string>
     <string name="about_source_code">Source code</string>

--- a/app/src/rc3/res/values-de/strings.xml
+++ b/app/src/rc3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2020, Online</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
     </string>

--- a/app/src/rc3/res/values-de/strings.xml
+++ b/app/src/rc3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2020, Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Eintrag im Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3. Design von <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-de/strings.xml
+++ b/app/src/rc3/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Fahrplan</string>
     <string name="app_hardcoded_subtitle">27.-30. Dezember 2020, Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Quellcode</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Eintrag im Google PlayStore</a>]]>
     </string>

--- a/app/src/rc3/res/values-es/strings.xml
+++ b/app/src/rc3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rc3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2020. Online</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
     </string>

--- a/app/src/rc3/res/values-es/strings.xml
+++ b/app/src/rc3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rc3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2020. Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Listado de Google PlayStore </a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rc3. Diseño por <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-es/strings.xml
+++ b/app/src/rc3/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rc3 Calendario</string>
     <string name="app_hardcoded_subtitle">27 - 30 de Diciembre de 2020. Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Listado de Google PlayStore </a>]]>
     </string>

--- a/app/src/rc3/res/values-fr/strings.xml
+++ b/app/src/rc3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du rc3</string>
-    <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[rc3. Conçu par <a href="https://kreatur.works">KREATUR WORKS</a>]]></string>
     <string name="about_logo_content_description">rc3 logo</string>
     <string name="app_hardcoded_subtitle">27–30 décembre 2020, Online</string>

--- a/app/src/rc3/res/values-fr/strings.xml
+++ b/app/src/rc3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du rc3</string>
-    <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Code source</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[rc3. Conçu par <a href="https://kreatur.works">KREATUR WORKS</a>]]></string>
     <string name="about_logo_content_description">rc3 logo</string>

--- a/app/src/rc3/res/values-fr/strings.xml
+++ b/app/src/rc3/res/values-fr/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Programme du rc3</string>
-    <string name="conference_url"><![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]></string>
     <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Code source</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Page sur le PlayStore Google</a>]]></string>
     <string name="copyright_logo"><![CDATA[rc3. Conçu par <a href="https://kreatur.works">KREATUR WORKS</a>]]></string>

--- a/app/src/rc3/res/values-ja/strings.xml
+++ b/app/src/rc3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">2020年12月27日〜30日, Online</string>
-    <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[rC3. <a href="https://kreatur.works">KREATUR WORKS</a>]]>によるデザイン</string>
     <string name="about_logo_content_description">rC3 のロゴ</string>
 </resources>

--- a/app/src/rc3/res/values-ja/strings.xml
+++ b/app/src/rc3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">2020年12月27日〜30日, Online</string>
-    <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[rC3. <a href="https://kreatur.works">KREATUR WORKS</a>]]>によるデザイン</string>
     <string name="about_logo_content_description">rC3 のロゴ</string>

--- a/app/src/rc3/res/values-ja/strings.xml
+++ b/app/src/rc3/res/values-ja/strings.xml
@@ -2,7 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">2020年12月27日〜30日, Online</string>
-    <string name="conference_url"><![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]></string>
     <string name="source_code"><![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">ソースコード</a>]]></string>
     <string name="google_play_store"><![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStoreのリスト</a>]]></string>
     <string name="copyright_logo"><![CDATA[rC3. <a href="https://kreatur.works">KREATUR WORKS</a>]]>によるデザイン</string>

--- a/app/src/rc3/res/values-nl/strings.xml
+++ b/app/src/rc3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore vermelding</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3. Ontwerp door <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-nl/strings.xml
+++ b/app/src/rc3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Bron-code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore vermelding</a>]]>
     </string>

--- a/app/src/rc3/res/values-nl/strings.xml
+++ b/app/src/rc3/res/values-nl/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Bron-code</a>]]>
     </string>

--- a/app/src/rc3/res/values-pt/strings.xml
+++ b/app/src/rc3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma rC3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2020, Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Listagem da Play Store</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3. Design por <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-pt/strings.xml
+++ b/app/src/rc3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma rC3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2020, Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Listagem da Play Store</a>]]>
     </string>

--- a/app/src/rc3/res/values-pt/strings.xml
+++ b/app/src/rc3/res/values-pt/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Cronograma rC3</string>
     <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2020, Online</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Código fonte</a>]]>
     </string>

--- a/app/src/rc3/res/values-ru/strings.xml
+++ b/app/src/rc3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание rC3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2020, Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Запись в Google PlayStore</a>]]>
     </string>

--- a/app/src/rc3/res/values-ru/strings.xml
+++ b/app/src/rc3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание rC3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2020, Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Запись в Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3 дизайн от <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-ru/strings.xml
+++ b/app/src/rc3/res/values-ru/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">Pасписание rC3</string>
     <string name="app_hardcoded_subtitle">27.-30-го декабря 2020, Online</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Исходный код</a>]]>
     </string>

--- a/app/src/rc3/res/values-sv/strings.xml
+++ b/app/src/rc3/res/values-sv/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">27–30 december 2020, Online</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Källkod</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore</a>]]>
     </string>

--- a/app/src/rc3/res/values-sv/strings.xml
+++ b/app/src/rc3/res/values-sv/strings.xml
@@ -2,9 +2,6 @@
 <resources>
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">27–30 december 2020, Online</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3. Design av <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/rc3/res/values-sv/strings.xml
+++ b/app/src/rc3/res/values-sv/strings.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">rC3 Schedule</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    "</string>
     <string name="app_hardcoded_subtitle">27–30 december 2020, Online</string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Källkod</a>]]>

--- a/app/src/rc3/res/values/strings.xml
+++ b/app/src/rc3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
     <string name="conference_name" translatable="false">rC3</string>
-    <string name="conference_url">
-        <![CDATA[<a href="https://rc3.world">https://rc3.world</a>]]>
-    </string>
     <string name="source_code">
         <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
     </string>

--- a/app/src/rc3/res/values/strings.xml
+++ b/app/src/rc3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
     <string name="conference_name" translatable="false">rC3</string>
-    <string name="source_code">
-        <![CDATA[<a href="https://github.com/EventFahrplan/EventFahrplan">Source code</a>]]>
-    </string>
     <string name="google_play_store">
         <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore listing</a>]]>
     </string>

--- a/app/src/rc3/res/values/strings.xml
+++ b/app/src/rc3/res/values/strings.xml
@@ -3,9 +3,6 @@
     <string name="app_name">rC3 Schedule</string>
     <string name="app_hardcoded_subtitle">December 27.-30. 2020, Online</string>
     <string name="conference_name" translatable="false">rC3</string>
-    <string name="google_play_store">
-        <![CDATA[<a href="https://play.google.com/store/apps/details?id=info.metadude.android.rc3.schedule">Google PlayStore listing</a>]]>
-    </string>
     <string name="copyright_logo">
         <![CDATA[rC3. Design by <a href="https://kreatur.works">KREATUR WORKS</a>]]>
     </string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
@@ -1,0 +1,56 @@
+package nerd.tuxmobil.fahrplan.congress.extensions
+
+import android.text.Spannable
+import android.text.method.MovementMethod
+import android.text.style.URLSpan
+import android.widget.TextView
+import androidx.core.text.set
+import androidx.core.text.toSpannable
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import org.junit.Test
+import org.mockito.ArgumentCaptor
+
+class TextViewExtensionsTest {
+
+    @Test
+    fun `setLinkText applies formatted link text with title and MovementMethod and LinkTextColor`() {
+        val textView = mock<TextView>()
+        val movementMethod = mock<MovementMethod>()
+        val plainLinkUrl = "https://example.com"
+        val urlTitle = "Example website"
+        textView.setLinkText(
+                plainLinkUrl = plainLinkUrl,
+                urlTitle = urlTitle,
+                movementMethod = movementMethod,
+                linkTextColor = 23
+        )
+        val linkTextSpannableCaptor = ArgumentCaptor.forClass(Spannable::class.java)
+        verify(textView).setText(linkTextSpannableCaptor.capture(), any())
+        verify(textView).movementMethod = movementMethod
+        verify(textView).setLinkTextColor(23)
+        val linkText = urlTitle.toSpannable().apply { set(0, urlTitle.length, URLSpan(plainLinkUrl)) }
+        assertThat(linkTextSpannableCaptor.value.toString()).isEqualTo(linkText.toString())
+    }
+
+    @Test
+    fun `setLinkText applies formatted link text without title and MovementMethod and LinkTextColor`() {
+        val textView = mock<TextView>()
+        val movementMethod = mock<MovementMethod>()
+        val plainLinkUrl = "https://example.com"
+        textView.setLinkText(
+                plainLinkUrl = plainLinkUrl,
+                movementMethod = movementMethod,
+                linkTextColor = 23
+        )
+        val linkTextSpannableCaptor = ArgumentCaptor.forClass(Spannable::class.java)
+        verify(textView).setText(linkTextSpannableCaptor.capture(), any())
+        verify(textView).movementMethod = movementMethod
+        verify(textView).setLinkTextColor(23)
+        val linkText = plainLinkUrl.toSpannable().apply { set(0, plainLinkUrl.length, URLSpan(plainLinkUrl)) }
+        assertThat(linkTextSpannableCaptor.value.toString()).isEqualTo(linkText.toString())
+    }
+
+}


### PR DESCRIPTION
# Description
- Revise configuration of links (event website, source code, Google Play, issues, data privacy statement)  in the _About_ screen (see screenshot) ...
  - to make it less an effort to add a new product flavor.
  - to prevent manual errors when editing the same information over and over.
  - to ease translation of product flavor specific strings.
- Allow to configure custom URLs for _Engelsystem_ JSON export hint in _Settings_ screen (see screenshot) per product flavor.
- Avoid applying customized _c3nav_ URL to all product flavors.

# Affected screens
![F1](https://user-images.githubusercontent.com/144518/103484668-f7cf9b80-4df0-11eb-8500-847a5e7e6bdd.png) ![F2](https://user-images.githubusercontent.com/144518/103484670-f8683200-4df0-11eb-9aea-95d2af13ccfe.png)

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10