### PR TITLE
Allow track resources names to be formatted with line breaks.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TrackBackgrounds.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TrackBackgrounds.java
@@ -48,7 +48,7 @@ public class TrackBackgrounds {
                     }
                 } else if (eventType == XmlPullParser.TEXT) {
                     if (null != key) {
-                        value = parser.getText();
+                        value = parser.getText().trim();
                     }
                 }
                 eventType = parser.next();


### PR DESCRIPTION
# Description
+ This allows an `<entry>` in the `track_resource_names.xml` files to be formatted as multi-line text.
+ Before the hash map created by `TrackBackgrounds#getHashMapResource` would contain resource identifiers with the value `0` leading to a runtime crash when looking up a track color.
+ Error: `android.content.res.Resources$NotFoundException: Resource ID #0x0.`

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)