### PR TITLE
Enable users to switch between device and event time zone

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
@@ -34,15 +34,17 @@ public abstract class SessionsAdapter extends ArrayAdapter<Session> {
 
     private final List<Session> list;
     private final int numDays;
+    protected final boolean useDeviceTimeZone;
     private ArrayList<Integer> mMapper;
     private ArrayList<String> mSeparatorStrings;
     private TreeSet<Integer> mSeparatorsSet;
 
-    public SessionsAdapter(Context context, @LayoutRes int layout, List<Session> list, int numDays) {
+    public SessionsAdapter(Context context, @LayoutRes int layout, List<Session> list, int numDays, boolean useDeviceTimeZone) {
         super(context, layout, list);
         this.context = new ContextThemeWrapper(context, R.style.Theme_AppCompat_Light);
         this.list = list;
         this.numDays = numDays;
+        this.useDeviceTimeZone = useDeviceTimeZone;
         initMapper();
     }
 
@@ -196,7 +198,7 @@ public abstract class SessionsAdapter extends ArrayAdapter<Session> {
             if (day != lastDay) {
                 lastDay = day;
                 if (numDays > 1) {
-                    String formattedDate = DateFormatter.newInstance().getFormattedDate(l.dateUTC, l.timeZoneOffset);
+                    String formattedDate = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(l.dateUTC, l.timeZoneOffset);
                     String dayDateSeparator = String.format(daySeparator, day, formattedDate);
                     mSeparatorStrings.add(dayDateSeparator);
                     mSeparatorsSet.add(index + sepCount);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -16,14 +16,16 @@ class ChangeListAdapter internal constructor(
 
         context: Context,
         list: List<Session>,
-        numDays: Int
+        numDays: Int,
+        useDeviceTimeZone: Boolean
 
 ) : SessionsAdapter(
 
         context,
         R.layout.session_list_item,
         list,
-        numDays
+        numDays,
+        useDeviceTimeZone
 
 ) {
 
@@ -51,9 +53,9 @@ class ChangeListAdapter internal constructor(
             speakers.textOrHide = session.formattedSpeakers
             lang.textOrHide = session.lang
             lang.contentDescription = session.getLanguageContentDescription(context)
-            val dayText = DateFormatter.newInstance().getFormattedDate(session.dateUTC, session.timeZoneOffset)
+            val dayText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(session.dateUTC, session.timeZoneOffset)
             day.textOrHide = dayText
-            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC, session.timeZoneOffset)
+            val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
             room.textOrHide = session.room
             val durationText = context.getString(R.string.session_duration, session.duration)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -83,7 +83,8 @@ public class ChangeListFragment extends AbstractListFragment {
         Context context = requireContext();
         changesList = appRepository.loadChangedSessions();
         Meta meta = appRepository.readMeta();
-        mAdapter = new ChangeListAdapter(context, changesList, meta.getNumDays());
+        boolean useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled();
+        mAdapter = new ChangeListAdapter(context, changesList, meta.getNumDays(), useDeviceTimeZone);
         MyApp.LogDebug(LOG_TAG, "onCreate, " + changesList.size() + " changes");
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -47,4 +47,7 @@ public interface BundleKeys {
             "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_URL_UPDATED";
     String BUNDLE_KEY_ALTERNATIVE_HIGHLIGHTING_UPDATED =
             "nerd.tuxmobil.fahrplan.congress.Prefs.ALTERNATIVE_HIGHLIGHT";
+    String BUNDLE_KEY_USE_DEVICE_TIME_ZONE_UPDATED =
+            "nerd.tuxmobil.fahrplan.congress.Prefs.USE_DEVICE_TIME_ZONE_UPDATED";
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -41,7 +41,8 @@ class SessionDetailsViewModel @JvmOverloads constructor(
             RoomForC3NavConverter.convert(this.room)
         },
         private val toFormattedZonedDateTime: Session.() -> String = {
-            DateFormatter.newInstance().getFormattedDateTimeShort(this.dateUTC, this.timeZoneOffset)
+            val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
+            DateFormatter.newInstance(useDeviceTimeZone).getFormattedDateTimeShort(this.dateUTC, this.timeZoneOffset)
         },
         private val toHtmlLink: String.() -> String = {
             StringUtils.getHtmlLinkFromMarkdown(this)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -15,14 +15,17 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 class StarredListAdapter internal constructor(
 
         context: Context,
-        list: List<Session>, numDays: Int
+        list: List<Session>,
+        numDays: Int,
+        useDeviceTimeZone: Boolean
 
 ) : SessionsAdapter(
 
         context,
         R.layout.session_list_item,
         list,
-        numDays
+        numDays,
+        useDeviceTimeZone
 
 ) {
 
@@ -52,7 +55,7 @@ class StarredListAdapter internal constructor(
             lang.textOrHide = session.lang
             lang.contentDescription = session.getLanguageContentDescription(context)
             day.isVisible = false
-            val timeText = DateFormatter.newInstance().getFormattedTime(session.dateUTC, session.timeZoneOffset)
+            val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
             room.textOrHide = session.room
             val durationText = context.getString(R.string.session_duration, session.duration)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.java
@@ -109,7 +109,8 @@ public class StarredListFragment extends AbstractListFragment implements
         Context context = requireContext();
         starredList = appRepository.loadStarredSessions();
         Meta meta = appRepository.readMeta();
-        mAdapter = new StarredListAdapter(context, starredList, meta.getNumDays());
+        boolean useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled();
+        mAdapter = new StarredListAdapter(context, starredList, meta.getNumDays(), useDeviceTimeZone);
         MyApp.LogDebug(LOG_TAG, "initStarredList: " + starredList.size() + " favorites");
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -39,6 +39,12 @@ class SharedPreferencesRepository(val context: Context) {
         return preferences.getString(key, defaultValue)
     }
 
+    fun isUseDeviceTimeZoneEnabled(): Boolean {
+        val key = context.getString(R.string.preference_key_use_device_time_zone_enabled)
+        val defaultValue = context.resources.getBoolean(R.bool.preference_default_value_use_device_time_zone_enabled)
+        return preferences.getBoolean(key, defaultValue)
+    }
+
     fun isAlternativeHighlightingEnabled(): Boolean {
         val key = context.getString(R.string.preference_key_alternative_highlighting_enabled)
         val defaultValue = context.resources.getBoolean(R.bool.preference_default_value_alternative_highlighting_enabled)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -449,6 +449,9 @@ object AppRepository {
         return AlarmToneConversion.getNotificationIntentUri(alarmTone, AlarmTonePreference.DEFAULT_VALUE_URI)
     }
 
+    fun readUseDeviceTimeZoneEnabled() =
+        sharedPreferencesRepository.isUseDeviceTimeZoneEnabled()
+
     fun readAlternativeHighlightingEnabled() =
             sharedPreferencesRepository.isAlternativeHighlightingEnabled()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -475,12 +475,14 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private void fillTimes() {
         int normalizedBoxHeight = getNormalizedBoxHeight(displayDensityScale);
+        boolean useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled();
         List<TimeTextViewParameter> parameters = TimeTextViewParameter.parametersOf(
                 Moment.now(),
                 conference,
                 BuildConfig.SCHEDULE_FIRST_DAY_START_DAY,
                 mDay,
-                normalizedBoxHeight
+                normalizedBoxHeight,
+                useDeviceTimeZone
         );
         LinearLayout timeTextColumn = requireViewByIdCompat(requireView(), R.id.times_layout);
         timeTextColumn.removeAllViews();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -427,7 +427,9 @@ public class MainActivity extends BaseActivity implements
                 break;
             case MyApp.SETTINGS:
                 if (resultCode == Activity.RESULT_OK && intent != null) {
-                    if (intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_ALTERNATIVE_HIGHLIGHTING_UPDATED, false)) {
+                    boolean isAlternativeHighlightingUpdated = intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_ALTERNATIVE_HIGHLIGHTING_UPDATED, false);
+                    boolean isUseDeviceTimeZoneUpdated = intent.getBooleanExtra(BundleKeys.BUNDLE_KEY_USE_DEVICE_TIME_ZONE_UPDATED, false);
+                    if (isAlternativeHighlightingUpdated || isUseDeviceTimeZoneUpdated) {
                         if (findViewById(R.id.schedule) != null && findFragment(FahrplanFragment.FRAGMENT_TAG) == null) {
                             replaceFragment(R.id.schedule, new FahrplanFragment(),
                                     FahrplanFragment.FRAGMENT_TAG);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -45,8 +45,8 @@ internal class TimeSegment private constructor(
      *
      * See [DateFormatter.getFormattedTime24Hour].
      */
-    fun getFormattedText(sessionZoneOffset: ZoneOffset?): String =
-        DateFormatter.newInstance().getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
+    fun getFormattedText(sessionZoneOffset: ZoneOffset?, useDeviceTimeZone: Boolean): String =
+        DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
 
     /**
      * Returns true if the given [otherMoment] matches the internal rounded moment taken the

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameter.kt
@@ -31,7 +31,8 @@ internal data class TimeTextViewParameter private constructor(
                 conference: Conference,
                 firstDayStartDay: Int,
                 dayIndex: Int,
-                normalizedBoxHeight: Int
+                normalizedBoxHeight: Int,
+                useDeviceTimeZone: Boolean
         ): List<TimeTextViewParameter> {
             val parameters = mutableListOf<TimeTextViewParameter>()
             var sessionStartsAt = conference.firstSessionStartsAt
@@ -48,7 +49,7 @@ internal data class TimeTextViewParameter private constructor(
                 } else {
                     R.layout.time_layout
                 }
-                val titleText = timeSegment.getFormattedText(conference.timeZoneOffset)
+                val titleText = timeSegment.getFormattedText(conference.timeZoneOffset, useDeviceTimeZone)
                 val parameter = TimeTextViewParameter(timeTextLayout, timeTextViewHeight, titleText)
                 parameters.add(parameter)
                 sessionStartsAt = sessionStartsAt.plusMinutes(FIFTEEN_MINUTES.toLong())

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -55,6 +55,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
+        requirePreference<SwitchPreferenceCompat>(resources.getString(R.string.preference_key_use_device_time_zone_enabled)).onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any ->
+            requestRedraw(BundleKeys.BUNDLE_KEY_USE_DEVICE_TIME_ZONE_UPDATED)
+            true
+        }
+
         val appNotificationSettingsPreference = requirePreference<Preference>(getString(R.string.preference_key_app_notification_settings))
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             categoryGeneral.removePreference(appNotificationSettingsPreference)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.java
@@ -49,7 +49,9 @@ public class SimpleSessionFormat {
 
     private static void appendSession(StringBuilder builder, Session session, ZoneId timeZoneId) {
         long startTime = session.getStartTimeMilliseconds();
-        String shareableStartTime = DateFormatter.newInstance().getFormattedShareable(startTime, timeZoneId);
+        boolean useDeviceTimeZone = false; // Always share in the original session time zone.
+        //noinspection ConstantConditions
+        String shareableStartTime = DateFormatter.newInstance(useDeviceTimeZone).getFormattedShareable(startTime, timeZoneId);
         builder.append(session.title);
         builder.append(LINE_BREAK);
         builder.append(shareableStartTime);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -88,7 +88,8 @@ public class FahrplanMisc {
         String sessionId = session.sessionId;
         String sessionTitle = session.title;
         int alarmTimeInMin = alarmTimes.get(alarmTimesIndex);
-        String timeText = DateFormatter.newInstance().getFormattedDateTimeShort(alarmTime, session.timeZoneOffset);
+        boolean useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled();
+        String timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDateTimeShort(alarmTime, session.timeZoneOffset);
         int day = session.day;
 
         Alarm alarm = new Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText);

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -14,6 +14,9 @@
     <!-- Alarm tone -->
     <string name="preference_title_alarm_tone">Alarmton</string>
 
+    <!-- Device time zone -->
+    <string name="preference_title_use_device_time_zone_enabled">Zeitzone des Geräts nutzen</string>
+
     <!-- Alternative highlighting -->
     <string name="preference_title_alternative_highlighting_enabled">Alternative Hervorhebung</string>
 

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -55,6 +55,10 @@
     <string name="preference_key_alarm_tone" translatable="false">reminder_tone</string>
     <string name="preference_title_alarm_tone">Alarm tone</string>
 
+    <!-- Device time zone -->
+    <string name="preference_key_use_device_time_zone_enabled" translatable="false">use_device_time_zone</string>
+    <bool name="preference_default_value_use_device_time_zone_enabled">false</bool>
+
     <!-- Alternative highlighting -->
     <string name="preference_key_alternative_highlighting_enabled" translatable="false">alternative_highlight</string>
     <bool name="preference_default_value_alternative_highlighting_enabled">true</bool>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -58,6 +58,7 @@
     <!-- Device time zone -->
     <string name="preference_key_use_device_time_zone_enabled" translatable="false">use_device_time_zone</string>
     <bool name="preference_default_value_use_device_time_zone_enabled">false</bool>
+    <string name="preference_title_use_device_time_zone_enabled">Use device time zone</string>
 
     <!-- Alternative highlighting -->
     <string name="preference_key_alternative_highlighting_enabled" translatable="false">alternative_highlight</string>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -15,6 +15,12 @@
             android:title="@string/preference_title_auto_update_enabled"
             app:iconSpaceReserved="false" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/preference_default_value_use_device_time_zone_enabled"
+            android:key="@string/preference_key_use_device_time_zone_enabled"
+            android:title="@string/preference_title_use_device_time_zone_enabled"
+            app:iconSpaceReserved="false" />
+
         <Preference
             android:key="@string/preference_key_app_notification_settings"
             android:title="@string/preference_title_app_notification_settings"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
@@ -49,7 +49,7 @@ class TimeSegmentFormattedTextTest(
         val zoneOffsetNow = OffsetDateTime.now().offset
         val moment = Moment.now().startOfDay().plusMinutes(minutesOfTheDay.toLong())
         val segment = TimeSegment.ofMoment(moment)
-        assertThat(segment.getFormattedText(zoneOffsetNow)).isEqualTo(expectedFormattedText)
+        assertThat(segment.getFormattedText(zoneOffsetNow, useDeviceTimeZone = false)).isEqualTo(expectedFormattedText)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeTextViewParameterTest.kt
@@ -112,7 +112,7 @@ class TimeTextViewParameterTest {
     private fun parametersOf(nowMoment: Moment, moment: Moment, duration: Int, dayIndex: Int): List<TimeTextViewParameter> {
         val session = createSession(moment, duration)
         val conference = Conference.ofSessions(listOf(session))
-        return TimeTextViewParameter.parametersOf(nowMoment, conference, moment.monthDay, dayIndex, NORMALIZED_BOX_HEIGHT)
+        return TimeTextViewParameter.parametersOf(nowMoment, conference, moment.monthDay, dayIndex, NORMALIZED_BOX_HEIGHT, useDeviceTimeZone = false)
     }
 
     private fun TimeTextViewParameter.assert(@LayoutRes layout: Int, titleText: String) {

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -11,7 +11,12 @@ import org.threeten.bp.format.FormatStyle
 /**
  * Format timestamps according to system locale and system time zone.
  */
-class DateFormatter private constructor() {
+class DateFormatter private constructor(
+
+    val useDeviceTimeZone: Boolean
+
+) {
+
     private val timeShortNumberOnlyFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val timeShortFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val dateShortFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
@@ -95,19 +100,19 @@ class DateFormatter private constructor() {
 
     /**
      * Returns the available zone offset - either the given [sessionZoneOffset] or the zone offset
-     * of the device.
+     * of the device. The user can overrule the logic by setting [useDeviceTimeZone].
      */
     private fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
         val deviceZoneOffset = OffsetDateTime.now().offset
         val useDeviceZoneOffset = sessionZoneOffset == null || sessionZoneOffset == deviceZoneOffset
-        return if (useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset!!
+        return if (useDeviceTimeZone || useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset!!
     }
 
     companion object {
 
         @JvmStatic
-        fun newInstance(): DateFormatter {
-            return DateFormatter()
+        fun newInstance(useDeviceTimeZone: Boolean): DateFormatter {
+            return DateFormatter(useDeviceTimeZone)
         }
     }
 }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
@@ -98,7 +98,7 @@ class DateFormatterFormattedTime24HourTest(
         pairs.forEach { (dateTime, expectedFormattedTime) ->
             val (moment, offset) = parse(dateTime)
             withTimeZone(timeZoneId) {
-                val formattedTime = DateFormatter.newInstance().getFormattedTime24Hour(moment, offset)
+                val formattedTime = DateFormatter.newInstance(useDeviceTimeZone = false).getFormattedTime24Hour(moment, offset)
                 assertThat(formattedTime).isEqualTo(expectedFormattedTime)
             }
         }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -109,7 +109,7 @@ class DateFormatterTest {
     }
 
     private fun createDateFormatter(): DateFormatter {
-        return DateFormatter.newInstance()
+        return DateFormatter.newInstance(useDeviceTimeZone = false)
     }
 
     private fun getTimeZoneOffsetNow(): ZoneOffset {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -37,42 +37,42 @@ class DateFormatterTest {
     fun getFormattedTime() {
         Locale.setDefault(Locale("en", "US"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("1:00 AM")
+        assertThat(createDateFormatter().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("1:00 AM")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("2:00 PM")
+        assertThat(createDateFormatter().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("2:00 PM")
 
         Locale.setDefault(Locale("de", "DE"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("14:00")
+        assertThat(createDateFormatter().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("14:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"))
-        assertThat(DateFormatter.newInstance().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("06:00")
+        assertThat(createDateFormatter().getFormattedTime(timestamp, getTimeZoneOffsetNow())).isEqualTo("06:00")
     }
 
     @Test
     fun getFormattedTimeNumbersOnly() {
         Locale.setDefault(Locale("en", "US"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("01:00")
+        assertThat(createDateFormatter().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("01:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
+        assertThat(createDateFormatter().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
 
         Locale.setDefault(Locale("de", "DE"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("06:00")
+        assertThat(createDateFormatter().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("06:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(DateFormatter.newInstance().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
+        assertThat(createDateFormatter().getFormattedTime24Hour(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
     }
 
     @Test
     fun getFormattedDate() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19")
+        assertThat(createDateFormatter().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
+        assertThat(createDateFormatter().getFormattedDate(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
     }
 
     // This test only passes when being executed in a JDK 8 environment.
@@ -80,19 +80,19 @@ class DateFormatterTest {
     @Test
     fun getFormattedShareable() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
+        assertThat(createDateFormatter().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
                 .isEqualTo("Tuesday, January 22, 2019 1:00 AM GMT+01:00")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
+        assertThat(createDateFormatter().getFormattedShareable(timestamp, NO_TIME_ZONE_ID))
                 .isEqualTo("Dienstag, 22. Januar 2019 01:00 GMT+01:00")
 
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
+        assertThat(createDateFormatter().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
                 .isEqualTo("Tuesday, January 22, 2019 1:00 AM CET (Europe/Berlin)")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
+        assertThat(createDateFormatter().getFormattedShareable(timestamp, TIME_ZONE_EUROPE_BERLIN))
                 .isEqualTo("Dienstag, 22. Januar 2019 01:00 MEZ (Europe/Berlin)")
 
     }
@@ -102,10 +102,14 @@ class DateFormatterTest {
     @Test
     fun getFormattedDateTimeShort() {
         Locale.setDefault(Locale.US)
-        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19 1:00 AM")
+        assertThat(createDateFormatter().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("1/22/19 1:00 AM")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(DateFormatter.newInstance().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19 01:00")
+        assertThat(createDateFormatter().getFormattedDateTimeShort(timestamp, getTimeZoneOffsetNow())).isEqualTo("22.01.19 01:00")
+    }
+
+    private fun createDateFormatter(): DateFormatter {
+        return DateFormatter.newInstance()
     }
 
     private fun getTimeZoneOffsetNow(): ZoneOffset {


### PR DESCRIPTION
# Description
- Prepare `DateFormatter` to format based on the **time zone of the device**.
  - This allows to overrule the general logic of choosing a time zone for rendering date/time information.
- Enable users to **switch between device and event time zone**.
  - Add `Use device time zone` **settings** switch which allows users to render schedule information according to the time zone of the device. This feature aims at users who watch an event from remote from a time zone different from the "natural" time zone of the event.
  - Sharing event data is **not affected** by this setting.

# Use device time zone setting disabled
- The system time zone of the device is set to New York (GMT-05:00).
![rC3-settings-event-time-zone](https://user-images.githubusercontent.com/144518/109716770-88ceb300-7ba5-11eb-8643-123f5d5b4385.png) ![rC3-schedule-event-time-zone](https://user-images.githubusercontent.com/144518/109716767-88ceb300-7ba5-11eb-8b07-3daf3175e1ec.png) ![rC3-favs-event-time-zone](https://user-images.githubusercontent.com/144518/109716765-88361c80-7ba5-11eb-8917-3c236b4f2dfe.png) ![rC3-alarm-event-time-zone](https://user-images.githubusercontent.com/144518/109716760-879d8600-7ba5-11eb-884f-29549b7e6ce2.png)

# Use device time zone setting enabled
- The system time zone of the device is set to New York (GMT-05:00).
![rC3-settings-device-time-zone](https://user-images.githubusercontent.com/144518/109716824-93894800-7ba5-11eb-9a2a-4183ede38dad.png) ![rC3-schedule-device-time-zone](https://user-images.githubusercontent.com/144518/109716821-93894800-7ba5-11eb-99b6-76a099e1a161.png) ![rC3-favs-device-time-zone](https://user-images.githubusercontent.com/144518/109716819-92f0b180-7ba5-11eb-841c-e3126c176da3.png) ![rC3-alarms-device-time-zone](https://user-images.githubusercontent.com/144518/109716814-92581b00-7ba5-11eb-9f04-95a15691cb0c.png)

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)

# Travis CI
- Please ignore the build. CI is currently out of service. :no_entry: 

---

Resolves #69