### PR TITLE
Render time information sensitive to the original time zone of the event.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
@@ -196,7 +196,7 @@ public abstract class SessionsAdapter extends ArrayAdapter<Session> {
             if (day != lastDay) {
                 lastDay = day;
                 if (numDays > 1) {
-                    String formattedDate = DateFormatter.newInstance().getFormattedDate(l.dateUTC);
+                    String formattedDate = DateFormatter.newInstance().getFormattedDate(l.dateUTC, l.timeZoneOffset);
                     String dayDateSeparator = String.format(daySeparator, day, formattedDate);
                     mSeparatorStrings.add(dayDateSeparator);
                     mSeparatorsSet.add(index + sepCount);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -51,9 +51,9 @@ class ChangeListAdapter internal constructor(
             speakers.textOrHide = session.formattedSpeakers
             lang.textOrHide = session.lang
             lang.contentDescription = session.getLanguageContentDescription(context)
-            val dayText = DateFormatter.newInstance().getFormattedDate(session.dateUTC)
+            val dayText = DateFormatter.newInstance().getFormattedDate(session.dateUTC, session.timeZoneOffset)
             day.textOrHide = dayText
-            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC)
+            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
             room.textOrHide = session.room
             val durationText = context.getString(R.string.session_duration, session.duration)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -42,6 +42,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         speakers = speakers,
         startTime = startTime, // minutes since day start
         subtitle = subtitle,
+        timeZoneOffset = timeZoneOffset, // seconds
         title = title,
         track = track,
         type = type,
@@ -83,6 +84,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.speakers = speakers
     session.startTime = startTime // minutes since day start
     session.subtitle = subtitle
+    session.timeZoneOffset = timeZoneOffset // seconds
     session.title = title
     session.track = track
     session.type = type
@@ -126,6 +128,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.speakers = speakers
     session.startTime = startTime // minutes since day start
     session.subtitle = subtitle
+    session.timeZoneOffset = timeZoneOffset // seconds
     session.title = title
     session.track = track
     session.type = type

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.threeten.bp.ZoneOffset
 import info.metadude.android.eventfahrplan.database.models.Highlight as HighlightDatabaseModel
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
@@ -42,7 +43,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         speakers = speakers,
         startTime = startTime, // minutes since day start
         subtitle = subtitle,
-        timeZoneOffset = timeZoneOffset, // seconds
+        timeZoneOffset = timeZoneOffset?.totalSeconds, // seconds
         title = title,
         track = track,
         type = type,
@@ -84,7 +85,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.speakers = speakers
     session.startTime = startTime // minutes since day start
     session.subtitle = subtitle
-    session.timeZoneOffset = timeZoneOffset // seconds
+    session.timeZoneOffset = timeZoneOffset?.let { ZoneOffset.ofTotalSeconds(it) } // seconds
     session.title = title
     session.track = track
     session.type = type
@@ -128,7 +129,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.speakers = speakers
     session.startTime = startTime // minutes since day start
     session.subtitle = subtitle
-    session.timeZoneOffset = timeZoneOffset // seconds
+    session.timeZoneOffset = timeZoneOffset?.let { ZoneOffset.ofTotalSeconds(it) } // seconds
     session.title = title
     session.track = track
     session.type = type

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -95,7 +95,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
 
             // Detailbar
             var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
-            textView.text = if (viewModel.hasDateUtc) viewModel.formattedDateUtc else ""
+            textView.text = if (viewModel.hasDateUtc) viewModel.formattedZonedDateTime else ""
 
             textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
             textView.text = viewModel.roomName

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -40,8 +40,8 @@ class SessionDetailsViewModel @JvmOverloads constructor(
         private val toC3NavRoomName: Session.() -> String = {
             RoomForC3NavConverter.convert(this.room)
         },
-        private val toFormattedDateUtc: Session.() -> String = {
-            DateFormatter.newInstance().getFormattedDateTimeShort(this.dateUTC)
+        private val toFormattedZonedDateTime: Session.() -> String = {
+            DateFormatter.newInstance().getFormattedDateTimeShort(this.dateUTC, this.timeZoneOffset)
         },
         private val toHtmlLink: String.() -> String = {
             StringUtils.getHtmlLinkFromMarkdown(this)
@@ -70,7 +70,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
     private val timeZoneId = repository.readMeta().timeZoneId
 
     val hasDateUtc get() = session.dateUTC > 0
-    val formattedDateUtc get() = session.toFormattedDateUtc()
+    val formattedZonedDateTime get() = session.toFormattedZonedDateTime()
 
     val isSessionIdEmpty get() = sessionId.isEmpty()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -52,7 +52,7 @@ class StarredListAdapter internal constructor(
             lang.textOrHide = session.lang
             lang.contentDescription = session.getLanguageContentDescription(context)
             day.isVisible = false
-            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC)
+            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
             room.textOrHide = session.room
             val durationText = context.getString(R.string.session_duration, session.duration)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
+import org.threeten.bp.ZoneOffset;
+
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
 import info.metadude.android.eventfahrplan.network.temporal.DateParser;
@@ -27,7 +29,7 @@ public class Session {
     public String date;                 // YYYY-MM-DD
     public long dateUTC;                // milliseconds
     @Nullable
-    public Integer timeZoneOffset;      // seconds
+    public ZoneOffset timeZoneOffset;
     public int startTime;               // minutes since day start
     public int relStartTime;            // minutes since conference start
     public int duration;                // minutes
@@ -95,7 +97,7 @@ public class Session {
         highlight = false;
         hasAlarm = false;
         dateUTC = 0;
-        timeZoneOffset = 0;
+        timeZoneOffset = null;
         roomIndex = 0;
         recordingLicense = "";
         recordingOptOut = RECORDING_OPTOUT_OFF;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
@@ -25,6 +26,8 @@ public class Session {
     public int day;
     public String date;                 // YYYY-MM-DD
     public long dateUTC;                // milliseconds
+    @Nullable
+    public Integer timeZoneOffset;      // seconds
     public int startTime;               // minutes since day start
     public int relStartTime;            // minutes since conference start
     public int duration;                // minutes
@@ -92,6 +95,7 @@ public class Session {
         highlight = false;
         hasAlarm = false;
         dateUTC = 0;
+        timeZoneOffset = 0;
         roomIndex = 0;
         recordingLicense = "";
         recordingOptOut = RECORDING_OPTOUT_OFF;
@@ -116,6 +120,7 @@ public class Session {
         this.day = session.day;
         this.date = session.date;
         this.dateUTC = session.dateUTC;
+        this.timeZoneOffset = session.timeZoneOffset;
         this.startTime = session.startTime;
         this.relStartTime = session.relStartTime;
         this.duration = session.duration;
@@ -206,6 +211,7 @@ public class Session {
         if (!ObjectsCompat.equals(track, session.track)) return false;
         if (!ObjectsCompat.equals(type, session.type)) return false;
         if (dateUTC != session.dateUTC) return false;
+        if (!ObjectsCompat.equals(timeZoneOffset, session.timeZoneOffset)) return false;
 
         return true;
     }
@@ -227,6 +233,7 @@ public class Session {
         result = 31 * result + ObjectsCompat.hashCode(recordingLicense);
         result = 31 * result + (recordingOptOut ? 1 : 0);
         result = 31 * result + (int) dateUTC;
+        result = 31 * result + ObjectsCompat.hashCode(timeZoneOffset);
         return result;
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.schedule.TimeSegment.Companion.TIME_GRID_MINIMUM_SEGMENT_HEIGHT
+import org.threeten.bp.ZoneOffset
 
 /**
  * Holds the minutes of the day which represent a time segment (hours and minutes).
@@ -47,9 +48,11 @@ internal class TimeSegment private constructor(
     /**
      * Returns the normalized and formatted text representing the given minutes of the day.
      * This text is ready to be displayed in the time column.
+     *
+     * See [DateFormatter.getFormattedTime24Hour].
      */
-    val formattedText: String
-        get() = DateFormatter.newInstance().getFormattedTime24Hour(roundedMoment)
+    fun getFormattedText(sessionZoneOffset: ZoneOffset?): String =
+        DateFormatter.newInstance().getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
 
     /**
      * Returns true if the given [otherMoment] matches the internal rounded moment taken the

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameter.kt
@@ -47,7 +47,8 @@ internal data class TimeTextViewParameter private constructor(
                 } else {
                     R.layout.time_layout
                 }
-                val parameter = TimeTextViewParameter(timeTextLayout, timeTextViewHeight, timeSegment.formattedText)
+                val titleText = timeSegment.getFormattedText(conference.timeZoneOffset)
+                val parameter = TimeTextViewParameter(timeTextLayout, timeTextViewHeight, titleText)
                 parameters.add(parameter)
                 time += FIFTEEN_MINUTES
                 printTime = time

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -88,7 +88,7 @@ public class FahrplanMisc {
         String sessionId = session.sessionId;
         String sessionTitle = session.title;
         int alarmTimeInMin = alarmTimes.get(alarmTimesIndex);
-        String timeText = DateFormatter.newInstance().getFormattedDateTimeShort(alarmTime);
+        String timeText = DateFormatter.newInstance().getFormattedDateTimeShort(alarmTime, session.timeZoneOffset);
         int day = session.day;
 
         Alarm alarm = new Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText);

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -36,6 +36,7 @@ class SessionExtensionsTest {
                 startTime = 1036,
                 slug = "lorem",
                 subtitle = "My subtitle",
+                timeZoneOffset = 3600,
                 title = "My title",
                 track = "Security & Hacking",
                 type = "tutorial",
@@ -80,6 +81,7 @@ class SessionExtensionsTest {
                 startTime = 1036,
                 slug = "lorem",
                 subtitle = "My subtitle",
+                timeZoneOffset = 3600,
                 title = "My title",
                 track = "Security & Hacking",
                 type = "tutorial",
@@ -118,6 +120,7 @@ class SessionExtensionsTest {
             startTime = 1036
             slug = "lorem"
             subtitle = "My subtitle"
+            timeZoneOffset = 3600
             title = "My title"
             track = "Security & Hacking"
             type = "tutorial"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -7,6 +7,7 @@ import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.threeten.bp.ZoneOffset
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
 import nerd.tuxmobil.fahrplan.congress.models.Session as SessionAppModel
@@ -120,7 +121,7 @@ class SessionExtensionsTest {
             startTime = 1036
             slug = "lorem"
             subtitle = "My subtitle"
-            timeZoneOffset = 3600
+            timeZoneOffset = ZoneOffset.ofTotalSeconds(3600)
             title = "My title"
             track = "Security & Hacking"
             type = "tutorial"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.Test
+import org.threeten.bp.ZoneOffset
 
 class ConferenceTest {
 
@@ -27,18 +28,20 @@ class ConferenceTest {
     fun `calculateTimeFrame with frab data spanning multiple days`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536504300000L) // 2018-09-09T16:45:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt) = createConference(opening, closing)
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
         assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
         assertThat(lastSessionEndsAt).isEqualTo(17 * 60 + 15 - 2 * 60 + MINUTES_OF_ONE_DAY) // -> 17:15 -2h zone offset + day switch
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
     }
 
     @Test
     fun `calculateTimeFrame with frab data spanning a single day`() {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L) // 2018-09-07T18:00:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt) = createConference(opening, closing)
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing)
         assertThat(firstSessionStartsAt).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
         assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
     }
 
     @Test
@@ -46,9 +49,10 @@ class ConferenceTest {
         val opening = createSession("Opening", duration = 30, dateUtc = 1536328800000L) // 2018-09-07T16:00:00+02:00
         val middle = createSession("Middle", duration = 20, dateUtc = 1536332400000L) // 2018-09-07T17:00:00+02:00
         val closing = createSession("Closing", duration = 30, dateUtc = 1536336000000L) // 2018-09-07T18:00:00+02:00
-        val (firstSessionStartsAt, lastSessionEndsAt) = createConference(opening, closing, middle)
+        val (firstSessionStartsAt, lastSessionEndsAt, timeZoneOffset) = createConference(opening, closing, middle)
         assertThat(firstSessionStartsAt).isEqualTo(16 * 60 - 2 * 60) // 16:00h -2h zone offset = 14:00h
         assertThat(lastSessionEndsAt).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
+        assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+01:00"))
     }
 
     private fun createConference(vararg sessions: Session) = Conference().apply {
@@ -58,6 +62,7 @@ class ConferenceTest {
     private fun createSession(sessionId: String, duration: Int, dateUtc: Long) = Session(sessionId).apply {
         this.dateUTC = dateUtc
         this.duration = duration
+        this.timeZoneOffset = ZoneOffset.ofTotalSeconds(3600)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
@@ -5,6 +5,7 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import org.threeten.bp.OffsetDateTime
 import java.util.TimeZone
 
 @RunWith(Parameterized::class)
@@ -45,9 +46,10 @@ class TimeSegmentFormattedTextTest(
     @Test
     fun formattedText() {
         TimeZone.setDefault(DEFAULT_TIME_ZONE)
+        val zoneOffsetNow = OffsetDateTime.now().offset
         val moment = Moment.now().startOfDay().plusMinutes(minutesOfTheDay.toLong())
         val segment = TimeSegment.ofMoment(moment)
-        assertThat(segment.formattedText).isEqualTo(expectedFormattedText)
+        assertThat(segment.getFormattedText(zoneOffsetNow)).isEqualTo(expectedFormattedText)
     }
 
 }

--- a/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/TimeZoneUtils.kt
+++ b/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/TimeZoneUtils.kt
@@ -1,0 +1,12 @@
+@file:JvmName("TimeZoneUtils")
+
+package info.metadude.android.eventfahrplan.commons.testing
+
+import java.util.TimeZone
+
+fun withTimeZone(temporaryTimeZoneId: String, block: () -> Unit) {
+    val systemTimezone = TimeZone.getDefault()
+    TimeZone.setDefault(TimeZone.getTimeZone(temporaryTimeZoneId))
+    block()
+    TimeZone.setDefault(systemTimezone)
+}

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation Libs.tracedroid
     api Libs.threeTenBp
 
+    testImplementation project(":commons-testing")
     testImplementation Libs.junit
     testImplementation Libs.assertjAndroid
     testImplementation Libs.truth

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -3,6 +3,8 @@ package info.metadude.android.eventfahrplan.commons.temporal
 import org.threeten.bp.Instant
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle
 
@@ -18,25 +20,42 @@ class DateFormatter private constructor() {
     private val timeZoneOffsetFormatter = DateTimeFormatter.ofPattern("z")
 
     /**
-     * Returns 01:00, 14:00 etc. for all locales. Always without AM or PM postfix in 24 hour format.
+     * Returns a formatted `hours:minutes` string. Formatting happens by taking the [original time
+     * zone of the associated session][sessionZoneOffset] into account. If [sessionZoneOffset] is
+     * missing then formatting falls back to using the current time zone offset of the device.
+     *
+     * The returned text is formatted equally for all locales, e.g. 01:00, 14:00 etc. - always
+     * without AM or PM postfix - in 24 hours format.
      */
-    fun getFormattedTime24Hour(moment: Moment): String =
-            timeShortNumberOnlyFormatter.format(moment.toZonedDateTime(OffsetDateTime.now().offset))
+    fun getFormattedTime24Hour(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
+        val zoneOffset = getAvailableZoneOffset(sessionZoneOffset)
+        return timeShortNumberOnlyFormatter.format(moment.toZonedDateTime(zoneOffset))
+    }
 
     /**
      * Returns 01:00 AM, 02:00 PM, 14:00 etc, depending on current system locale either
      * in 24 or 12 hour format. The latter featuring AM or PM postfixes.
+     *
+     * Formatting happens by taking the [original time zone of the associated session][sessionZoneOffset]
+     * into account. If [sessionZoneOffset] is missing then formatting falls back to using the
+     * current time zone offset of the device.
      */
-    fun getFormattedTime(time: Long): String {
-        return timeShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    fun getFormattedTime(time: Long, sessionZoneOffset: ZoneOffset?): String {
+        val zoneOffset = getAvailableZoneOffset(sessionZoneOffset)
+        return timeShortFormatter.withZone(zoneOffset).format(Instant.ofEpochMilli(time))
     }
 
     /**
      * Returns day, month and year in current system locale.
      * E.g. 1/22/19 or 22.01.19
+     *
+     * Formatting happens by taking the [original time zone of the associated session][sessionZoneOffset]
+     * into account. If [sessionZoneOffset] is missing then formatting falls back to using the
+     * current time zone offset of the device.
      */
-    fun getFormattedDate(time: Long): String {
-        return dateShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    fun getFormattedDate(time: Long, sessionZoneOffset: ZoneOffset?): String {
+        val zoneOffset = getAvailableZoneOffset(sessionZoneOffset)
+        return dateShortFormatter.withZone(zoneOffset).format(Instant.ofEpochMilli(time))
     }
 
     /**
@@ -62,11 +81,26 @@ class DateFormatter private constructor() {
     }
 
     /**
-     * Returns day, month, year and time in current system locale in short format.
+     * Returns day, month, year and time in short format. Formatting happens by taking the [original
+     * time zone of the associated session][sessionZoneOffset] into account. If [sessionZoneOffset]
+     * is missing then formatting falls back to using the current time zone offset of the device.
+     *
      * E.g. 1/22/19 1:00 AM
      */
-    fun getFormattedDateTimeShort(time: Long): String {
-        return dateShortTimeShortFormatter.withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(time))
+    fun getFormattedDateTimeShort(time: Long, sessionZoneOffset: ZoneOffset?): String {
+        val zoneOffset = getAvailableZoneOffset(sessionZoneOffset)
+        val toZonedDateTime: ZonedDateTime = Moment.ofEpochMilli(time).toZonedDateTime(zoneOffset)
+        return dateShortTimeShortFormatter.format(toZonedDateTime)
+    }
+
+    /**
+     * Returns the available zone offset - either the given [sessionZoneOffset] or the zone offset
+     * of the device.
+     */
+    private fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
+        val deviceZoneOffset = OffsetDateTime.now().offset
+        val useDeviceZoneOffset = sessionZoneOffset == null || sessionZoneOffset == deviceZoneOffset
+        return if (useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset!!
     }
 
     companion object {

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
@@ -1,0 +1,25 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import org.threeten.bp.ZonedDateTime
+import org.threeten.bp.format.DateTimeFormatter
+import org.threeten.bp.format.DateTimeParseException
+
+object DateParser {
+
+    /**
+     * Parses the given [text] and returns its time zone offset value represented in seconds.
+     *
+     * The [text] is expected to be provided in the [ISO_DATE_TIME][DateTimeFormatter.ISO_DATE_TIME]
+     * format (e.g. 2019-01-01T00:00:00Z).
+     */
+    @JvmStatic
+    fun parseTimeZoneOffset(text: String): Int {
+        val zonedDateTime = try {
+            ZonedDateTime.parse(text, DateTimeFormatter.ISO_DATE_TIME)
+        } catch (e: DateTimeParseException) {
+            throw IllegalArgumentException("Error parsing time zone offset from: '$text'.")
+        }
+        return zonedDateTime.offset.totalSeconds
+    }
+
+}

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
@@ -1,10 +1,24 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
+import org.threeten.bp.Instant
+import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.DateTimeParseException
 
 object DateParser {
+
+    /**
+     * Parses the given [text] and returns its date value represented in milliseconds.
+     *
+     * Expects the [text] to be provided in [ISO_DATE_TIME][DateTimeFormatter.ISO_DATE_TIME]
+     * format (e.g. 2019-01-01T00:00:00Z).
+     */
+    fun parseDateTime(text: String): Long {
+        val instant = Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(text))
+        val atUtcOffset = instant.atOffset(ZoneOffset.UTC)
+        return atUtcOffset.toEpochSecond() * Moment.MILLISECONDS_OF_ONE_SECOND
+    }
 
     /**
      * Parses the given [text] and returns its time zone offset value represented in seconds.

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
@@ -1,0 +1,129 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatterFormattedTime24HourTest.TestParameter.Companion.parse
+import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.threeten.bp.ZoneOffset
+
+/**
+ * Covers the time zone aware time rendering of [DateFormatter.getFormattedTime24Hour].
+ * - Iterating all valid time zone offsets
+ * - Iterating all hours of a day
+ * - Testing with summer and winter time
+ *
+ * Regardless which time zone is set at the device always the time zone of the event/session will
+ * be rendered.
+ *
+ * TODO: TechDebt: Once the app offers an option to render sessions in the device time zone this test must be adapted.
+ */
+@RunWith(Parameterized::class)
+class DateFormatterFormattedTime24HourTest(
+
+    private val timeZoneId: String
+
+) {
+
+    companion object {
+
+        private val timeZoneOffsets = -12..14
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{index}: timeZoneId = {0}")
+        fun data() = timeZoneOffsets.map { arrayOf("GMT$it") }
+
+    }
+
+    @Test
+    fun `getFormattedTime24Hour 2021-03-27`() = testEach(listOf(
+        "2021-03-27T00:01:00+01:00" to "00:01",
+        "2021-03-27T01:00:00+01:00" to "01:00",
+        "2021-03-27T02:00:00+01:00" to "02:00",
+        "2021-03-27T03:00:00+01:00" to "03:00",
+        "2021-03-27T04:00:00+01:00" to "04:00",
+        "2021-03-27T05:00:00+01:00" to "05:00",
+        "2021-03-27T06:00:00+01:00" to "06:00",
+        "2021-03-27T07:00:00+01:00" to "07:00",
+        "2021-03-27T08:00:00+01:00" to "08:00",
+        "2021-03-27T09:00:00+01:00" to "09:00",
+        "2021-03-27T10:00:00+01:00" to "10:00",
+        "2021-03-27T11:00:00+01:00" to "11:00",
+        "2021-03-27T12:00:00+01:00" to "12:00",
+        "2021-03-27T13:00:00+01:00" to "13:00",
+        "2021-03-27T14:00:00+01:00" to "14:00",
+        "2021-03-27T15:00:00+01:00" to "15:00",
+        "2021-03-27T16:00:00+01:00" to "16:00",
+        "2021-03-27T17:00:00+01:00" to "17:00",
+        "2021-03-27T18:00:00+01:00" to "18:00",
+        "2021-03-27T19:00:00+01:00" to "19:00",
+        "2021-03-27T20:00:00+01:00" to "20:00",
+        "2021-03-27T21:00:00+01:00" to "21:00",
+        "2021-03-27T22:00:00+01:00" to "22:00",
+        "2021-03-27T23:00:00+01:00" to "23:00",
+        "2021-03-27T23:59:00+01:00" to "23:59",
+    ))
+
+    @Test
+    fun `getFormattedTime24Hour 2021-03-28`() = testEach(listOf(
+        "2021-03-28T00:01:00+02:00" to "00:01",
+        "2021-03-28T01:00:00+02:00" to "01:00",
+        "2021-03-28T02:00:00+02:00" to "02:00", // TechDebt: Daylight saving time is ignored here.
+        "2021-03-28T03:00:00+02:00" to "03:00",
+        "2021-03-28T04:00:00+02:00" to "04:00",
+        "2021-03-28T05:00:00+02:00" to "05:00",
+        "2021-03-28T06:00:00+02:00" to "06:00",
+        "2021-03-28T07:00:00+02:00" to "07:00",
+        "2021-03-28T08:00:00+02:00" to "08:00",
+        "2021-03-28T09:00:00+02:00" to "09:00",
+        "2021-03-28T10:00:00+02:00" to "10:00",
+        "2021-03-28T11:00:00+02:00" to "11:00",
+        "2021-03-28T12:00:00+02:00" to "12:00",
+        "2021-03-28T13:00:00+02:00" to "13:00",
+        "2021-03-28T14:00:00+02:00" to "14:00",
+        "2021-03-28T15:00:00+02:00" to "15:00",
+        "2021-03-28T16:00:00+02:00" to "16:00",
+        "2021-03-28T17:00:00+02:00" to "17:00",
+        "2021-03-28T18:00:00+02:00" to "18:00",
+        "2021-03-28T19:00:00+02:00" to "19:00",
+        "2021-03-28T20:00:00+02:00" to "20:00",
+        "2021-03-28T21:00:00+02:00" to "21:00",
+        "2021-03-28T22:00:00+02:00" to "22:00",
+        "2021-03-28T23:00:00+02:00" to "23:00",
+        "2021-03-28T23:59:00+02:00" to "23:59",
+    ))
+
+    private fun testEach(pairs: List<Pair<String, String>>) {
+        pairs.forEach { (dateTime, expectedFormattedTime) ->
+            val (moment, offset) = parse(dateTime)
+            withTimeZone(timeZoneId) {
+                val formattedTime = DateFormatter.newInstance().getFormattedTime24Hour(moment, offset)
+                assertThat(formattedTime).isEqualTo(expectedFormattedTime)
+            }
+        }
+    }
+
+    private data class TestParameter(val moment: Moment, val offset: ZoneOffset) {
+
+        companion object {
+
+            fun parse(dateTime: String) = TestParameter(
+                parseMoment(dateTime),
+                parseTimeZoneOffset(dateTime)
+            )
+
+            private fun parseMoment(text: String): Moment {
+                val milliseconds = DateParser.parseDateTime(text)
+                return Moment.ofEpochMilli(milliseconds)
+            }
+
+            private fun parseTimeZoneOffset(text: String): ZoneOffset {
+                val seconds = DateParser.parseTimeZoneOffset(text)
+                return ZoneOffset.ofTotalSeconds(seconds)
+            }
+
+        }
+    }
+
+}

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -4,7 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset
 import java.util.Locale
 import java.util.TimeZone
 
@@ -35,42 +37,42 @@ class DateFormatterTest {
     fun getFormattedTime() {
         Locale.setDefault(Locale("en", "US"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp)).isEqualTo("1:00 AM")
+        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("1:00 AM")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp)).isEqualTo("2:00 PM")
+        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("2:00 PM")
 
         Locale.setDefault(Locale("de", "DE"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp)).isEqualTo("14:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("14:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp)).isEqualTo("06:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("06:00")
     }
 
     @Test
     fun getFormattedTimeNumbersOnly() {
         Locale.setDefault(Locale("en", "US"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment)).isEqualTo("01:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("01:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment)).isEqualTo("14:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
 
         Locale.setDefault(Locale("de", "DE"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment)).isEqualTo("06:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("06:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment)).isEqualTo("14:00")
+        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
     }
 
     @Test
     fun getFormattedDate() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp)).isEqualTo("1/22/19")
+        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp)).isEqualTo("22.01.19")
+        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
     }
 
     // This test only passes when being executed in a JDK 8 environment.
@@ -100,9 +102,14 @@ class DateFormatterTest {
     @Test
     fun getFormattedDateTimeShort() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp)).isEqualTo("1/22/19 1:00 AM")
+        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19 1:00 AM")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp)).isEqualTo("22.01.19 01:00")
+        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19 01:00")
     }
+
+    private fun getTimeZoneOffsetNow(): ZoneOffset {
+        return OffsetDateTime.now().offset
+    }
+
 }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
@@ -3,8 +3,63 @@ package info.metadude.android.eventfahrplan.commons.temporal
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
+import org.threeten.bp.DateTimeException
+import org.threeten.bp.format.DateTimeParseException
 
 class DateParserTest {
+
+    @Test
+    fun `parseDateTime returns milliseconds for 2019 date and time with time zone and offset`() {
+        assertThat(DateParser.parseDateTime("2019-01-01T00:00:00Z")).isEqualTo(1546300800000)
+    }
+
+    @Test
+    fun `parseDateTime returns milliseconds for 1970 epoch date and time UTC`() {
+        assertThat(DateParser.parseDateTime("1970-01-01T00:00:00Z")).isEqualTo(0)
+    }
+
+    @Test
+    fun `parseDateTime returns milliseconds for 1970 epoch date and time with time zone with zero offset`() {
+        assertThat(DateParser.parseDateTime("1970-01-01T00:00:00+00:00")).isEqualTo(0)
+    }
+
+    @Test
+    fun `parseDateTime returns milliseconds for short after 1970 epoch date and time with time zone with offset`() {
+        assertThat(DateParser.parseDateTime("1970-01-01T02:00:00+01:00")).isEqualTo(3600000)
+    }
+
+    @Test
+    fun `parseDateTime returns milliseconds for 2016 date and time with time zone with offset`() {
+        // Test format of date / times ever seen in schedule.xml files.
+        assertThat(DateParser.parseDateTime("2016-09-14T14:30:00+02:00")).isEqualTo(1473856200000)
+    }
+
+    @Test
+    fun `parseDateTime returns milliseconds for 2016 date and time UTC`() {
+        // Test format of date / times ever seen in schedule.xml files.
+        assertThat(DateParser.parseDateTime("2016-09-14T12:30:00Z")).isEqualTo(1473856200000)
+    }
+
+    @Test
+    fun `parseDateTime fails when time zone offset is missing without a colon`() {
+        // Test format of date / times ever seen in schedule.xml files.
+        try {
+            DateParser.parseDateTime("2016-09-14T14:30:00+0200")
+            fail("Failure expected because malformed date string should not be parsed.")
+        } catch (e: DateTimeParseException) {
+            assertThat(e.message).startsWith("Text '2016-09-14T14:30:00+0200' could not be parsed")
+        }
+    }
+
+    @Test
+    fun `parseDateTime fails when time zone offset is missing`() {
+        try {
+            DateParser.parseDateTime("1970-01-01T03:00:00")
+            fail("Failure expected because malformed date string should not be parsed.")
+        } catch (e: DateTimeException) {
+            assertThat(e.message).startsWith("Unable to obtain Instant from TemporalAccessor: DateTimeBuilder")
+        }
+    }
 
     @Test
     fun `parseTimeZoneOffset returns negative integer for negative time zone offset`() {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
@@ -1,0 +1,34 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+
+class DateParserTest {
+
+    @Test
+    fun `parseTimeZoneOffset returns negative integer for negative time zone offset`() {
+        assertThat(DateParser.parseTimeZoneOffset("1980-01-01T02:00:00-01:00")).isEqualTo(-3600)
+    }
+
+    @Test
+    fun `parseTimeZoneOffset returns positive integer for positive time zone offset`() {
+        assertThat(DateParser.parseTimeZoneOffset("1980-01-01T02:00:00+01:00")).isEqualTo(3600)
+    }
+
+    @Test
+    fun `parseTimeZoneOffset returns 0 for UTC offset`() {
+        assertThat(DateParser.parseTimeZoneOffset("1980-01-01T02:00:00Z")).isEqualTo(0)
+    }
+
+    @Test
+    fun `parseTimeZoneOffset fails when time zone offset is missing`() {
+        try {
+            DateParser.parseTimeZoneOffset("1970-01-01T03:00:00")
+            fail("Failure expected because malformed date string should not be parsed.")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).startsWith("Error parsing time zone offset from: '1970-01-01T03:00:00'.")
+        }
+    }
+
+}

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -5,12 +5,12 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MIL
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.toMoment
+import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
-import java.util.TimeZone
 
 class MomentTest {
 
@@ -175,13 +175,6 @@ class MomentTest {
     @Test
     fun getSystemOffsetMinutesWithGmtMinus1() = withTimeZone("GMT-1") {
         assertThat(Moment.getSystemOffsetMinutes()).isEqualTo(-60)
-    }
-
-    private fun withTimeZone(temporaryTimeZoneId: String, block: () -> Unit) {
-        val systemTimezone = TimeZone.getDefault()
-        TimeZone.setDefault(TimeZone.getTimeZone(temporaryTimeZoneId))
-        block()
-        TimeZone.setDefault(systemTimezone)
     }
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -123,6 +123,7 @@ public interface FahrplanContract {
             /* 31 */ String CHANGED_IS_CANCELED = "changed_is_canceled";
             /* 32 */ String SLUG = "slug";
             /* 33 */ String URL = "url";
+            /* 34 */ String TIME_ZONE_OFFSET = "time_zone_offset";
         }
 
         interface Defaults {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
@@ -6,6 +6,7 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
 import android.database.Cursor
+import androidx.core.database.getIntOrNull
 import androidx.core.database.getStringOrNull
 
 /**
@@ -18,6 +19,17 @@ import androidx.core.database.getStringOrNull
  * @see Cursor.getInt
  */
 inline fun Cursor.getInt(columnName: String): Int = getInt(getColumnIndexOrThrow(columnName))
+
+/**
+ * Returns the value of the requested column as an int or null.
+ *
+ * The result and whether this method throws an exception when the column type is not a int type
+ * is implementation-defined.
+ *
+ * @see Cursor.getColumnIndexOrThrow
+ * @see Cursor.getIntOrNull
+ */
+inline fun Cursor.getIntOrNull(columnName: String): Int? = getIntOrNull(getColumnIndexOrThrow(columnName))
 
 /**
  * Returns the value of the requested column as a long.

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
@@ -33,6 +33,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SPEAKERS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.START
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SUBTITLE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TIME_ZONE_OFFSET
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TYPE
@@ -60,6 +61,7 @@ fun Session.toContentValues() = contentValuesOf(
         SPEAKERS to speakers,
         START to startTime,
         SUBTITLE to subtitle,
+        TIME_ZONE_OFFSET to timeZoneOffset,
         TITLE to title,
         TRACK to track,
         TYPE to type,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
@@ -25,6 +25,7 @@ data class Session(
         val startTime: Int = 0,         // minutes since day start
         val slug: String = "",
         val subtitle: String = "",
+        val timeZoneOffset: Int? = null, // seconds
         val title: String = "",
         val track: String = "",
         val type: String = "",

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
@@ -38,6 +38,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SPEAKERS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.START
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SUBTITLE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TIME_ZONE_OFFSET
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TYPE
@@ -45,6 +46,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Values.REC_OPT_OUT_OFF
 import info.metadude.android.eventfahrplan.database.extensions.delete
 import info.metadude.android.eventfahrplan.database.extensions.getInt
+import info.metadude.android.eventfahrplan.database.extensions.getIntOrNull
 import info.metadude.android.eventfahrplan.database.extensions.getLong
 import info.metadude.android.eventfahrplan.database.extensions.getString
 import info.metadude.android.eventfahrplan.database.extensions.insert
@@ -207,6 +209,7 @@ class SessionsDatabaseRepository(
                     speakers = cursor.getString(SPEAKERS),
                     subtitle = cursor.getString(SUBTITLE),
                     startTime = cursor.getInt(START),
+                    timeZoneOffset = cursor.getIntOrNull(TIME_ZONE_OFFSET),
                     title = cursor.getString(TITLE),
                     track = cursor.getString(TRACK),
                     type = cursor.getString(TYPE),

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
@@ -15,7 +15,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 
 public class SessionsDBOpenHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 10;
+    private static final int DATABASE_VERSION = 11;
 
     private static final String DATABASE_NAME = "lectures"; // Keep table name to avoid database migration.
 
@@ -39,6 +39,7 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
                     Columns.DATE + " STRING, " +
                     Columns.LINKS + " STRING, " +
                     Columns.DATE_UTC + " INTEGER, " +
+                    Columns.TIME_ZONE_OFFSET + " INTEGER DEFAULT NULL, " +
                     Columns.ROOM_IDX + " INTEGER, " +
                     Columns.REC_LICENSE + " STRING, " +
                     Columns.REC_OPTOUT + " INTEGER," +
@@ -129,6 +130,9 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
         }
         if (oldVersion < 10 && newVersion >= 10) {
             db.execSQL(SESSION_BY_NOTIFICATION_ID_TABLE_CREATE);
+        }
+        if (oldVersion < 11 && newVersion >= 11) {
+            db.execSQL("ALTER TABLE " + SessionsTable.NAME + " ADD COLUMN " + Columns.TIME_ZONE_OFFSET + " INTEGER DEFAULT NULL");
         }
     }
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
@@ -28,6 +28,7 @@ data class Session(
         var startTime: Int = 0, // minutes since day start
         var slug: String = "",
         var subtitle: String = "",
+        var timeZoneOffset: Int? = null, // seconds
         var title: String = "",
         var track: String = "",
         var type: String = "",

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -255,7 +255,9 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                             session.setDuration(DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser)));
                                         } else if (name.equals("date")) {
                                             parser.next();
-                                            session.setDateUTC(DateParser.getDateTime(XmlPullParsers.getSanitizedText(parser)));
+                                            String sanitizedText = XmlPullParsers.getSanitizedText(parser);
+                                            session.setDateUTC(DateParser.getDateTime(sanitizedText));
+                                            session.setTimeZoneOffset(info.metadude.android.eventfahrplan.commons.temporal.DateParser.parseTimeZoneOffset(sanitizedText));
                                         } else if (name.equals("recording")) {
                                             eventType = parser.next();
                                             boolean recordingDone = false;

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DateParser.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DateParser.kt
@@ -1,8 +1,8 @@
 package info.metadude.android.eventfahrplan.network.temporal
 
+import info.metadude.android.eventfahrplan.commons.temporal.DateParser
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
-import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
@@ -17,12 +17,12 @@ class DateParser {
          *
          * @param text either ISO-8601 date and time format (e.g. 2019-01-01T00:00:00Z)
          * or ISO-8601 date format (i.e. 2019-01-01).
+         *
+         * Also see [DateParser.parseDateTime].
          */
         @JvmStatic
         fun getDateTime(text: String) = if (text.length > 10) {
-            val parsed = Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(text))
-            val atUTCOffset = parsed.atOffset(ZoneOffset.UTC)
-            atUTCOffset.toEpochSecond() * MILLISECONDS_OF_ONE_SECOND
+            DateParser.parseDateTime(text)
         } else {
             val parsed = LocalDate.parse(text)
             val atUTCOffset = parsed.atTime(0, 0).atOffset(ZoneOffset.UTC)

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.threeten.bp.DateTimeException
 import org.threeten.bp.format.DateTimeParseException
+import java.security.InvalidParameterException
 
 class DateParserTest {
 

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
@@ -1,66 +1,9 @@
 package info.metadude.android.eventfahrplan.network.temporal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.fail
 import org.junit.Test
-import org.threeten.bp.DateTimeException
-import org.threeten.bp.format.DateTimeParseException
-import java.security.InvalidParameterException
 
 class DateParserTest {
-
-    @Test
-    fun `getDateTime returns milliseconds for 2019 date and time with time zone and offset`() {
-        assertThat(DateParser.getDateTime("2019-01-01T00:00:00Z")).isEqualTo(1546300800000)
-    }
-
-    @Test
-    fun `getDateTime returns milliseconds for 1970 epoch date and time UTC`() {
-        assertThat(DateParser.getDateTime("1970-01-01T00:00:00Z")).isEqualTo(0)
-    }
-
-    @Test
-    fun `getDateTime returns milliseconds for 1970 epoch date and time with time zone with zero offset`() {
-        assertThat(DateParser.getDateTime("1970-01-01T00:00:00+00:00")).isEqualTo(0)
-    }
-
-    @Test
-    fun `getDateTime returns milliseconds for short after 1970 epoch date and time with time zone with offset`() {
-        assertThat(DateParser.getDateTime("1970-01-01T02:00:00+01:00")).isEqualTo(3600000)
-    }
-
-    @Test
-    fun `getDateTime returns milliseconds for 2016 date and time with time zone with offset`() {
-        // Test format of date / times ever seen in schedule.xml files.
-        assertThat(DateParser.getDateTime("2016-09-14T14:30:00+02:00")).isEqualTo(1473856200000)
-    }
-
-    @Test
-    fun `getDateTime returns milliseconds for 2016 date and time UTC`() {
-        // Test format of date / times ever seen in schedule.xml files.
-        assertThat(DateParser.getDateTime("2016-09-14T12:30:00Z")).isEqualTo(1473856200000)
-    }
-
-    @Test
-    fun `getDateTime fails when time zone offset is missing without a colon`() {
-        // Test format of date / times ever seen in schedule.xml files.
-        try {
-            DateParser.getDateTime("2016-09-14T14:30:00+0200")
-            fail("Failure expected because malformed date string should not be parsed.")
-        } catch (e: DateTimeParseException) {
-            assertThat(e.message).startsWith("Text '2016-09-14T14:30:00+0200' could not be parsed")
-        }
-    }
-
-    @Test
-    fun `getDateTime fails when time zone offset is missing`() {
-        try {
-            DateParser.getDateTime("1970-01-01T03:00:00")
-            fail("Failure expected because malformed date string should not be parsed.")
-        } catch (e: DateTimeException) {
-            assertThat(e.message).startsWith("Unable to obtain Instant from TemporalAccessor: DateTimeBuilder")
-        }
-    }
 
     @Test
     fun `getDateTime returns milliseconds for first day in 2019 date`() {


### PR DESCRIPTION
# Description
+ The **original time zone offset** of a session is parsed, stored and used to render its time correctly - at any point in time. That means, the device system time might be set to **before, at or after** the time of the event. Further, the time zone of the device does not need to match the time zone of the event.
+ **Fallback:** If the time zone offset is not provided then the app falls back to using the current **time zone offset of the device** in lack of better knowledge.
+ Rendering time information according to the time zone of the device is **not** implemented yet. It will be implemented later.
+ Test time rendering in **different device time zones**.

## This commit affects the rendering of:
+ the time text column (hours, minutes)
+ the time information in the top bar in the details screen
+ the time information of an alarm item in the alarms screen
+ the time information of the session items in the favorites screen
+ the time information of the session items in the changes screen

## This commit does not affect the scrolling behavior:
+ Scrolling to the current time if the selected event day matches the current day
+ Scrolling to the associated session (time) when tapping an alarm notification
  + Here are still issues which will be addressed in a follow-up pull request

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)

# Related
- [Issue #69: Event time or device time](https://github.com/EventFahrplan/EventFahrplan/issues/69)
- [Pull request #245: Centralize date handling](https://github.com/EventFahrplan/EventFahrplan/pull/245)
- [Issue #260: Time column ignores daylight saving time](https://github.com/EventFahrplan/EventFahrplan/issues/260)

# Travis CI
- Please ignore the build. CI is currently out of service. :no_entry: 

---

Resolves #260