### PR TITLE
Revise app settings screen

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -11,6 +11,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceChangeListener
 import androidx.preference.Preference.OnPreferenceClickListener
+import androidx.preference.Preference.SummaryProvider
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
@@ -76,6 +77,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 requestRedraw(BundleKeys.BUNDLE_KEY_SCHEDULE_URL_UPDATED)
                 true
             }
+            alternativeScheduleUrlPreference.summaryProvider = SummaryProvider<EditTextPreference> {
+                when (it.text.isEmpty()) {
+                    true -> getString(R.string.preference_summary_alternative_schedule_url)
+                    false -> it.text
+                }
+            }
         } else {
             categoryGeneral.removePreference(alternativeScheduleUrlPreference)
         }
@@ -89,7 +96,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val engelsystemCategory = requirePreference<PreferenceCategory>(getString(R.string.preference_engelsystem_category_key))
         if (BuildConfig.ENABLE_ENGELSYSTEM_SHIFTS) {
             val urlPreference = requirePreference<EditTextPreference>(getString(R.string.preference_key_engelsystem_json_export_url))
-            urlPreference.summary = getString(R.string.preference_summary_engelsystem_json_export_url).toSpanned()
+            urlPreference.summaryProvider = SummaryProvider<EditTextPreference> {
+                when (it.text.isEmpty()) {
+                    true -> getString(R.string.preference_summary_engelsystem_json_export_url).toSpanned()
+                    false -> "${it.text.dropLast(23)}..." // Truncate to keep the key private.
+                }
+            }
             urlPreference.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->
                 requestRedraw(BundleKeys.BUNDLE_KEY_ENGELSYSTEM_SHIFTS_URL_UPDATED)
                 true

--- a/app/src/main/res/drawable-v21/ic_open_external.xml
+++ b/app/src/main/res/drawable-v21/ic_open_external.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?android:attr/textColorSecondary"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?android:attr/textColorSecondary"
+        android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z" />
+</vector>

--- a/app/src/main/res/drawable/ic_open_external.xml
+++ b/app/src/main/res/drawable/ic_open_external.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#ffffff"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z" />
+</vector>

--- a/app/src/main/res/layout/settings_widget_open_external.xml
+++ b/app/src/main/res/layout/settings_widget_open_external.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:layout_marginLeft="12dp"
+        android:layout_marginEnd="12dp"
+        android:layout_marginRight="12dp"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_open_external" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -2,29 +2,36 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen &#8230;</string>
+    <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen</string>
+    <string name="preference_summary_app_notification_settings">Öffne den dazugehörigen System-Einstellungen-Bildschirm von hier.</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Automatische Aktualisierung</string>
+    <string name="preference_title_auto_update_enabled">Automatische Aktualisierung anschalten</string>
+    <string name="preference_summary_auto_update_enabled">Lädt den Fahrplan regelmäßig herunter.</string>
 
     <!-- Alarm time index -->
     <string name="preference_dialog_title_alarm_time">Wähle eine Standard-Alarmzeit</string>
-    <string name="preference_title_alarm_time">Standard-Alarmzeit</string>
+    <string name="preference_title_alarm_time">Standard-Alarmzeit auswählen</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Alarmton</string>
+    <string name="preference_title_alarm_tone">Alarmton auswählen</string>
+    <string name="preference_summary_alarm_tone">Öffne den Töne-Auswahl-Bildschirm von hier.</string>
 
     <!-- Device time zone -->
     <string name="preference_title_use_device_time_zone_enabled">Zeitzone des Geräts nutzen</string>
+    <string name="preference_summary_use_device_time_zone_enabled">Zeigt Datums- und Zeitangaben entsprechend an.</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Alternative Hervorhebung</string>
+    <string name="preference_title_alternative_highlighting_enabled">Alternative Hervorhebung anschalten</string>
+    <string name="preference_summary_alternative_highlighting_enabled">Fügt favorisierten Vorträgen eine Umrandung hinzu.</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">Alternative Fahrplan URL</string>
+    <string name="preference_title_alternative_schedule_url">Alternative Fahrplan URL festlegen</string>
+    <string name="preference_summary_alternative_schedule_url">Füge eine Ausweich-URL ein, wenn der voreingestellte Server nicht erreichbar ist.</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Dauerhafter Alarm</string>
+    <string name="preference_title_insistent_alarms_enabled">Dauerhaften Alarm anschalten</string>
+    <string name="preference_summary_insistent_alarms_enabled">Lässt einen Alarm unendlich lange klingeln.</string>
 
     <!-- Category Engelsystem -->
 
@@ -35,5 +42,6 @@
         3. Füge die URL hier ein.<br/><br/>
         Schichten vor und nach den offiziellen Konferenztagen werden <u>nicht</u> dargestellt.]]>
     </string>
+    <string name="preference_title_engelsystem_json_export_url">JSON Export URL festlegen</string>
 
 </resources>

--- a/app/src/main/res/values-es/preferences.xml
+++ b/app/src/main/res/values-es/preferences.xml
@@ -2,26 +2,18 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Personalizar notificaciones &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Actualizaciones automáticas</string>
 
     <!-- Alarm time index -->
-    <string name="preference_title_alarm_time">Horario de alarma por defecto</string>
-    <string name="preference_dialog_title_alarm_time">Escoja un horario de alarma por defecto</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Tono de alarma</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Destacado alternativo</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">URL alternativa del calendario</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Alarma persistente</string>
 
     <!-- Category Engelsystem -->
 

--- a/app/src/main/res/values-fr/preferences.xml
+++ b/app/src/main/res/values-fr/preferences.xml
@@ -2,26 +2,18 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Personnaliser les notifications&#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Mises à jour automatiques</string>
 
     <!-- Alarm time index -->
-    <string name="preference_title_alarm_time">Heure par défaut du rappel</string>
-    <string name="preference_dialog_title_alarm_time">Choisissez l’heure par défaut du rappel</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Sonnerie du rappel</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Mise en évidence alternative</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">URL alternative du programme</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Rappel insistant</string>
 
     <!-- Category Engelsystem -->
     <string name="preference_summary_engelsystem_json_export_url"><![CDATA[Afin de voir vos créneaux de service, veuillez entrer votre URL <u>personnel</u>ici.<br /><br />

--- a/app/src/main/res/values-it/preferences.xml
+++ b/app/src/main/res/values-it/preferences.xml
@@ -2,25 +2,17 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Preferenze per le notifiche &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Aggiornamenti automatici</string>
 
     <!-- Alarm time index -->
-    <string name="preference_title_alarm_time">Ora predefinita per i promemoria</string>
-    <string name="preference_dialog_title_alarm_time">Si scelga un\'ora predefinita per i promemoria</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Suoneria del promemoria</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Highlight alternativo</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">URL alternativo del programma</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Promemoria persistente</string>
 
 </resources>

--- a/app/src/main/res/values-ja/preferences.xml
+++ b/app/src/main/res/values-ja/preferences.xml
@@ -2,26 +2,18 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">通知をカスタマイズ &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">自動更新</string>
 
     <!-- Alarm time index -->
-    <string name="preference_dialog_title_alarm_time">デフォルトのアラーム時間を選択します</string>
-    <string name="preference_title_alarm_time">デフォルトのアラーム時間</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">アラーム音</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">代替の強調表示</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">代替のスケジュールURL</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">しつこいアラーム</string>
 
     <!-- Category Engelsystem -->
     <string name="preference_summary_engelsystem_json_export_url">

--- a/app/src/main/res/values-nl/preferences.xml
+++ b/app/src/main/res/values-nl/preferences.xml
@@ -2,25 +2,17 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Meldingen aanpassen &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Automatisch bijwerken</string>
 
     <!-- Alarm time index -->
-    <string name="preference_dialog_title_alarm_time">Kies een standaard alarmtijd</string>
-    <string name="preference_title_alarm_time">Standaard alarmtijd</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Alarm toon</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Alternatieve markering</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">Alternatieve tijdschema URL</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Aanhoudend alarm</string>
 
 </resources>

--- a/app/src/main/res/values-pt/preferences.xml
+++ b/app/src/main/res/values-pt/preferences.xml
@@ -22,8 +22,5 @@
         3. Cole a URL aqui.<br/><br/>
         Os turnos antes e depois dos dias da conferência principal <u>não</u> são exibidos.]]>
     </string>
-    <string name="preference_url_type_friendly_name_engelsystem_json_export">
-        Engelsystem
-    </string>
 
 </resources>

--- a/app/src/main/res/values-pt/preferences.xml
+++ b/app/src/main/res/values-pt/preferences.xml
@@ -2,26 +2,18 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Customizar notificações &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Atualizações automáticas</string>
 
     <!-- Alarm time index -->
-    <string name="preference_dialog_title_alarm_time">Escolha o horário de alerta padrão</string>
-    <string name="preference_title_alarm_time">Horário padrão de alerta</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Som do alerta</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Destaque alternativo</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">URL alternativa de cronograma</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Alerta persistente</string>
 
     <string name="preference_summary_engelsystem_json_export_url">
     <![CDATA[Para ver seus turnos, insira sua URL <u>pessoal</u> aqui.<br/><br/>

--- a/app/src/main/res/values-ru/preferences.xml
+++ b/app/src/main/res/values-ru/preferences.xml
@@ -2,25 +2,17 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Настройки уведомлений &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Автоматические обновления</string>
 
     <!-- Alarm time index -->
-    <string name="preference_dialog_title_alarm_time">Выбрать время напоминания по умолчанию</string>
-    <string name="preference_title_alarm_time">Время напоминания по умолчанию</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Мелодия напоминаний</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Альтернативная подсветка</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">Альтернативный URL расписания</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Настойчивое напоминание</string>
 
 </resources>

--- a/app/src/main/res/values-sv/preferences.xml
+++ b/app/src/main/res/values-sv/preferences.xml
@@ -2,26 +2,18 @@
 <resources>
 
     <!-- App notification settings -->
-    <string name="preference_title_app_notification_settings">Anpassa aviseringar &#8230;</string>
 
     <!-- Automatic schedule updates -->
-    <string name="preference_title_auto_update_enabled">Automatiska uppdateringar</string>
 
     <!-- Alarm time index -->
-    <string name="preference_dialog_title_alarm_time">Välj standard alarm tid</string>
-    <string name="preference_title_alarm_time">Standard alarm tid</string>
 
     <!-- Alarm tone -->
-    <string name="preference_title_alarm_tone">Alarmsignal</string>
 
     <!-- Alternative highlighting -->
-    <string name="preference_title_alternative_highlighting_enabled">Alternerande markering</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_title_alternative_schedule_url">Alternativ schema-URL</string>
 
     <!-- Insistent session alarms -->
-    <string name="preference_title_insistent_alarms_enabled">Ihållande varning</string>
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[För att se din pass, ange din <u>personliga</u> URL här.<br/><br/>

--- a/app/src/main/res/values-sv/preferences.xml
+++ b/app/src/main/res/values-sv/preferences.xml
@@ -23,8 +23,4 @@
         Pass före och efter huvudkonferensens dagar syns <u>inte</u>.]]>
     </string>
 
-    <string name="preference_url_type_friendly_name_engelsystem_json_export">
-        Engelsystem
-    </string>
-
 </resources>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -10,7 +10,8 @@
     <!-- Automatic schedule updates -->
     <string name="preference_key_auto_update_enabled" translatable="false">auto_update</string>
     <bool name="preference_default_value_auto_update_enabled">true</bool>
-    <string name="preference_title_auto_update_enabled">Automatic updates</string>
+    <string name="preference_title_auto_update_enabled">Enable automatic updates</string>
+    <string name="preference_summary_auto_update_enabled">Downloads the schedule periodically.</string>
 
     <!-- Alarm time index -->
     <string name="preference_key_alarm_time_index" translatable="false">default_alarm_time</string>
@@ -24,7 +25,7 @@
     -->
     <string name="preference_default_value_alarm_time_value" translatable="false">10</string>
     <string name="preference_dialog_title_alarm_time">Choose a default alarm time</string>
-    <string name="preference_title_alarm_time">Default alarm time</string>
+    <string name="preference_title_alarm_time">Choose default alarm time</string>
     <string-array name="preference_entries_alarm_time_titles">
         <item>@string/alarm_time_title_at_start_time</item>
         <item>@string/alarm_time_title_5_minutes_before</item>
@@ -53,17 +54,20 @@
 
     <!-- Alarm tone -->
     <string name="preference_key_alarm_tone" translatable="false">reminder_tone</string>
-    <string name="preference_title_alarm_tone">Alarm tone</string>
+    <string name="preference_title_alarm_tone">Choose alarm tone</string>
+    <string name="preference_summary_alarm_tone">Open the sounds selection screen from here.</string>
 
     <!-- Device time zone -->
     <string name="preference_key_use_device_time_zone_enabled" translatable="false">use_device_time_zone</string>
     <bool name="preference_default_value_use_device_time_zone_enabled">false</bool>
     <string name="preference_title_use_device_time_zone_enabled">Use device time zone</string>
+    <string name="preference_summary_use_device_time_zone_enabled">Displays dates and times accordingly.</string>
 
     <!-- Alternative highlighting -->
     <string name="preference_key_alternative_highlighting_enabled" translatable="false">alternative_highlight</string>
     <bool name="preference_default_value_alternative_highlighting_enabled">true</bool>
-    <string name="preference_title_alternative_highlighting_enabled">Alternative highlighting</string>
+    <string name="preference_title_alternative_highlighting_enabled">Enable alternative highlighting</string>
+    <string name="preference_summary_alternative_highlighting_enabled">Adds a border around favored sessions.</string>
 
     <!-- Alternative schedule URL -->
     <string name="preference_key_alternative_schedule_url" translatable="false">
@@ -73,16 +77,19 @@
     <string name="preference_hint_alternative_schedule_url" translatable="false">
         https://yourhost/schedule.xml
     </string>
-    <string name="preference_title_alternative_schedule_url">Alternative schedule URL</string>
+    <string name="preference_title_alternative_schedule_url">Configure alternative schedule URL</string>
+    <string name="preference_summary_alternative_schedule_url">Enter a backup URL if the preconfigured server cannot be reached.</string>
 
     <!-- App notification settings -->
     <string name="preference_key_app_notification_settings" translatable="false">app_notification_settings</string>
-    <string name="preference_title_app_notification_settings">Customize notifications &#8230;</string>
+    <string name="preference_title_app_notification_settings">Customize notifications</string>
+    <string name="preference_summary_app_notification_settings">Open the associated system settings screen from here.</string>
 
     <!-- Insistent session alarms -->
     <string name="preference_key_insistent_alarms_enabled" translatable="false">insistent</string>
     <bool name="preference_default_value_insistent_alarms_enabled">false</bool>
-    <string name="preference_title_insistent_alarms_enabled">Insistent alarm</string>
+    <string name="preference_title_insistent_alarms_enabled">Enable insistent alarm</string>
+    <string name="preference_summary_insistent_alarms_enabled">Keeps an alarm on infinitely.</string>
 
     <!-- Category Engelsystem -->
 
@@ -93,7 +100,7 @@
     <string name="preference_key_engelsystem_json_export_url" translatable="false">
         preference_key_engelsystem_json_export_url
     </string>
-    <string name="preference_default_value_engelsystem_json_export_url" translatable="false"/>
+    <string name="preference_default_value_engelsystem_json_export_url" translatable="false" />
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[In order to see your shifts please enter your <u>personal</u> URL here.<br/><br/>
         1. Login to your Engelsystem account.<br/>
@@ -101,7 +108,7 @@
         3. Paste the URL here.<br/><br/>
         Shifts before and after the main conference days are <u>not</u> displayed.]]>
     </string>
-    <string name="preference_title_engelsystem_json_export_url" translatable="false">JSON Export URL</string>
+    <string name="preference_title_engelsystem_json_export_url">Configure JSON Export URL</string>
     <string name="preference_url_type_friendly_name_engelsystem_json_export">
         Engelsystem
     </string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -109,7 +109,7 @@
         Shifts before and after the main conference days are <u>not</u> displayed.]]>
     </string>
     <string name="preference_title_engelsystem_json_export_url">Configure JSON Export URL</string>
-    <string name="preference_url_type_friendly_name_engelsystem_json_export">
+    <string name="preference_url_type_friendly_name_engelsystem_json_export" translatable="false">
         Engelsystem
     </string>
 

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -13,18 +13,21 @@
             android:defaultValue="@bool/preference_default_value_auto_update_enabled"
             android:key="@string/preference_key_auto_update_enabled"
             android:title="@string/preference_title_auto_update_enabled"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_auto_update_enabled" />
 
         <SwitchPreferenceCompat
             android:defaultValue="@bool/preference_default_value_use_device_time_zone_enabled"
             android:key="@string/preference_key_use_device_time_zone_enabled"
             android:title="@string/preference_title_use_device_time_zone_enabled"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_use_device_time_zone_enabled" />
 
         <Preference
             android:key="@string/preference_key_app_notification_settings"
             android:title="@string/preference_title_app_notification_settings"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_app_notification_settings" />
 
         <!--
         TODO: Use ValidateableEditTextPreference
@@ -36,13 +39,15 @@
             android:inputType="textUri"
             android:key="@string/preference_key_alternative_schedule_url"
             android:title="@string/preference_title_alternative_schedule_url"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
 
         <SwitchPreferenceCompat
             android:defaultValue="@bool/preference_default_value_alternative_highlighting_enabled"
             android:key="@string/preference_key_alternative_highlighting_enabled"
             android:title="@string/preference_title_alternative_highlighting_enabled"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_alternative_highlighting_enabled" />
 
     </PreferenceCategory>
 
@@ -54,13 +59,15 @@
         <nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
             android:key="@string/preference_key_alarm_tone"
             android:title="@string/preference_title_alarm_tone"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_alarm_tone" />
 
         <SwitchPreferenceCompat
             android:defaultValue="@bool/preference_default_value_insistent_alarms_enabled"
             android:key="@string/preference_key_insistent_alarms_enabled"
             android:title="@string/preference_title_insistent_alarms_enabled"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_insistent_alarms_enabled" />
 
         <ListPreference
             android:defaultValue="@string/preference_default_value_alarm_time_value"
@@ -69,7 +76,8 @@
             android:entryValues="@array/preference_entry_values_alarm_time"
             android:key="@string/preference_key_alarm_time_index"
             android:title="@string/preference_title_alarm_time"
-            app:iconSpaceReserved="false" />
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -27,7 +27,8 @@
             android:key="@string/preference_key_app_notification_settings"
             android:title="@string/preference_title_app_notification_settings"
             app:iconSpaceReserved="false"
-            app:summary="@string/preference_summary_app_notification_settings" />
+            app:summary="@string/preference_summary_app_notification_settings"
+            app:widgetLayout="@layout/settings_widget_open_external" />
 
         <!--
         TODO: Use ValidateableEditTextPreference
@@ -60,7 +61,8 @@
             android:key="@string/preference_key_alarm_tone"
             android:title="@string/preference_title_alarm_tone"
             app:iconSpaceReserved="false"
-            app:summary="@string/preference_summary_alarm_tone" />
+            app:summary="@string/preference_summary_alarm_tone"
+            app:widgetLayout="@layout/settings_widget_open_external" />
 
         <SwitchPreferenceCompat
             android:defaultValue="@bool/preference_default_value_insistent_alarms_enabled"


### PR DESCRIPTION
# Description
+ Revise settings screen.
  + Consolidate title texts.
  + Add summary texts.
    + Some summary texts are not static but change depending on the presence of a value.
    + The Engelsystem shifts URL display text is truncated to preserve privacy.
  + Use icon to indicate that external screen will be opened.
+ Drop outdated translations for settings screen.
  + It is easier to spot missing than outdated translations.
+ Exclude "Engelsystem" proper noun from translations.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)
- :heavy_check_mark: Nexus 5 emulator, Android 4.3.1 (API 18)

# Before and after screenshots
This is how the settings looked before and how the look now.
![before1a](https://user-images.githubusercontent.com/144518/115862947-0c35b380-a435-11eb-91d5-1301ee63eb79.png) ![after2a](https://user-images.githubusercontent.com/144518/115862943-0b048680-a435-11eb-961a-bda93757f4ea.png)

# After screenshot of Engelsystem setting
This is how the setting looks like when a shifts URL is set
![after1a](https://user-images.githubusercontent.com/144518/115863554-e8bf3880-a435-11eb-9267-703ff4e4e280.png)

Resolves #321