### PR TITLE
Use compileSdkVersion & targetSdkVersion 30 (Android 11).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ notifications:
   email: true
 
 before_install:
-- yes | sdkmanager "platforms;android-29"
+- yes | sdkmanager "platforms;android-30"
 
 before_script:
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -4,9 +4,9 @@ package nerd.tuxmobil.fahrplan.congress
 
 object Android {
     const val buildToolsVersion = "29.0.3"
-    const val compileSdkVersion = 29
+    const val compileSdkVersion = 30
     const val minSdkVersion = 14
-    const val targetSdkVersion = 29
+    const val targetSdkVersion = 30
 }
 
 object Plugins {


### PR DESCRIPTION
# Description
- Use compileSdkVersion 30.
- Use targetSdkVersion 30.
- Update Android version for Travis CI.

# Successfully tested on
with `rc3` flavor, `release` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 9, Android 7.1.1 (API 25)

with `ccc36c3` flavor, `release` build
- :heavy_check_mark: Nexus 9, Android 7.1.1 (API 25)
  - checked Engelsystem feature here

---

Resolves #371.