### PR TITLE
Allow to sort specific rooms to the end of the list (screen).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
@@ -17,9 +17,9 @@ class SessionsTransformer(private val prioritizedRoomProvider: PrioritizedRoomPr
     fun transformSessions(dayIndex: Int, sessions: List<Session>): ScheduleData {
         // Pre-populate the map with prioritized rooms
         val roomMap = prioritizedRoomProvider.prioritizedRooms
-                .map { it to mutableListOf<Session>() }
-                .toMap()
-                .toMutableMap()
+            .map { it to mutableListOf<Session>() }
+            .toMap()
+            .toMutableMap()
 
         val sortedSessions = sessions.sortedBy { it.roomIndex }
         for (session in sortedSessions) {
@@ -33,8 +33,8 @@ class SessionsTransformer(private val prioritizedRoomProvider: PrioritizedRoomPr
                 null
             } else {
                 RoomData(
-                        roomName = roomName,
-                        sessions = sessions.sortedBy { it.dateUTC }.toList()
+                    roomName = roomName,
+                    sessions = sessions.sortedBy { it.dateUTC }.toList()
                 )
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
@@ -4,7 +4,7 @@ import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 
-class SessionsTransformer(private val prioritizedRoomProvider: PrioritizedRoomProvider) {
+class SessionsTransformer(private val roomProvider: RoomProvider) {
 
     /**
      * Transforms the given [sessions] for the given [dayIndex] into a [ScheduleData] object.
@@ -16,7 +16,7 @@ class SessionsTransformer(private val prioritizedRoomProvider: PrioritizedRoomPr
      */
     fun transformSessions(dayIndex: Int, sessions: List<Session>): ScheduleData {
         // Pre-populate the map with prioritized rooms
-        val roomMap = prioritizedRoomProvider.prioritizedRooms
+        val roomMap = roomProvider.prioritizedRooms
             .map { it to mutableListOf<Session>() }
             .toMap()
             .toMutableMap()
@@ -43,6 +43,6 @@ class SessionsTransformer(private val prioritizedRoomProvider: PrioritizedRoomPr
     }
 }
 
-interface PrioritizedRoomProvider {
+interface RoomProvider {
     val prioritizedRooms: List<String>
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -39,7 +39,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import org.ligi.tracedroid.logging.Log;
 import org.threeten.bp.ZoneId;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,17 +103,8 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private int mDay = 1;
 
-    private static final String[] rooms = {
-            "Saal 1",
-            "Saal 2",
-            "Saal G",
-            "Saal 6",
-            "Saal 17",
-            "Lounge"
-    };
-
     private static final SessionsTransformer sessionsTransformer =
-            new SessionsTransformer(() -> Arrays.asList(rooms));
+            SessionsTransformer.createSessionsTransformer();
 
     private Typeface light;
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -65,6 +65,58 @@ class SessionsTransformerTest {
     }
 
     @Test
+    fun `empty deprioritized rooms do not reorder the list`() {
+        val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = emptyList()))
+        val sessionsInDatabase = listOf(
+            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
+            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
+            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+        )
+
+        val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
+
+        val roomNames = scheduleData.roomDataList.map { it.roomName }
+        assertThat(roomNames).isEqualTo(listOf("Ada", "Zeppelin", "You", "Erna", "Bjoern"))
+    }
+
+
+    @Test
+    fun `odd deprioritized rooms are last in list`() {
+        val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = listOf("Hamburg", "Frankfurt")))
+        val sessionsInDatabase = listOf(
+            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
+            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
+            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+        )
+
+        val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
+
+        val roomNames = scheduleData.roomDataList.map { it.roomName }
+        assertThat(roomNames).isEqualTo(listOf("Ada", "Zeppelin", "You", "Erna", "Bjoern"))
+    }
+
+    @Test
+    fun `deprioritized rooms are last in list`() {
+        val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = listOf("You", "Zeppelin")))
+        val sessionsInDatabase = listOf(
+            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
+            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
+            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+        )
+
+        val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
+
+        val roomNames = scheduleData.roomDataList.map { it.roomName }
+        assertThat(roomNames).isEqualTo(listOf("Ada", "Erna", "Bjoern", "You", "Zeppelin"))
+    }
+
+    @Test
     fun `same roomIndex does not influence RoomData contents`() {
         val transformer = SessionsTransformer(createRoomProvider())
         val sessionsInDatabase = listOf(
@@ -104,9 +156,11 @@ class SessionsTransformerTest {
 
     private fun createRoomProvider(
         prioritizedRooms: List<String> = listOf("Ada", "Borg", "Clarke", "Dijkstra", "Eliza"),
+        deprioritizedRooms: List<String> = emptyList()
     ): RoomProvider {
         return object : RoomProvider {
             override val prioritizedRooms = prioritizedRooms
+            override val deprioritizedRooms = deprioritizedRooms
         }
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -21,10 +21,10 @@ class SessionsTransformerTest {
     @Test
     fun `rooms are ordered by roomIndex`() {
         val sessionsInDatabase = listOf(
-                createSession(sessionId = "L0", roomName = "Four", roomIndex = 2342),
-                createSession(sessionId = "L1", roomName = "Two", roomIndex = 1),
-                createSession(sessionId = "L2", roomName = "One", roomIndex = 0),
-                createSession(sessionId = "L3", roomName = "Three", roomIndex = 4)
+            createSession(sessionId = "L0", roomName = "Four", roomIndex = 2342),
+            createSession(sessionId = "L1", roomName = "Two", roomIndex = 1),
+            createSession(sessionId = "L2", roomName = "One", roomIndex = 0),
+            createSession(sessionId = "L3", roomName = "Three", roomIndex = 4)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -36,11 +36,11 @@ class SessionsTransformerTest {
     @Test
     fun `prioritized rooms are first in list`() {
         val sessionsInDatabase = listOf(
-                createSession(sessionId = "L0", roomName = "Chaos-West Bühne", roomIndex = 11),
-                createSession(sessionId = "L1", roomName = "c-base", roomIndex = 12),
-                createSession(sessionId = "L2", roomName = "Eliza", roomIndex = 13),
-                createSession(sessionId = "L3", roomName = "Borg", roomIndex = 14),
-                createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(sessionId = "L0", roomName = "Chaos-West Bühne", roomIndex = 11),
+            createSession(sessionId = "L1", roomName = "c-base", roomIndex = 12),
+            createSession(sessionId = "L2", roomName = "Eliza", roomIndex = 13),
+            createSession(sessionId = "L3", roomName = "Borg", roomIndex = 14),
+            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -52,9 +52,9 @@ class SessionsTransformerTest {
     @Test
     fun `same roomIndex does not influence RoomData contents`() {
         val sessionsInDatabase = listOf(
-                createSession(sessionId = "L0", roomName = "Borg", roomIndex = 2),
-                createSession(sessionId = "L1", roomName = "Broken One", roomIndex = 2),
-                createSession(sessionId = "L2", roomName = "Broken Two", roomIndex = 2)
+            createSession(sessionId = "L0", roomName = "Borg", roomIndex = 2),
+            createSession(sessionId = "L1", roomName = "Broken One", roomIndex = 2),
+            createSession(sessionId = "L2", roomName = "Broken Two", roomIndex = 2)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -74,10 +74,10 @@ class SessionsTransformerTest {
     }
 
     private fun createSession(
-            sessionId: String,
-            roomName: String,
-            roomIndex: Int,
-            dateUTC: Long = 0
+        sessionId: String,
+        roomName: String,
+        roomIndex: Int,
+        dateUTC: Long = 0
     ): Session {
         return Session(sessionId).apply {
             this.room = roomName

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -5,11 +5,12 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.Test
 
 class SessionsTransformerTest {
-    private val prioritizedRoomProvider = object : PrioritizedRoomProvider {
+
+    private val roomProvider = object : RoomProvider {
         override val prioritizedRooms = listOf("Ada", "Borg", "Clarke", "Dijkstra", "Eliza")
     }
 
-    private val transformer = SessionsTransformer(prioritizedRoomProvider)
+    private val transformer = SessionsTransformer(roomProvider)
 
     @Test
     fun `ScheduleData_dayIndex contains proper day value`() {


### PR DESCRIPTION
# Description
- Rooms which are sorted to the front in the schedule XML can be sorted to the end by specifying their names.
- The order of the trailing list is sorted itself according to the order of the room names list.

# Successfully tested on
with `foss4g2021` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 10 (API 29)