### PR TITLE
Prevent schedule changes dialog opens when returning from schedule changes screen

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -122,6 +122,7 @@ public class ChangeListFragment extends AbstractListFragment {
     public void onResume() {
         super.onResume();
         new NotificationHelper(requireContext()).cancelScheduleUpdateNotification();
+        appRepository.updateScheduleChangesSeen(true);
     }
 
     @MainThread


### PR DESCRIPTION
# Description
+ In this scenario the user has not tapped the schedule changes notification but went directly into the schedule changes screen by tapping the respective toolbar icon.
+ Assuming that the user has consumed the schedule changes there is no reason to show the schedule changes dialog in such a situation.
+ A new notification and a dialog will still be shown if new schedule data has been fetched in the meantime.

# Before
- Describe the behavior before the change.

https://user-images.githubusercontent.com/144518/104714489-8ca59380-5725-11eb-9158-f2f738eb6061.mp4



# After
- Describe the behavior after the change.

https://user-images.githubusercontent.com/144518/104714520-94fdce80-5725-11eb-8c91-96a2616dd346.mp4

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10

# Travis CI
- Please ignore the build. CI is currently out of service.