### PR TITLE
Prevent crash when loaded schedule does not contain any session.

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -43,6 +43,14 @@
     <string name="dlg_err_failed_parse_failure">Kann Antwort nicht dekodieren.</string>
     <string name="dlg_err_failed_ssl_failure">SSL Fehler</string>
     <string name="dlg_err_failed_http_cleartext_not_permitted">HTTP ist nicht erlaubt. Bitte HTTPS nutzen.</string>
+    <string name="dlg_err_schedule_data">Fahrplandaten-Fehler</string>
+    <string name="dlg_err_schedule_data_empty">
+        Nichts darzustellen. Der Fahrplan mit Version
+        \"<xliff:g example="0.99" id="version">%s</xliff:g>\" erhält keine Einträge.
+    </string>
+    <string name="dlg_err_schedule_data_empty_without_version">
+        Nichts darzustellen. Der Fahrplan erhält keine Einträge.
+    </string>
     <string name="uptodate">Fahrplan ist aktuell.</string>
 
     <!-- Schedule changes dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,14 @@
     <string name="dlg_err_failed_parse_failure">Couldn\'t parse response</string>
     <string name="dlg_err_failed_ssl_failure">SSL failure</string>
     <string name="dlg_err_failed_http_cleartext_not_permitted">HTTP is not allowed. Please use HTTPS.</string>
+    <string name="dlg_err_schedule_data">Schedule data error</string>
+    <string name="dlg_err_schedule_data_empty">
+        Nothing to display. The schedule with version \"<xliff:g example="0.99" id="version">%s</xliff:g>\"
+        does not contain any session.
+    </string>
+    <string name="dlg_err_schedule_data_empty_without_version">
+        Nothing to display. The schedule does not contain any session.
+    </string>
     <string name="uptodate">Schedule is up to date.</string>
 
     <!-- Schedule changes dialog -->


### PR DESCRIPTION
# Description
- The crash happens if the schedule is emtpy.

## Example schedule

``` xml
<schedule>
	<generator name="test" version="1.0.0"/>
	<version/>
	<conference>
		<title>Test</title>
		<timeslot_duration>00:15</timeslot_duration>
		<base_url>https://example.com</base_url>
		<time_zone_name>Etc/UTC</time_zone_name>
		<acronym>test</acronym>
	</conference>
</schedule>
```

# Stacktrace

``` java
E  java.lang.NullPointerException: Parameter specified as non-null is null: 
   method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter conference
E      at nerd.tuxmobil.fahrplan.congress.schedule.TimeTextViewParameter$Companion.parametersOf(TimeTextViewParameter.kt)
E      at nerd.tuxmobil.fahrplan.congress.schedule.TimeTextViewParameter.parametersOf(TimeTextViewParameter.kt)
E      at nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.fillTimes(FahrplanFragment.java:490)
E      at nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.onParseDone(FahrplanFragment.java:615)
E      at nerd.tuxmobil.fahrplan.congress.schedule.MainActivity.onParseDone(MainActivity.java:223)
E      at nerd.tuxmobil.fahrplan.congress.schedule.MainActivity.lambda$fetchFahrplan$1$MainActivity(MainActivity.java:284)
E      at nerd.tuxmobil.fahrplan.congress.schedule.-$$Lambda$MainActivity$iwsIjXUPA82UxmQJgqYf6xkB5bw.invoke(lambda)
E      at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository$parseSchedule$3.invoke(AppRepository.kt:180)
E      at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository$parseSchedule$3.invoke(AppRepository.kt:179)
E      at info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository$parseSchedule$1.onParseDone(ScheduleNetworkRepository.kt:31)
E      at info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository$parseSchedule$1.onParseDone(ScheduleNetworkRepository.kt:28)
E      at info.metadude.android.eventfahrplan.network.serialization.ParserTask.notifyActivity(FahrplanParser.java:104)
E      at info.metadude.android.eventfahrplan.network.serialization.ParserTask.onPostExecute(FahrplanParser.java:113)
E      at info.metadude.android.eventfahrplan.network.serialization.ParserTask.onPostExecute(FahrplanParser.java:62)
```

# Successfully tested on
with `ccc36c3`, `debconf2021` flavors, `debug` build
- :heavy_check_mark: Nexus 9 device, Android 7.1.1 (API 25)