### PR TITLE
Preserve sessions view scrolling position when returning from details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -423,17 +423,17 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                 conference, MyApp.dateInfos, scheduleData, nowMoment, currentDayIndex, boxHeight, columnIndex);
 
         final int pos = scrollAmount;
-        final NestedScrollView scrollView = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
-        scrollView.scrollTo(0, scrollAmount);
-        scrollView.post(() -> scrollView.scrollTo(0, pos));
+        final NestedScrollView verticalScrollView = requireViewByIdCompat(layoutRootView, R.id.verticalScrollView);
+        verticalScrollView.scrollTo(0, scrollAmount);
+        verticalScrollView.post(() -> verticalScrollView.scrollTo(0, pos));
     }
 
     private void setBell(Session session) {
-        NestedScrollView parent = requireView().findViewById(R.id.scrollView1);
-        if (parent == null) {
+        NestedScrollView verticalScrollView = requireView().findViewById(R.id.verticalScrollView);
+        if (verticalScrollView == null) {
             return;
         }
-        View v = parent.findViewWithTag(session);
+        View v = verticalScrollView.findViewWithTag(session);
         if (v == null) {
             return;
         }
@@ -454,8 +454,8 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         int pos = scrollAmountCalculator.calculateScrollAmount(conference, session, height);
         MyApp.LogDebug(LOG_TAG, "position is " + pos);
         View layoutRootView = requireView();
-        final NestedScrollView parent = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
-        parent.post(() -> parent.scrollTo(0, pos));
+        final NestedScrollView verticalScrollView = requireViewByIdCompat(layoutRootView, R.id.verticalScrollView);
+        verticalScrollView.post(() -> verticalScrollView.scrollTo(0, pos));
         final HorizontalSnapScrollView horiz = layoutRootView.findViewById(R.id.horizScroller);
         if (horiz != null) {
             final int hpos = scheduleData.findRoomIndex(session);
@@ -753,11 +753,11 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     }
 
     private View getSessionView(Session session) {
-        NestedScrollView parent = requireView().findViewById(R.id.scrollView1);
-        if (parent == null) {
+        NestedScrollView verticalScrollView = requireView().findViewById(R.id.verticalScrollView);
+        if (verticalScrollView == null) {
             return null;
         }
-        return parent.findViewWithTag(session);
+        return verticalScrollView.findViewWithTag(session);
     }
 
     private void refreshViews() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -31,6 +31,7 @@ import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.widget.NestedScrollView;
+import androidx.core.widget.NestedScrollView.OnScrollChangeListener;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -130,6 +131,8 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private ScrollAmountCalculator scrollAmountCalculator;
 
+    private boolean preserveVerticalScrollPosition = false;
+
     private final OnSessionsChangeListener onSessionsChangeListener = new OnSessionsChangeListener() {
         @Override
         public void onAlarmsChanged() {
@@ -169,7 +172,11 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     public View onCreateView(@NonNull LayoutInflater inflater,
                              @Nullable ViewGroup container,
                              @Nullable Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.schedule, container, false);
+        View layoutRootView = inflater.inflate(R.layout.schedule, container, false);
+        NestedScrollView verticalScrollView = requireViewByIdCompat(layoutRootView, R.id.verticalScrollView);
+        verticalScrollView.setOnScrollChangeListener((OnScrollChangeListener)
+                (view, scrollX, scrollY, oldScrollX, oldScrollY) -> preserveVerticalScrollPosition = true);
+        return layoutRootView;
     }
 
     @Override
@@ -299,7 +306,10 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         addRoomColumns(horizontalScroller, columnWidth, scheduleData, forceReload);
 
         MainActivity.getInstance().shouldScheduleScrollToCurrentTimeSlot(() -> {
-            scrollToCurrent(boxHeight);
+            if (!preserveVerticalScrollPosition) {
+                scrollToCurrent(boxHeight);
+                preserveVerticalScrollPosition = false;
+            }
             return Unit.INSTANCE;
         });
 
@@ -468,6 +478,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         if (chosenDay + 1 != mDay) {
             mDay = chosenDay + 1;
             saveCurrentDay(mDay);
+            preserveVerticalScrollPosition = false;
             viewDay(true);
             fillTimes();
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -21,7 +21,6 @@ import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
-import android.widget.ScrollView;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -31,6 +30,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -423,13 +423,13 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                 conference, MyApp.dateInfos, scheduleData, nowMoment, currentDayIndex, boxHeight, columnIndex);
 
         final int pos = scrollAmount;
-        final ScrollView scrollView = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
+        final NestedScrollView scrollView = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
         scrollView.scrollTo(0, scrollAmount);
         scrollView.post(() -> scrollView.scrollTo(0, pos));
     }
 
     private void setBell(Session session) {
-        ScrollView parent = requireView().findViewById(R.id.scrollView1);
+        NestedScrollView parent = requireView().findViewById(R.id.scrollView1);
         if (parent == null) {
             return;
         }
@@ -454,7 +454,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         int pos = scrollAmountCalculator.calculateScrollAmount(conference, session, height);
         MyApp.LogDebug(LOG_TAG, "position is " + pos);
         View layoutRootView = requireView();
-        final ScrollView parent = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
+        final NestedScrollView parent = requireViewByIdCompat(layoutRootView, R.id.scrollView1);
         parent.post(() -> parent.scrollTo(0, pos));
         final HorizontalSnapScrollView horiz = layoutRootView.findViewById(R.id.horizScroller);
         if (horiz != null) {
@@ -753,7 +753,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     }
 
     private View getSessionView(Session session) {
-        ScrollView parent = requireView().findViewById(R.id.scrollView1);
+        NestedScrollView parent = requireView().findViewById(R.id.scrollView1);
         if (parent == null) {
             return null;
         }

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -36,7 +36,7 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/scrollView1"
+            android:id="@+id/verticalScrollView"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:layout_below="@+id/roomNameLandscape">

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -35,7 +35,7 @@
         </HorizontalScrollView>
     </LinearLayout>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
             android:id="@+id/scrollView1"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
@@ -74,6 +74,6 @@
 
         </LinearLayout>
 
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -36,7 +36,7 @@
 
     </LinearLayout>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
             android:id="@+id/scrollView1"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
@@ -76,5 +76,5 @@
                 </LinearLayout>
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </RelativeLayout>

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -37,7 +37,7 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/scrollView1"
+            android:id="@+id/verticalScrollView"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:layout_below="@+id/roomNameLandscape"

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -36,7 +36,7 @@
         </HorizontalScrollView>
     </LinearLayout>
 
-    <ScrollView
+    <androidx.core.widget.NestedScrollView
             android:id="@+id/scrollView1"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
@@ -76,5 +76,5 @@
                 </LinearLayout>
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>
-    </ScrollView>
+    </androidx.core.widget.NestedScrollView>
 </RelativeLayout>

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -37,7 +37,7 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/scrollView1"
+            android:id="@+id/verticalScrollView"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:layout_below="@+id/roomNameLandscape"


### PR DESCRIPTION
# Description
This fixes an issue which occurred when the following conditions were met:
  1. the current day was selected in the app
  2. a session was un/favored in the details screen

Then the sessions view always scrolled to the current time when the user navigated back from the details screen instead of remaining its scroll position.

# Before
The video show how the scroll position always jumps back to the current time.

https://user-images.githubusercontent.com/144518/114065533-0c617b00-989b-11eb-9051-344686b45639.mp4

# After
The video show how the scroll position is retained.

https://user-images.githubusercontent.com/144518/114065755-4c286280-989b-11eb-9e6a-92f5ac2c953d.mp4

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10


---

Resolves #381 