### PR TITLE
Derive text color from current theme.

### DIFF
--- a/app/src/main/res/layout-port/about_dialog.xml
+++ b/app/src/main/res/layout-port/about_dialog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -34,9 +34,7 @@
                 android:layout_gravity="center"
                 android:gravity="center|top"
                 android:paddingBottom="5dp"
-                android:textColor="#FFF"
-                android:textSize="16sp"
-                android:textStyle="bold"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
                 tools:text="33. Chaos Communication Congress"/>
 
         <TextView
@@ -46,7 +44,7 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:paddingBottom="10dp"
-                android:textColor="#FFF"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
                 android:textStyle="italic"
                 android:typeface="serif"
                 tools:text="Works for me">

--- a/app/src/main/res/layout/about_dialog_land.xml
+++ b/app/src/main/res/layout/about_dialog_land.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -34,9 +34,7 @@
                 android:layout_gravity="center"
                 android:gravity="center|top"
                 android:paddingBottom="5dp"
-                android:textColor="#FFF"
-                android:textSize="16sp"
-                android:textStyle="bold"
+                android:textAppearance="@style/TextAppearance.AppCompat.Title"
                 tools:text="33. Chaos Communication Congress"/>
 
         <TextView
@@ -46,7 +44,7 @@
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:paddingBottom="10dp"
-                android:textColor="#FFF"
+                android:textAppearance="@style/TextAppearance.AppCompat.Subhead"
                 android:textStyle="italic"
                 android:typeface="serif"
                 tools:text="Works for me">


### PR DESCRIPTION
# Description
+ Avoid hardcoding text color values.
+ The text size of the title and subtitle are slightly increased now.

# Before and after
![before](https://user-images.githubusercontent.com/144518/131164312-c51fd7e9-cbbb-494e-9383-c330effff85e.png) ![after](https://user-images.githubusercontent.com/144518/131164333-fddfbfa9-b445-4b5a-b0d5-0c3b2f24e341.png)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)