### PR TITLE
Fix current time highlighting in time column when start day value is off.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -276,6 +276,13 @@ object AppRepository {
             .also { logging.d(javaClass.simpleName, "${it.size} sessions changed.") }
 
     /**
+     * Loads the first session of the first day from the database.
+     * Throws an exception if no session is present.
+     */
+    fun loadEarliestSession() = loadSessionsForAllDays(true)
+            .first()
+
+    /**
      * Loads all sessions from the database which take place on all days.
      * To exclude Engelsystem shifts pass false to [includeEngelsystemShifts].
      */

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -479,11 +479,13 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private void fillTimes() {
         int normalizedBoxHeight = getNormalizedBoxHeight(displayDensityScale);
+        Session earliestSession = appRepository.loadEarliestSession();
+        int firstDayStartDay = earliestSession.getStartTimeMoment().getMonthDay();
         boolean useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled();
         List<TimeTextViewParameter> parameters = TimeTextViewParameter.parametersOf(
                 Moment.now(),
                 conference,
-                BuildConfig.SCHEDULE_FIRST_DAY_START_DAY,
+                firstDayStartDay,
                 mDay,
                 normalizedBoxHeight,
                 useDeviceTimeZone

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -8,6 +8,7 @@ import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSessionsDatabaseModel
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.Assert.fail
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
 
@@ -154,6 +155,26 @@ class AppRepositorySessionsTest {
         val uncanceledSessions = testableAppRepository.loadUncanceledSessionsForDayIndex(0)
         assertThat(uncanceledSessions).containsExactly(SESSION_3001)
         verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(anyInt())
+    }
+
+    @Test
+    fun `loadEarliestSession fails when no session is present`() {
+        whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn emptyList()
+        try {
+            testableAppRepository.loadEarliestSession()
+            fail()
+        } catch (e: NoSuchElementException) {
+            assertThat(e.message).isEqualTo("List is empty.")
+        }
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
+    }
+
+    @Test
+    fun `loadEarliestSession returns the first session of the first day`() {
+        val sessions = listOf(SESSION_1005, SESSION_1001)
+        whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn sessions.toSessionsDatabaseModel()
+        assertThat(testableAppRepository.loadEarliestSession()).isEqualTo(SESSION_1005)
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsOrderedByDateUtc()
     }
 
 }


### PR DESCRIPTION
# Description
+ Before, the highlighting only showed up when the day value of the first day in the **build configuration** matched the day value of the earliest session of all days as being retrieved from the **XML schedule** file.
+ Now, the match relies on the actual session data only.

# Successfully tested on
with `debconf2021` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)

# Related
- [Issue #33: Misplaced resp. multiple time column highlights](https://github.com/EventFahrplan/EventFahrplan/issues/33)
- [Issue #105: Current time marker](https://github.com/EventFahrplan/EventFahrplan/issues/105)
- [Issue #167: Time column not shown](https://github.com/EventFahrplan/EventFahrplan/issues/167)