### PR TITLE
Use snackengage-playrate v.0.28.

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -50,7 +50,7 @@ object Libs {
         const val preference = "1.1.1"
         const val retrofit = "2.6.4"
         const val robolectric = "4.3_r2-robolectric-0"
-        const val snackengage = "0.27"
+        const val snackengage = "0.28"
         const val testExtJunit = "1.1.2"
         const val threeTenBp = "1.5.0"
         const val tracedroid = "1.4"


### PR DESCRIPTION
+ Changes: https://github.com/ligi/SnackEngage/compare/0.27..0.28.
+ Increases `com.google.android.material:material` from `1.2.1` to `1.3.0` to match project.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)