### PR TITLE
Migrate Conference class to use Moment class.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -1,3 +1,5 @@
+@file:JvmName("SessionExtensions")
+
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
@@ -13,6 +15,14 @@ fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
         shiftRoomIndexBy(1)
     }
     return this
+}
+
+/**
+ * Returns a moment based on the start time of this session.
+ */
+fun Session.toStartsAtMoment(): Moment {
+    require(dateUTC > 0) { "Field 'dateUTC' is 0." }
+    return Moment.ofEpochMilli(dateUTC)
 }
 
 fun Session.toDateInfo(): DateInfo = DateInfo(day, Moment.parseDate(date))

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
@@ -53,6 +53,7 @@ data class Conference(
             require(sessions.isNotEmpty()) { "Empty list of sessions." }
             val firstSession = sessions.first()
             val first = Moment.ofEpochMilli(firstSession.dateUTC)
+            // TODO Replace with firstSession.toStartsAtMoment() once Session#relStartTime is no longer used.
             val endingLatest = sessions.endingLatest()
             val endsAt = endingLatest.endsAtDateUtc
             val last = Moment.ofEpochMilli(endsAt)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
-import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -23,33 +22,20 @@ import org.threeten.bp.ZoneOffset
 // TODO Use Moment class, merge with ConferenceTimeFrame class?
 data class Conference(
 
-        var firstSessionStartsAt: Int = 0,
-        var lastSessionEndsAt: Int = 0,
-        var timeZoneOffset: ZoneOffset? = null
+        val firstSessionStartsAt: Moment,
+        val lastSessionEndsAt: Moment,
+        var timeZoneOffset: ZoneOffset? = null,
+        val spansMultipleDays: Boolean
 
 ) {
-
-    /**
-     * Calculates the [firstSessionStartsAt] and [lastSessionEndsAt] time stamps for the
-     * given sorted sessions. Further, the [timeZoneOffset] is derived from the first session.
-     *
-     * @param sessions     Sorted list of sessions.
-     */
-    @Deprecated("Make ofSessions public and use it and make Conference immutable as soon as Moment is used.")
-    fun calculateTimeFrame(sessions: List<Session>) {
-        val conference = ofSessions(sessions)
-        firstSessionStartsAt = conference.firstSessionStartsAt
-        lastSessionEndsAt = conference.lastSessionEndsAt
-        timeZoneOffset = conference.timeZoneOffset
-    }
 
     companion object {
 
         /**
          * Creates a [Conference] from the given chronologically sorted [sessions].
          */
-        @VisibleForTesting
-        internal fun ofSessions(sessions: List<Session>): Conference {
+        @JvmStatic
+        fun ofSessions(sessions: List<Session>): Conference {
             require(sessions.isNotEmpty()) { "Empty list of sessions." }
             val firstSession = sessions.first()
             val first = Moment.ofEpochMilli(firstSession.dateUTC)
@@ -60,10 +46,12 @@ data class Conference(
             val minutesToAdd = if (first.monthDay == last.monthDay) 0 else MINUTES_OF_ONE_DAY
             // Here we are assuming all sessions have the same time zone offset.
             val timeZoneOffset = firstSession.timeZoneOffset
+            val veryLast = last.plusMinutes(minutesToAdd.toLong())
             return Conference(
-                firstSessionStartsAt = first.minuteOfDay,
-                lastSessionEndsAt = last.minuteOfDay + minutesToAdd,
-                timeZoneOffset = timeZoneOffset
+                firstSessionStartsAt = first,
+                lastSessionEndsAt = veryLast,
+                timeZoneOffset = timeZoneOffset,
+                spansMultipleDays = minutesToAdd > 0
             )
         }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -36,7 +36,6 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import org.ligi.tracedroid.logging.Log;
-import org.threeten.bp.Duration;
 import org.threeten.bp.ZoneId;
 
 import java.util.Arrays;
@@ -90,7 +89,6 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     private static final int CONTEXT_MENU_ITEM_ID_SHARE_TEXT = 5;
     private static final int CONTEXT_MENU_ITEM_ID_SHARE_JSON = 6;
 
-    public static final int ONE_DAY = (int) Duration.ofDays(1).toMinutes();
     public static final int FIFTEEN_MINUTES = 15;
     public static final int BOX_HEIGHT_MULTIPLIER = 3;
 
@@ -98,7 +96,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private LayoutInflater inflater;
 
-    private final Conference conference = new Conference();
+    private Conference conference;
 
     private AppRepository appRepository;
 
@@ -261,7 +259,9 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
             }
             intent.removeExtra(BundleKeys.BUNDLE_KEY_SESSION_ALARM_SESSION_ID); // jump to given sessionId only once
         }
-        fillTimes();
+        if (conference != null) {
+            fillTimes();
+        }
 
         appRepository.setOnSessionsChangeListener(onSessionsChangeListener);
     }
@@ -287,7 +287,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
         if (!sessionsOfDay.isEmpty()) {
             // TODO: Move this to AppRepository and include the result in ScheduleData
-            conference.calculateTimeFrame(sessionsOfDay);
+            conference = Conference.ofSessions(sessionsOfDay);
             MyApp.LogDebug(LOG_TAG, "Conference = " + conference);
         }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -417,8 +417,9 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         }
 
         Moment nowMoment = Moment.now();
-        ScrollAmountCalculator calculator = new ScrollAmountCalculator(Logging.get(), MyApp.dateInfos, scheduleData, conference);
-        int scrollAmount = calculator.calculateScrollAmount(nowMoment, currentDayIndex, boxHeight, columnIndex);
+        ScrollAmountCalculator scrollAmountCalculator = new ScrollAmountCalculator(Logging.get());
+        int scrollAmount = scrollAmountCalculator.calculateScrollAmount(
+                conference, MyApp.dateInfos, scheduleData, nowMoment, currentDayIndex, boxHeight, columnIndex);
 
         final int pos = scrollAmount;
         final ScrollView scrollView = requireViewByIdCompat(layoutRootView, R.id.scrollView1);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -28,7 +28,7 @@ data class LayoutCalculator @JvmOverloads constructor(
 
     fun calculateLayoutParams(roomData: RoomData, conference: Conference): Map<Session, LinearLayout.LayoutParams> {
         val sessions = roomData.sessions
-        var previousSessionEndsAt: Int = conference.firstSessionStartsAt
+        var previousSessionEndsAt: Int = conference.firstSessionStartsAt.minuteOfDay
         var startTime: Int
         var margin: Int
         var previousSession: Session? = null

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -3,8 +3,8 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import info.metadude.android.eventfahrplan.commons.logging.Logging
-import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.threeten.bp.Duration
@@ -74,7 +74,7 @@ data class LayoutCalculator @JvmOverloads constructor(
     private fun getStartTime(session: Session, previousSessionEndsAt: Int): Int {
         var startTime: Int
         if (session.dateUTC > 0) {
-            startTime = Moment.ofEpochMilli(session.dateUTC).minuteOfDay
+            startTime = session.toStartsAtMoment().minuteOfDay
             if (startTime < previousSessionEndsAt) {
                 startTime += Duration.ofDays(1).toMinutes().toInt()
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -4,6 +4,7 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.BOX_HEIGHT_MULTIPLIER
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.FIFTEEN_MINUTES
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.ONE_DAY
@@ -71,4 +72,16 @@ internal class ScrollAmountCalculator(
         }
         return scrollAmount
     }
+
+    fun calculateScrollAmount(conference: Conference, session: Session, boxHeight: Int): Int {
+        // TODO Replace with proper Moment based implementation as soon as possible. See code review in https://github.com/EventFahrplan/EventFahrplan/pull/347
+        val startsAtMinuteUtc = session.relStartTime - conference.firstSessionStartsAt
+        val systemOffsetMinutes = Moment.getSystemOffsetMinutes()
+        // Translate start time minutes from UTC to system time zone rendered to the user.
+        val startsAtMinuteSystem = startsAtMinuteUtc - systemOffsetMinutes
+        val pos = startsAtMinuteSystem / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight
+        logging.e(javaClass.simpleName, "relStartTime=${session.relStartTime}, height = $boxHeight, pos = $pos")
+        return pos
+    }
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -15,10 +15,7 @@ import nerd.tuxmobil.fahrplan.congress.schedule.TimeSegment.Companion.TIME_GRID_
  */
 internal class ScrollAmountCalculator(
 
-        private val logging: Logging,
-        private val dateInfos: DateInfos,
-        private val scheduleData: ScheduleData,
-        private val conference: Conference
+        private val logging: Logging
 
 ) {
 
@@ -29,7 +26,15 @@ internal class ScrollAmountCalculator(
     /**
      * Returns the amount to be scrolled. Valid values are 0 and positive integers.
      */
-    fun calculateScrollAmount(nowMoment: Moment, currentDayIndex: Int, boxHeight: Int, columnIndex: Int): Int {
+    fun calculateScrollAmount(
+        conference: Conference,
+        dateInfos: DateInfos,
+        scheduleData: ScheduleData,
+        nowMoment: Moment,
+        currentDayIndex: Int,
+        boxHeight: Int,
+        columnIndex: Int
+    ): Int {
         var time = conference.firstSessionStartsAt
         var printTime = time
         var scrollAmount = 0

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -27,12 +27,6 @@ internal class TimeSegment private constructor(
          */
         const val TIME_GRID_MINIMUM_SEGMENT_HEIGHT = 5
 
-        @Deprecated("Use TimeSegment.ofMoment", replaceWith = ReplaceWith("TimeSegment.ofMoment()"))
-        @JvmStatic
-        fun ofMinutesOfTheDay(minutesOfTheDay: Int): TimeSegment {
-            return ofMoment(Moment.now().startOfDay().plusMinutes(minutesOfTheDay.toLong()))
-        }
-
         @JvmStatic
         fun ofMoment(moment: Moment) = TimeSegment(moment)
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -144,6 +144,23 @@ class SessionExtensionsTest {
     }
 
     @Test
+    fun `toMoment returns Moment object if dateUTC has proper value`() {
+        val session = Session("").apply { dateUTC = 1582963200000L }
+        val moment = session.toStartsAtMoment()
+        assertThat(moment).isEqualTo(Moment.ofEpochMilli(1582963200000L))
+    }
+
+    @Test
+    fun `toMoment throws exception if dateUTC is 0`() {
+        val session = Session("")
+        try {
+            session.toStartsAtMoment()
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("Field 'dateUTC' is 0.")
+        }
+    }
+
+    @Test
     fun toDateInfo() {
         val session = Session("")
         session.date = "2015-08-13"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -9,14 +9,7 @@ import org.threeten.bp.ZoneOffset
 class ConferenceTest {
 
     @Test
-    fun `default values`() {
-        val conference = Conference()
-        assertThat(conference.firstSessionStartsAt).isEqualTo(0)
-        assertThat(conference.lastSessionEndsAt).isEqualTo(0)
-    }
-
-    @Test
-    fun `calculateTimeFrame throws exception if empty list is passed`() {
+    fun `ofSessions throws exception if empty list is passed`() {
         try {
             createConference(*emptyList<Session>().toTypedArray())
         } catch (e: IllegalArgumentException) {
@@ -25,39 +18,40 @@ class ConferenceTest {
     }
 
     @Test
-    fun `calculateTimeFrame with frab data spanning multiple days`() {
+    fun `ofSessions with frab data spanning multiple days`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536504300000L, ZoneOffset.of("+02:00")) // 2018-09-09T16:45:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
-        assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
-        assertThat(lastSessionEndsAt).isEqualTo(17 * 60 + 15 - 2 * 60 + MINUTES_OF_ONE_DAY) // -> 17:15 -2h zone offset + day switch
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
+        val firstSessionStartsAtMinutes = firstSessionStartsAt.minuteOfDay
+        val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
+        val lastSessionEndsAtMinutes = lastSessionEndsAt.minuteOfDay + minutesToAdd
+        assertThat(firstSessionStartsAtMinutes).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
+        assertThat(lastSessionEndsAtMinutes).isEqualTo(17 * 60 + 15 - 2 * 60 + MINUTES_OF_ONE_DAY) // -> 17:15 -2h zone offset + day switch
         assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
     @Test
-    fun `calculateTimeFrame with frab data spanning a single day`() {
+    fun `ofSessions with frab data spanning a single day`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
-        assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
-        assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset, _) = createConference(opening, closing)
+        assertThat(firstSessionStartsAt.minuteOfDay).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
+        assertThat(lastSessionEndsAt.minuteOfDay).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
         assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
     @Test
-    fun `calculateTimeFrame with frab data spanning a single day in non-chronological order`() {
+    fun `ofSessions with frab data spanning a single day in non-chronological order`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536328800000L, ZoneOffset.of("+02:00")) // 2018-09-07T16:00:00+02:00
         val middle = createSession("Middle", duration = 20, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing, middle)
-        assertThat(firstSessionStartsAt).isEqualTo(16 * 60 - 2 * 60) // 16:00h -2h zone offset = 14:00h
-        assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset, _) = createConference(opening, closing, middle)
+        assertThat(firstSessionStartsAt.minuteOfDay).isEqualTo(16 * 60 - 2 * 60) // 16:00h -2h zone offset = 14:00h
+        assertThat(lastSessionEndsAt.minuteOfDay).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
         assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
-    private fun createConference(vararg sessions: Session) = Conference().apply {
-        calculateTimeFrame(listOf(*sessions))
-    }
+    private fun createConference(vararg sessions: Session) = Conference.ofSessions(sessions.toList())
 
     private fun createSession(sessionId: String, duration: Int, dateUtc: Long, timeZoneOffset: ZoneOffset) = Session(sessionId).apply {
         this.dateUTC = dateUtc

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -26,43 +26,43 @@ class ConferenceTest {
 
     @Test
     fun `calculateTimeFrame with frab data spanning multiple days`() {
-        val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", duration = 30, dateUtc = 1536504300000L) // 2018-09-09T16:45:00+02:00
+        val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
+        val closing = createSession("Closing", duration = 30, dateUtc = 1536504300000L, ZoneOffset.of("+02:00")) // 2018-09-09T16:45:00+02:00
         val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
         assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
         assertThat(lastSessionEndsAt).isEqualTo(17 * 60 + 15 - 2 * 60 + MINUTES_OF_ONE_DAY) // -> 17:15 -2h zone offset + day switch
-        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
     @Test
     fun `calculateTimeFrame with frab data spanning a single day`() {
-        val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L) // 2018-09-07T18:00:00+02:00
+        val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
+        val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
         val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
         assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
         assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
-        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
     @Test
     fun `calculateTimeFrame with frab data spanning a single day in non-chronological order`() {
-        val opening = createSession("Opening", duration = 30, dateUtc = 1536328800000L) // 2018-09-07T16:00:00+02:00
-        val middle = createSession("Middle", duration = 20, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L) // 2018-09-07T18:00:00+02:00
+        val opening = createSession("Opening", duration = 30, dateUtc = 1536328800000L, ZoneOffset.of("+02:00")) // 2018-09-07T16:00:00+02:00
+        val middle = createSession("Middle", duration = 20, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
+        val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
         val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing, middle)
         assertThat(firstSessionStartsAt).isEqualTo(16 * 60 - 2 * 60) // 16:00h -2h zone offset = 14:00h
         assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
-        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
     private fun createConference(vararg sessions: Session) = Conference().apply {
         calculateTimeFrame(listOf(*sessions))
     }
 
-    private fun createSession(sessionId: String, duration: Int, dateUtc: Long) = Session(sessionId).apply {
+    private fun createSession(sessionId: String, duration: Int, dateUtc: Long, timeZoneOffset: ZoneOffset) = Session(sessionId).apply {
         this.dateUTC = dateUtc
         this.duration = duration
-        this.timeZoneOffset = ZoneOffset.ofTotalSeconds(3600)
+        this.timeZoneOffset = timeZoneOffset
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -31,6 +31,32 @@ class ConferenceTest {
     }
 
     @Test
+    fun `ofSessions with frab data spanning from winter to summer time`() {
+        val opening = createSession("Opening", duration = 30, dateUtc = 1616857200000L, ZoneOffset.of("+01:00")) // 2021-03-27T16:00:00+01:00
+        val closing = createSession("Closing", duration = 30, dateUtc = 1616940000000L, ZoneOffset.of("+02:00")) // 2021-03-28T16:00:00+02:00
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
+        val firstSessionStartsAtMinutes = firstSessionStartsAt.minuteOfDay
+        val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
+        val lastSessionEndsAtMinutes = lastSessionEndsAt.minuteOfDay + minutesToAdd
+        assertThat(firstSessionStartsAtMinutes).isEqualTo(16 * 60 - 1 * 60) // 16:00h -1h zone offset = 15:00
+        assertThat(lastSessionEndsAtMinutes).isEqualTo(16 * 60 - 2 * 60 + 30 + MINUTES_OF_ONE_DAY) // -> 16:30 -2h zone offset + day switch = 14:30
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
+    }
+
+    @Test
+    fun `ofSessions with frab data spanning from summer to winter time`() {
+        val opening = createSession("Opening", duration = 30, dateUtc = 1635602400000L, ZoneOffset.of("+02:00")) // 2021-10-30T16:00:00+02:00
+        val closing = createSession("Closing", duration = 30, dateUtc = 1635692400000L, ZoneOffset.of("+01:00")) // 2021-10-31T16:00:00+01:00
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
+        val firstSessionStartsAtMinutes = firstSessionStartsAt.minuteOfDay
+        val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
+        val lastSessionEndsAtMinutes = lastSessionEndsAt.minuteOfDay + minutesToAdd
+        assertThat(firstSessionStartsAtMinutes).isEqualTo(16 * 60 - 2 * 60) // 16:00h -1h zone offset = 14:00
+        assertThat(lastSessionEndsAtMinutes).isEqualTo(16 * 60 - 1 * 60 + 30 + MINUTES_OF_ONE_DAY) // -> 16:30 -1h zone offset + day switch = 15:30
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00")) // spanning is not supported yet, see Conference class
+    }
+
+    @Test
     fun `ofSessions with frab data spanning a single day`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.NoLogging
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
@@ -22,7 +23,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if room index preceeds the valid column indices`() {
         val session = createFirstSession()
         val scrollAmount = createCalculator(session).calculateScrollAmount(
-                nowMoment = Moment.ofEpochMilli(session.dateUTC),
+                nowMoment = session.toStartsAtMoment(),
                 currentDayIndex = session.day,
                 columnIndex = -1
         )
@@ -33,7 +34,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if room index exceeds the valid column indices`() {
         val session = createFirstSession()
         val scrollAmount = createCalculator(session).calculateScrollAmount(
-                nowMoment = Moment.ofEpochMilli(session.dateUTC),
+                nowMoment = session.toStartsAtMoment(),
                 currentDayIndex = session.day,
                 columnIndex = COLUMN_INDEX + 1
         )
@@ -44,7 +45,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if conference has not started but it will today`() {
         val session = createFirstSession()
         val scrollAmount = createCalculator(session).calculateScrollAmount(
-                nowMoment = Moment.ofEpochMilli(session.dateUTC).minusMinutes(1),
+                nowMoment = session.toStartsAtMoment().minusMinutes(1),
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(0)
@@ -54,7 +55,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if conference starts now`() {
         val session = createFirstSession()
         val scrollAmount = createCalculator(session).calculateScrollAmount(
-                nowMoment = Moment.ofEpochMilli(session.dateUTC),
+                nowMoment = session.toStartsAtMoment(),
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(0)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
@@ -1,0 +1,89 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
+import info.metadude.android.eventfahrplan.network.temporal.DateParser
+import nerd.tuxmobil.fahrplan.congress.NoLogging
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.threeten.bp.ZoneOffset
+
+/**
+ * Covers ScrollAmountCalculator.calculateScrollAmount(Conference, Session, int).
+ * Ensures correct behavior with different time zone offsets.
+ */
+@RunWith(Parameterized::class)
+class ScrollAmountCalculatorTimeZoneOffsetTest(
+
+        private val deviceTimeZoneId: String,
+        private val sessionStartsAtDateTimeIso8601: String,
+        private val conferenceStartedHoursAgo: Int,
+        private val expectedScrollAmount: Int
+
+) {
+
+    companion object {
+
+        private const val BOX_HEIGHT = 34 // Pixel 2 portrait mode
+        private val timeZoneOffsets = -12..14
+
+        private fun scenarioOf(
+                deviceTimeZoneId: String,
+                sessionStartsAtDateTimeIso8601: String,
+                startedHoursAgo: Int,
+                expectedScrollAmount: Int
+        ) =
+                arrayOf(deviceTimeZoneId, sessionStartsAtDateTimeIso8601, startedHoursAgo, expectedScrollAmount)
+
+        private fun startsNowScenarioOf(deviceTimeZoneId: String) =
+                scenarioOf(deviceTimeZoneId, "2019-08-21T11:00:00+02:00", startedHoursAgo = 0, expectedScrollAmount = 0)
+
+        private fun startedBeforeScenarioOf(deviceTimeZoneId: String) =
+                scenarioOf(deviceTimeZoneId, "2019-08-22T02:00:00+02:00", startedHoursAgo = 7, expectedScrollAmount = 2856)
+
+        private fun winterSummerScenarioOf(deviceTimeZoneId: String) =
+                scenarioOf(deviceTimeZoneId, "2021-03-28T06:00:00+02:00", startedHoursAgo = 7, expectedScrollAmount = 2856)
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: device = {0}, sessionStartsAt = {1}, conferenceStartedHoursAgo = {2} -> scrollAmount = {3}")
+        fun data() = timeZoneOffsets.map { startsNowScenarioOf(deviceTimeZoneId = "GMT$it") } +
+                timeZoneOffsets.map { startedBeforeScenarioOf(deviceTimeZoneId = "GMT$it") } +
+                timeZoneOffsets.map { winterSummerScenarioOf(deviceTimeZoneId = "GMT$it") }
+
+    }
+
+    @Test
+    fun calculateScrollAmount() {
+        withTimeZone(deviceTimeZoneId) {
+            val targetSessionStartsAtDateTime = DateParser.getDateTime(sessionStartsAtDateTimeIso8601)
+            val targetSessionStartsAt = Moment.ofEpochMilli(targetSessionStartsAtDateTime)
+            val targetSession = createBaseSession(sessionId = "target", moment = targetSessionStartsAt)
+
+            val sessions = if (conferenceStartedHoursAgo == 0) {
+                listOf(targetSession)
+            } else {
+                val firstSessionStartsAt = targetSessionStartsAt.minusHours(conferenceStartedHoursAgo.toLong())
+                val firstSession = createBaseSession(sessionId = "first", moment = firstSessionStartsAt)
+                listOf(firstSession, targetSession)
+            }
+
+            val conference = Conference.ofSessions(sessions)
+            val scrollAmount = ScrollAmountCalculator(NoLogging).calculateScrollAmount(conference, targetSession, BOX_HEIGHT)
+            assertThat(scrollAmount).isEqualTo(expectedScrollAmount)
+        }
+    }
+
+    private fun createBaseSession(sessionId: String, moment: Moment) = Session(sessionId).apply {
+        day = 0
+        date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
+        dateUTC = moment.toMilliseconds()
+        startTime = moment.minuteOfDay
+        relStartTime = moment.minuteOfDay // This might now always be the case, see ParserTask.parseFahrplan
+        duration = 60
+        room = "Main hall"
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameterTest.kt
@@ -4,6 +4,7 @@ import androidx.annotation.LayoutRes
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.After
 import org.junit.Before
@@ -36,7 +37,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters without -now- view parameter`() {
         val moment = Moment.ofEpochMilli(1582963200000L) // February 29, 2020 08:00:00 AM GMT)
-        val nowMoment = Moment.ofEpochMilli(createSession(moment).dateUTC)
+        val nowMoment = createSession(moment).toStartsAtMoment()
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, dayIndex)
         assertThat(parameters.size).isEqualTo(4)
@@ -49,7 +50,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters including one -now- view parameter`() {
         val moment = Moment.ofEpochMilli(1582963200000L) // February 29, 2020 08:00:00 AM GMT)
-        val nowMoment = Moment.ofEpochMilli(createSession(moment).dateUTC).plusMinutes(30)
+        val nowMoment = createSession(moment).toStartsAtMoment().plusMinutes(30)
         val dayIndex = 1 // represents today
         val parameters = parametersOf(nowMoment, moment, dayIndex)
         assertThat(parameters.size).isEqualTo(4)
@@ -62,7 +63,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters for a session crossing the intra-day limit`() {
         val moment = Moment.ofEpochMilli(1583019000000L) // February 29, 2020 11:30:00 PM GMT
-        val nowMoment = Moment.ofEpochMilli(createSession(moment).dateUTC)
+        val nowMoment = createSession(moment).toStartsAtMoment()
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, dayIndex)
         assertThat(parameters.size).isEqualTo(4)

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -1,10 +1,10 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
+import org.threeten.bp.Duration
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.LocalTime
-import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.temporal.ChronoField
@@ -100,6 +100,13 @@ class Moment private constructor(private val time: Instant) {
      */
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
 
+    /**
+     * Returns the duration in minutes between this and the given [moment].
+     */
+    fun minutesUntil(moment: Moment): Long {
+        return Duration.between(time, moment.time).toMinutes()
+    }
+
     override fun equals(other: Any?): Boolean {
         return time == (other as? Moment)?.time
     }
@@ -140,17 +147,6 @@ class Moment private constructor(private val time: Instant) {
          */
         @JvmStatic
         fun now() = Moment(Instant.now())
-
-        /**
-         * Returns the amount of minutes between the UTC and the system default time zone.
-         */
-        @JvmStatic
-        fun getSystemOffsetMinutes(): Int {
-            val dateTime = LocalDateTime.now()
-            val utcDateTime = ZonedDateTime.of(dateTime, ZoneId.of("UTC"))
-            val systemDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault())
-            return systemDateTime.offset.totalSeconds / SECONDS_OF_ONE_MINUTE
-        }
 
         /**
          * Creates a time zone neutral [Moment] instance from given [milliseconds].

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -5,7 +5,6 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MIL
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.toMoment
-import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.threeten.bp.LocalDate
@@ -127,6 +126,16 @@ class MomentTest {
     }
 
     @Test
+    fun durationUntil() {
+        val momentOne = Moment.now()
+        val momentTwo = momentOne.plusMinutes(1)
+
+        assertThat(momentOne.minutesUntil(momentOne)).isEqualTo(0)
+        assertThat(momentOne.minutesUntil(momentTwo)).isEqualTo(1)
+        assertThat(momentTwo.minutesUntil(momentOne)).isEqualTo(-1)
+    }
+
+    @Test
     fun plusSeconds() {
         val momentOne = Moment.ofEpochMilli(0).plusSeconds(1)
         assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_SECOND.toLong())
@@ -160,21 +169,6 @@ class MomentTest {
 
         val momentTwo = Moment.ofEpochMilli(0).minusMinutes(-1)
         assertThat(momentTwo.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_MINUTE.toLong())
-    }
-
-    @Test
-    fun getSystemOffsetMinutesWithGmtPlus1() = withTimeZone("GMT+1") {
-        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(60)
-    }
-
-    @Test
-    fun getSystemOffsetMinutesWithGmt() = withTimeZone("GMT") {
-        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(0)
-    }
-
-    @Test
-    fun getSystemOffsetMinutesWithGmtMinus1() = withTimeZone("GMT-1") {
-        assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(-60)
     }
 
 }


### PR DESCRIPTION
# Description
- Here, the `Conference` class is refactored to use the `Moment` class for its fields. Since all date/time information and conversion functions are encapsulated in the `Moment` class this refactoring reduces the complexity in other classes such as `Conference`. Also, the temptation to do "custom calculation" on the base of minutes is reduced.
- Further, wrong scrolling behavior for certain **time zone** scenarios is fixed in `ScrollAmountCalculator#calculateScrollAmount(conference: Conference, session: Session, boxHeight: Int)`. See earlier work discussed [here](https://github.com/EventFahrplan/EventFahrplan/pull/347#discussion_r535141680).
- As a side effect `FahrplanFragment#scrollTo` is simplified by the extraction of `ScrollAmountCalculator#calculateScrollAmount(conference: Conference, session: Session, boxHeight: Int)`.
- Increased test coverage, see `ScrollAmountCalculatorTimeZoneOffsetTest`, `ConferenceTest`, `TimeTextViewParameterTest`.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)

# Related
- [Issue #346: Tapping a session alarm notification scrolls the associated session out of view](https://github.com/EventFahrplan/EventFahrplan/issues/346)
- [Pull request #347: Fix scrolling to session when tapping session alarm notification.](https://github.com/EventFahrplan/EventFahrplan/issues/347)

# Travis CI
- Please ignore the build. CI is currently out of service. :no_entry: 