### PR TITLE
Drop support for devices running Android 4.0-4.0.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please read the instructions in the [contribution guide](CONTRIBUTING.md) in ord
 ## Table of contents
 
 - [Features](#features)
+- [Android versions](#android-versions)
 - [Event data](#event-data)
 - [Build instructions](#build-instructions)
 - [History](#history)
@@ -54,6 +55,12 @@ Please read the instructions in the [contribution guide](CONTRIBUTING.md) in ord
 * [c3nav][c3nav-github] - An indoor navigation project
 * [Engelsystem][engelsystem-website] - Online tool for coordinating helpers and shifts on large events
 * [Chaosflix][chaosflix-github] - Android app for media.ccc.de, share Fahrplan favorites with Chaosflix to import them as bookmarks
+
+
+## Android versions
+
+The application is designed to work both on smartphones and on tablets.
+Android 4.1 (Jelly Bean) and newer versions are supported.
 
 
 ## Event data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="nerd.tuxmobil.fahrplan.congress"
-          xmlns:tools="http://schemas.android.com/tools">
+          package="nerd.tuxmobil.fahrplan.congress">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-
-    <!-- Force minSdkVersion defined by this project, see LinkMovementMethodCompat. -->
-    <uses-sdk tools:overrideLibrary="me.saket.bettermovementmethod" />
 
     <application
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -305,9 +305,7 @@ public class MainActivity extends BaseActivity implements
     @Override
     protected void onResume() {
         super.onResume();
-        isScreenLocked = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
-                ? keyguardManager.isKeyguardLocked()
-                : keyguardManager.inKeyguardRestrictedInputMode();
+        isScreenLocked = keyguardManager.isKeyguardLocked();
 
         FrameLayout sidePane = findViewById(R.id.detail);
         if (sidePane != null && isFavoritesInSidePane) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LinkMovementMethodCompat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/LinkMovementMethodCompat.kt
@@ -1,23 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
-import android.os.Build
-import android.text.method.LinkMovementMethod
 import android.text.method.MovementMethod
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 
 object LinkMovementMethodCompat {
 
     /**
-     * Returns an instance of [BetterLinkMovementMethod] on devices running
-     * Android 4.1.x Jelly Bean (API 16) or newer. [LinkMovementMethod] is
-     * returned for devices running an older Android version.
+     * Returns an instance of [BetterLinkMovementMethod].
      */
     @JvmStatic
-    fun getInstance(): MovementMethod =
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-                LinkMovementMethod.getInstance()
-            } else {
-                BetterLinkMovementMethod.getInstance()
-            }
+    fun getInstance(): MovementMethod = BetterLinkMovementMethod.getInstance()
 
 }

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -5,7 +5,7 @@ package nerd.tuxmobil.fahrplan.congress
 object Android {
     const val buildToolsVersion = "30.0.3"
     const val compileSdkVersion = 30
-    const val minSdkVersion = 14
+    const val minSdkVersion = 16
     const val targetSdkVersion = 30
 }
 


### PR DESCRIPTION
# Description
+ Affects [API 14-15 (Ice Cream Sandwich)](https://en.wikipedia.org/wiki/Android_version_history#Android_4.0_Ice_Cream_Sandwich). :coffin: 
+ No device with these versions appeared for more then a year in the Google Play statistics.
+ Last minSdkVersion update: b29e454f90c82c2e105954457535e53287e51980.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Nexus 5 emulator, Android 4.1.2
- :heavy_check_mark: Pixel 2 device, Android 10