### PR TITLE
Let AppRepository be the single source of truth for details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
@@ -87,17 +87,6 @@ public abstract class BaseActivity extends AppCompatActivity {
                 .commit();
     }
 
-    protected void replaceFragment(@IdRes int containerViewId,
-                                   @NonNull Fragment fragment,
-                                   @NonNull String fragmentTag,
-                                   @NonNull String backStackStateName) {
-        getSupportFragmentManager()
-                .beginTransaction()
-                .replace(containerViewId, fragment, fragmentTag)
-                .addToBackStack(backStackStateName)
-                .commit();
-    }
-
     protected void removeFragment(@NonNull String fragmentTag) {
         FragmentManager supportFragmentManager = getSupportFragmentManager();
         Fragment fragment = supportFragmentManager.findFragmentByTag(fragmentTag);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
@@ -10,6 +10,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
 class ChangeListActivity :
     BaseActivity(),
@@ -43,7 +44,9 @@ class ChangeListActivity :
     }
 
     override fun onSessionListClick(sessionId: String) {
-        SessionDetailsActivity.start(this, sessionId)
+        if (AppRepository.updateSelectedSessionId(sessionId)) {
+            SessionDetailsActivity.start(this)
+        }
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -9,12 +9,15 @@ import android.view.ViewGroup
 import android.widget.HeaderViewListAdapter
 import android.widget.ListView
 import androidx.annotation.CallSuper
+import androidx.annotation.IdRes
 import androidx.annotation.MainThread
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
@@ -35,9 +38,16 @@ class ChangeListFragment : AbstractListFragment() {
 
         const val FRAGMENT_TAG = "changes"
 
-        @JvmStatic
         fun newInstance(sidePane: Boolean): ChangeListFragment {
             return ChangeListFragment().withArguments(BundleKeys.SIDEPANE to sidePane)
+        }
+
+        @JvmStatic
+        fun replace(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sidePane: Boolean) {
+            val fragment = ChangeListFragment().withArguments(
+                BundleKeys.SIDEPANE to sidePane
+            )
+            fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG, FRAGMENT_TAG)
         }
 
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.java
@@ -20,10 +20,6 @@ public interface BundleKeys {
     String BUNDLE_KEY_SESSION_ALARM_NOTIFICATION_ID =
             "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_NOTIFICATION_ID";
 
-    // Session details
-    String SESSION_ID =
-            "nerd.tuxmobil.fahrplan.congress.SESSION_ID";
-
     // Side pane
     String SIDEPANE =
             "nerd.tuxmobil.fahrplan.congress.SIDEPANE";

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
@@ -1,0 +1,35 @@
+package nerd.tuxmobil.fahrplan.congress.details
+
+/**
+ * Payload of the observable [selectedSessionParameter][SessionDetailsViewModel.selectedSessionParameter]
+ * property in the [SessionDetailsViewModel] which is observed by the [SessionDetailsFragment].
+ */
+data class SelectedSessionParameter(
+
+    // Details content
+    val sessionId: String,
+
+    val hasDateUtc: Boolean,
+    val formattedZonedDateTime: String,
+
+    val title: String,
+    val subtitle: String,
+    val speakerNames: String,
+    val formattedAbstract: String,
+    val abstract: String,
+    val description: String,
+    val formattedDescription: String,
+    val roomName: String,
+
+    val hasLinks: Boolean,
+    val formattedLinks: String,
+    val hasWikiLinks: Boolean,
+    val sessionLink: String,
+
+    // Options menu
+    val isFlaggedAsFavorite: Boolean,
+    val hasAlarm: Boolean,
+    val isFeedbackUrlEmpty: Boolean,
+    val isC3NavRoomNameEmpty: Boolean
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -8,8 +8,6 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
-import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
-import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
 
 class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
@@ -18,19 +16,17 @@ class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
 
         const val REQUEST_CODE = 2
 
-        fun start(activity: Activity, sessionId: String) {
-            activity.startActivity(createIntent(activity, sessionId))
+        fun start(activity: Activity) {
+            activity.startActivity(createIntent(activity))
         }
 
         @JvmStatic
-        fun startForResult(activity: Activity, sessionId: String) {
-            activity.startActivityForResult(createIntent(activity, sessionId), REQUEST_CODE)
+        fun startForResult(activity: Activity) {
+            activity.startActivityForResult(createIntent(activity), REQUEST_CODE)
         }
 
-        private fun createIntent(activity: Activity, sessionId: String) =
-            Intent(activity, SessionDetailsActivity::class.java).withExtras(
-                BundleKeys.SESSION_ID to sessionId
-            )
+        private fun createIntent(activity: Activity) =
+            Intent(activity, SessionDetailsActivity::class.java)
 
     }
 
@@ -50,10 +46,7 @@ class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
             finish()
         }
         if (intent != null && findViewById<View?>(R.id.detail) != null) {
-            val sessionId = requireNotNull(intent.getStringExtra(BundleKeys.SESSION_ID)) {
-                "Bundle does not contain a SESSION_ID."
-            }
-            SessionDetailsFragment.replace(supportFragmentManager, R.id.detail, sessionId)
+            SessionDetailsFragment.replace(supportFragmentManager, R.id.detail)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -9,7 +9,6 @@ import androidx.core.content.ContextCompat
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
-import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
 
@@ -54,15 +53,8 @@ class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
             val sessionId = requireNotNull(intent.getStringExtra(BundleKeys.SESSION_ID)) {
                 "Bundle does not contain a SESSION_ID."
             }
-            openDetails(sessionId)
+            SessionDetailsFragment.replace(supportFragmentManager, R.id.detail, sessionId)
         }
-    }
-
-    private fun openDetails(sessionId: String) {
-        val fragment = SessionDetailsFragment().withArguments(
-                BundleKeys.SESSION_ID to sessionId
-        )
-        replaceFragment(R.id.detail, fragment, SessionDetailsFragment.FRAGMENT_TAG)
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -16,12 +16,14 @@ import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.CallSuper
+import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.annotation.MainThread
 import androidx.annotation.NonNull
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import io.noties.markwon.Markwon
 import io.noties.markwon.linkify.LinkifyPlugin
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
@@ -31,8 +33,10 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
+import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
@@ -50,6 +54,23 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
         const val SESSION_DETAILS_FRAGMENT_REQUEST_CODE = 546
         private const val SCHEDULE_FEEDBACK_URL = BuildConfig.SCHEDULE_FEEDBACK_URL
         private val SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL)
+
+        @JvmStatic
+        fun replaceAtBackStack(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sessionId: String, sidePane: Boolean) {
+            val fragment = SessionDetailsFragment().withArguments(
+                BundleKeys.SESSION_ID to sessionId,
+                BundleKeys.SIDEPANE to sidePane
+            )
+            fragmentManager.popBackStack(FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+            fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG, FRAGMENT_TAG)
+        }
+
+        fun replace(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sessionId: String) {
+            val fragment = SessionDetailsFragment().withArguments(
+                BundleKeys.SESSION_ID to sessionId
+            )
+            fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG)
+        }
 
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -252,20 +252,15 @@ class SessionDetailsFragment : Fragment() {
         typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineSectionFont)
         sessionOnlineSectionView.typeface = typeface
         val sessionOnlineLinkView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_view)
-        if (model.hasWikiLinks) {
+        val sessionLink = model.sessionLink
+        if (model.hasWikiLinks || sessionLink.isEmpty()) {
             sessionOnlineSectionView.isVisible = false
             sessionOnlineLinkView.isVisible = false
         } else {
-            val sessionLink = model.sessionLink
-            if (sessionLink.isEmpty()) {
-                sessionOnlineSectionView.isVisible = false
-                sessionOnlineLinkView.isVisible = false
-            } else {
-                sessionOnlineSectionView.isVisible = true
-                sessionOnlineLinkView.isVisible = true
-                typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineFont)
-                sessionOnlineLinkView.applyHtml(typeface, sessionLink)
-            }
+            sessionOnlineSectionView.isVisible = true
+            sessionOnlineLinkView.isVisible = true
+            typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineFont)
+            sessionOnlineLinkView.applyHtml(typeface, sessionLink)
         }
     }
 
@@ -303,27 +298,20 @@ class SessionDetailsFragment : Fragment() {
         }
         inflater.inflate(R.menu.detailmenu, menu)
         if (model.isFlaggedAsFavorite) {
-            menu.findItem(R.id.menu_item_flag_as_favorite)?.let { it.isVisible = false }
-            menu.findItem(R.id.menu_item_unflag_as_favorite)?.let { it.isVisible = true }
+            menu.setMenuItemVisibility(R.id.menu_item_flag_as_favorite, false)
+            menu.setMenuItemVisibility(R.id.menu_item_unflag_as_favorite, true)
         }
         if (model.hasAlarm) {
-            menu.findItem(R.id.menu_item_set_alarm)?.let { it.isVisible = false }
-            menu.findItem(R.id.menu_item_delete_alarm)?.let { it.isVisible = true }
+            menu.setMenuItemVisibility(R.id.menu_item_set_alarm, false)
+            menu.setMenuItemVisibility(R.id.menu_item_delete_alarm, true)
         }
-        var item = menu.findItem(R.id.menu_item_feedback)
-        if (SHOW_FEEDBACK_MENU_ITEM && !model.isFeedbackUrlEmpty) {
-            item?.let { it.isVisible = true }
-        } else {
-            item?.let { it.isVisible = false }
-        }
+        menu.setMenuItemVisibility(R.id.menu_item_feedback, SHOW_FEEDBACK_MENU_ITEM && !model.isFeedbackUrlEmpty)
         if (sidePane) {
-            menu.findItem(R.id.menu_item_close_session_details)?.let { it.isVisible = true }
+            menu.setMenuItemVisibility(R.id.menu_item_close_session_details, true)
         }
-        menu.findItem(R.id.menu_item_navigate)?.let {
-            it.isVisible = !model.isC3NavRoomNameEmpty
-        }
+        menu.setMenuItemVisibility(R.id.menu_item_navigate, !model.isC3NavRoomNameEmpty)
         @Suppress("ConstantConditionIf")
-        item = if (BuildConfig.ENABLE_CHAOSFLIX_EXPORT) {
+        val item = if (BuildConfig.ENABLE_CHAOSFLIX_EXPORT) {
             menu.findItem(R.id.menu_item_share_session_menu)
         } else {
             menu.findItem(R.id.menu_item_share_session)
@@ -353,6 +341,10 @@ class SessionDetailsFragment : Fragment() {
                 true
             }
         }
+    }
+
+    private fun Menu.setMenuItemVisibility(itemId: Int, isVisible: Boolean) {
+        findItem(itemId)?.let { it.isVisible = isVisible }
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
-import android.net.Uri
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -24,6 +23,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.viewModels
 import io.noties.markwon.Markwon
 import io.noties.markwon.linkify.LinkifyPlugin
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
@@ -37,7 +37,6 @@ import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
-import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
@@ -45,49 +44,59 @@ import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
-class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHandler {
+class SessionDetailsFragment : Fragment() {
 
     companion object {
 
-        private const val LOG_TAG = "Detail"
+        private const val LOG_TAG = "SessionDetailsFragment"
         const val FRAGMENT_TAG = "detail"
         const val SESSION_DETAILS_FRAGMENT_REQUEST_CODE = 546
         private const val SCHEDULE_FEEDBACK_URL = BuildConfig.SCHEDULE_FEEDBACK_URL
         private val SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL)
 
         @JvmStatic
-        fun replaceAtBackStack(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sessionId: String, sidePane: Boolean) {
+        fun replaceAtBackStack(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sidePane: Boolean) {
             val fragment = SessionDetailsFragment().withArguments(
-                BundleKeys.SESSION_ID to sessionId,
                 BundleKeys.SIDEPANE to sidePane
             )
             fragmentManager.popBackStack(FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG, FRAGMENT_TAG)
         }
 
-        fun replace(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sessionId: String) {
-            val fragment = SessionDetailsFragment().withArguments(
-                BundleKeys.SESSION_ID to sessionId
-            )
+        fun replace(fragmentManager: FragmentManager, @IdRes containerViewId: Int) {
+            val fragment = SessionDetailsFragment()
             fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG)
         }
 
     }
 
     private lateinit var appRepository: AppRepository
-    private lateinit var sessionId: String
-    private lateinit var viewModel: SessionDetailsViewModel
     private lateinit var alarmServices: AlarmServices
+    private val viewModel: SessionDetailsViewModel by viewModels { SessionDetailsViewModelFactory(appRepository, alarmServices) }
+    private lateinit var model: SelectedSessionParameter
     private lateinit var markwon: Markwon
     private var sidePane = false
     private var hasArguments = false
+
+    private val viewModelFunctionByMenuItemId = mapOf<Int, SessionDetailsViewModel.() -> Unit>(
+        R.id.menu_item_feedback to { openFeedback() },
+        R.id.menu_item_share_session to { share() },
+        R.id.menu_item_share_session_text to { share() },
+        R.id.menu_item_share_session_json to { shareToChaosflix() },
+        R.id.menu_item_add_to_calendar to { addToCalendar() },
+        R.id.menu_item_flag_as_favorite to { favorSession() },
+        R.id.menu_item_unflag_as_favorite to { unfavorSession() },
+        R.id.menu_item_set_alarm to { setAlarm() },
+        R.id.menu_item_delete_alarm to { deleteAlarm() },
+        R.id.menu_item_close_session_details to { closeDetails() },
+        R.id.menu_item_navigate to { navigateToRoom() },
+    )
 
     @MainThread
     @CallSuper
     override fun onAttach(@NonNull context: Context) {
         super.onAttach(context)
         appRepository = AppRepository
-        viewModel = SessionDetailsViewModel(appRepository, sessionId, this)
         alarmServices = AlarmServices.newInstance(context, appRepository)
         markwon = Markwon.builder(requireContext())
             .usePlugin(LinkifyPlugin.create())
@@ -99,7 +108,6 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        MyApp.LogDebug(LOG_TAG, "onCreate")
     }
 
     override fun onCreateView(inflater: LayoutInflater,
@@ -112,113 +120,153 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     override fun setArguments(args: Bundle?) {
         super.setArguments(args)
         requireNotNull(args)
-        sessionId = args.getString(BundleKeys.SESSION_ID) ?: error("Missing 'sessionId' argument.")
         sidePane = args.getBoolean(BundleKeys.SIDEPANE, false)
         hasArguments = true
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        observeViewModel()
         val activity = requireActivity()
         if (hasArguments) {
-            val typefaceFactory = TypefaceFactory.getNewInstance(activity)
-
-            // Detailbar
-            var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
-            textView.text = if (viewModel.hasDateUtc) viewModel.formattedZonedDateTime else ""
-
-            textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
-            textView.text = viewModel.roomName
-            textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
-            textView.text = if (viewModel.isSessionIdEmpty) "" else getString(R.string.session_details_session_id, viewModel.sessionId)
-
-            // Title
-            textView = view.requireViewByIdCompat(R.id.session_details_content_title_view)
-            var typeface = typefaceFactory.getTypeface(viewModel.titleFont)
-            textView.applyText(typeface, viewModel.title)
-
-            // Subtitle
-            textView = view.requireViewByIdCompat(R.id.session_details_content_subtitle_view)
-            if (viewModel.isSubtitleEmpty) {
-                textView.isVisible = false
-            } else {
-                typeface = typefaceFactory.getTypeface(viewModel.subtitleFont)
-                textView.applyText(typeface, viewModel.subtitle)
-            }
-
-            // Speakers
-            textView = view.requireViewByIdCompat(R.id.session_details_content_speakers_view)
-            if (viewModel.isSpeakersEmpty) {
-                textView.isVisible = false
-            } else {
-                typeface = typefaceFactory.getTypeface(viewModel.speakersFont)
-                textView.applyText(typeface, viewModel.speakers)
-            }
-
-            // Abstract
-            textView = view.requireViewByIdCompat(R.id.session_details_content_abstract_view)
-            if (viewModel.isAbstractEmpty) {
-                textView.isVisible = false
-            } else {
-                typeface = typefaceFactory.getTypeface(viewModel.abstractFont)
-                if (ServerBackendType.PENTABARF.name == BuildConfig.SERVER_BACKEND_TYPE) {
-                    textView.applyHtml(typeface, viewModel.formattedAbstract)
-                } else {
-                    textView.applyMarkdown(typeface, viewModel.abstractt)
-                }
-            }
-
-            // Description
-            textView = view.requireViewByIdCompat(R.id.session_details_content_description_view)
-            if (viewModel.isDescriptionEmpty) {
-                textView.isVisible = false
-            } else {
-                typeface = typefaceFactory.getTypeface(viewModel.descriptionFont)
-                if (ServerBackendType.PENTABARF.name == BuildConfig.SERVER_BACKEND_TYPE) {
-                    textView.applyHtml(typeface, viewModel.formattedDescription)
-                } else {
-                    textView.applyMarkdown(typeface, viewModel.description)
-                }
-            }
-
-            // Links
-            val linksView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_links_section_view)
-            textView = view.requireViewByIdCompat(R.id.session_details_content_links_view)
-            if (viewModel.isLinksEmpty) {
-                linksView.isVisible = false
-                textView.isVisible = false
-            } else {
-                typeface = typefaceFactory.getTypeface(viewModel.linksSectionFont)
-                linksView.typeface = typeface
-                MyApp.LogDebug(LOG_TAG, "show links")
-                linksView.isVisible = true
-                typeface = typefaceFactory.getTypeface(viewModel.linksFont)
-                textView.applyHtml(typeface, viewModel.formattedLinks)
-            }
-
-            // Session online
-            val sessionOnlineSectionView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_section_view)
-            typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineSectionFont)
-            sessionOnlineSectionView.typeface = typeface
-            val sessionOnlineLinkView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_view)
-            if (viewModel.hasWikiLinks) {
-                sessionOnlineSectionView.isVisible = false
-                sessionOnlineLinkView.isVisible = false
-            } else {
-                val sessionLink = viewModel.sessionLink
-                if (sessionLink.isEmpty()) {
-                    sessionOnlineSectionView.isVisible = false
-                    sessionOnlineLinkView.isVisible = false
-                } else {
-                    sessionOnlineSectionView.isVisible = true
-                    sessionOnlineLinkView.isVisible = true
-                    typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineFont)
-                    sessionOnlineLinkView.applyHtml(typeface, sessionLink)
-                }
-            }
             activity.invalidateOptionsMenu()
         }
         activity.setResult(Activity.RESULT_CANCELED)
+    }
+
+    private fun observeViewModel() {
+        viewModel.selectedSessionParameter.observe(viewLifecycleOwner) { model ->
+            this.model = model
+            updateView()
+            updateOptionsMenu()
+        }
+        viewModel.openFeedBack.observe(viewLifecycleOwner) { uri ->
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
+        }
+        viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
+            SessionSharer.shareSimple(requireContext(), formattedSession)
+        }
+        viewModel.shareJson.observe(viewLifecycleOwner) { formattedSession ->
+            val context = requireContext()
+            if (!SessionSharer.shareJson(context, formattedSession)) {
+                Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
+            }
+        }
+        viewModel.addToCalendar.observe(viewLifecycleOwner) { session ->
+            CalendarSharing(requireContext()).addToCalendar(session)
+        }
+        viewModel.setAlarm.observe(viewLifecycleOwner) {
+            AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_CODE)
+        }
+        viewModel.navigateToRoom.observe(viewLifecycleOwner) { uri ->
+            startActivity(Intent(Intent.ACTION_VIEW, uri))
+        }
+        viewModel.closeDetails.observe(viewLifecycleOwner) {
+            val activity = requireActivity()
+            if (activity is OnSidePaneCloseListener) {
+                (activity as OnSidePaneCloseListener).onSidePaneClose(FRAGMENT_TAG)
+            }
+        }
+    }
+
+    private fun updateView() {
+        val view = requireView()
+        val activity = requireActivity()
+        val typefaceFactory = TypefaceFactory.getNewInstance(activity)
+
+        // Detailbar
+        var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
+        textView.text = if (model.hasDateUtc) model.formattedZonedDateTime else ""
+
+        textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
+        textView.text = model.roomName
+        textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
+        textView.text = if (model.sessionId.isEmpty()) "" else getString(R.string.session_details_session_id, model.sessionId)
+
+        // Title
+        textView = view.requireViewByIdCompat(R.id.session_details_content_title_view)
+        var typeface = typefaceFactory.getTypeface(viewModel.titleFont)
+        textView.applyText(typeface, model.title)
+
+        // Subtitle
+        textView = view.requireViewByIdCompat(R.id.session_details_content_subtitle_view)
+        if (model.subtitle.isEmpty()) {
+            textView.isVisible = false
+        } else {
+            typeface = typefaceFactory.getTypeface(viewModel.subtitleFont)
+            textView.applyText(typeface, model.subtitle)
+        }
+
+        // Speakers
+        textView = view.requireViewByIdCompat(R.id.session_details_content_speakers_view)
+        if (model.speakerNames.isEmpty()) {
+            textView.isVisible = false
+        } else {
+            typeface = typefaceFactory.getTypeface(viewModel.speakersFont)
+            textView.applyText(typeface, model.speakerNames)
+        }
+
+        // Abstract
+        textView = view.requireViewByIdCompat(R.id.session_details_content_abstract_view)
+        if (model.abstract.isEmpty()) {
+            textView.isVisible = false
+        } else {
+            typeface = typefaceFactory.getTypeface(viewModel.abstractFont)
+            if (ServerBackendType.PENTABARF.name == BuildConfig.SERVER_BACKEND_TYPE) {
+                textView.applyHtml(typeface, model.formattedAbstract)
+            } else {
+                textView.applyMarkdown(typeface, model.abstract)
+            }
+        }
+
+        // Description
+        textView = view.requireViewByIdCompat(R.id.session_details_content_description_view)
+        if (model.description.isEmpty()) {
+            textView.isVisible = false
+        } else {
+            typeface = typefaceFactory.getTypeface(viewModel.descriptionFont)
+            if (ServerBackendType.PENTABARF.name == BuildConfig.SERVER_BACKEND_TYPE) {
+                textView.applyHtml(typeface, model.formattedDescription)
+            } else {
+                textView.applyMarkdown(typeface, model.description)
+            }
+        }
+
+        // Links
+        val linksView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_links_section_view)
+        textView = view.requireViewByIdCompat(R.id.session_details_content_links_view)
+        if (model.hasLinks) {
+            typeface = typefaceFactory.getTypeface(viewModel.linksSectionFont)
+            linksView.typeface = typeface
+            MyApp.LogDebug(LOG_TAG, "show links")
+            linksView.isVisible = true
+            typeface = typefaceFactory.getTypeface(viewModel.linksFont)
+            textView.applyHtml(typeface, model.formattedLinks)
+        } else {
+            linksView.isVisible = false
+            textView.isVisible = false
+        }
+
+        // Session online
+        val sessionOnlineSectionView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_section_view)
+        typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineSectionFont)
+        sessionOnlineSectionView.typeface = typeface
+        val sessionOnlineLinkView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_view)
+        if (model.hasWikiLinks) {
+            sessionOnlineSectionView.isVisible = false
+            sessionOnlineLinkView.isVisible = false
+        } else {
+            val sessionLink = model.sessionLink
+            if (sessionLink.isEmpty()) {
+                sessionOnlineSectionView.isVisible = false
+                sessionOnlineLinkView.isVisible = false
+            } else {
+                sessionOnlineSectionView.isVisible = true
+                sessionOnlineLinkView.isVisible = true
+                typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineFont)
+                sessionOnlineLinkView.applyHtml(typeface, sessionLink)
+            }
+        }
     }
 
     private fun TextView.applyText(typeface: Typeface, text: String) {
@@ -243,19 +291,27 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
         this.isVisible = true
     }
 
+    private fun updateOptionsMenu() {
+        requireActivity().invalidateOptionsMenu()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
+        if (!::model.isInitialized) {
+            // Skip if lifecycle is faster than ViewModel.
+            return
+        }
         inflater.inflate(R.menu.detailmenu, menu)
-        if (viewModel.isFlaggedAsFavorite) {
+        if (model.isFlaggedAsFavorite) {
             menu.findItem(R.id.menu_item_flag_as_favorite)?.let { it.isVisible = false }
             menu.findItem(R.id.menu_item_unflag_as_favorite)?.let { it.isVisible = true }
         }
-        if (viewModel.hasAlarm()) {
+        if (model.hasAlarm) {
             menu.findItem(R.id.menu_item_set_alarm)?.let { it.isVisible = false }
             menu.findItem(R.id.menu_item_delete_alarm)?.let { it.isVisible = true }
         }
-        var item: MenuItem? = menu.findItem(R.id.menu_item_feedback)
-        if (SHOW_FEEDBACK_MENU_ITEM && !viewModel.isFeedbackUrlEmpty) {
+        var item = menu.findItem(R.id.menu_item_feedback)
+        if (SHOW_FEEDBACK_MENU_ITEM && !model.isFeedbackUrlEmpty) {
             item?.let { it.isVisible = true }
         } else {
             item?.let { it.isVisible = false }
@@ -264,7 +320,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
             menu.findItem(R.id.menu_item_close_session_details)?.let { it.isVisible = true }
         }
         menu.findItem(R.id.menu_item_navigate)?.let {
-            it.isVisible = !viewModel.isC3NavRoomNameEmpty
+            it.isVisible = !model.isC3NavRoomNameEmpty
         }
         @Suppress("ConstantConditionIf")
         item = if (BuildConfig.ENABLE_CHAOSFLIX_EXPORT) {
@@ -280,81 +336,23 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
                 resultCode == AlarmTimePickerFragment.ALERT_TIME_PICKED_RESULT_CODE &&
                 data != null
         ) {
-            val alarmTimesIndex = data.getIntExtra(
-                    AlarmTimePickerFragment.ALARM_PICKED_INTENT_KEY, 0)
-            onAlarmTimesIndexPicked(alarmTimesIndex)
+            val alarmTimesIndex = data.getIntExtra(AlarmTimePickerFragment.ALARM_PICKED_INTENT_KEY, 0)
+            viewModel.addAlarm(alarmTimesIndex)
         }
         super.onActivityResult(requestCode, resultCode, data)
     }
 
-    private fun onAlarmTimesIndexPicked(alarmTimesIndex: Int) {
-        val session = appRepository.readSessionBySessionId(sessionId)
-        val activity = requireActivity()
-        alarmServices.addSessionAlarm(session, alarmTimesIndex)
-        // Update the ViewModel session because refreshUI refers to its state.
-        viewModel.setHasAlarm(session.hasAlarm)
-        refreshUI(activity)
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return if (viewModel.onOptionsMenuItemSelected(item.itemId)) {
-            true
-        } else super.onOptionsItemSelected(item)
-    }
-
-    private fun refreshUI(activity: Activity) {
-        activity.invalidateOptionsMenu()
-        activity.setResult(Activity.RESULT_OK)
-    }
-
-    @MainThread
-    @CallSuper
-    override fun onDestroy() {
-        super.onDestroy()
-        MyApp.LogDebug(LOG_TAG, "onDestroy")
-    }
-
-    override fun openFeedback(uri: Uri) {
-        startActivity(Intent(Intent.ACTION_VIEW, uri))
-    }
-
-    override fun shareAsPlainText(formattedSessions: String) {
-        val context = requireContext()
-        SessionSharer.shareSimple(context, formattedSessions)
-    }
-
-    override fun shareAsJson(formattedSessions: String) {
-        val context = requireContext()
-        if (!SessionSharer.shareJson(context, formattedSessions)) {
-            Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
+        val itemId = item.itemId
+        return when (val function = viewModelFunctionByMenuItemId[itemId]) {
+            null -> {
+                return super.onOptionsItemSelected(item)
+            }
+            else -> {
+                function.invoke(viewModel)
+                true
+            }
         }
-    }
-
-    override fun addToCalendar(session: Session) {
-        CalendarSharing(requireContext()).addToCalendar(session)
-    }
-
-    override fun showAlarmTimePicker() {
-        AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_CODE)
-    }
-
-    override fun deleteAlarm(session: Session) {
-        alarmServices.deleteSessionAlarm(session)
-    }
-
-    override fun closeDetails() {
-        val activity: Activity = requireActivity()
-        if (activity is OnSidePaneCloseListener) {
-            (activity as OnSidePaneCloseListener).onSidePaneClose(FRAGMENT_TAG)
-        }
-    }
-
-    override fun navigateToRoom(uri: Uri) {
-        startActivity(Intent(Intent.ACTION_VIEW, uri))
-    }
-
-    override fun refreshUI() {
-        refreshUI(requireActivity())
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -23,6 +23,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
         private val repository: AppRepository,
         val sessionId: String,
         private val viewActionHandler: ViewActionHandler,
+        private val sessionFormatter: SessionFormatter = SessionFormatter(),
         private val markdownConversion: MarkdownConversion = MarkdownConverter,
 
         // Session conversion parameters
@@ -98,7 +99,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
     val isLinksEmpty get() = session.getLinks().isEmpty()
     val formattedLinks: String
         get() {
-            val html = session.getLinks().replace("\\),".toRegex(), ")<br>")
+            val html = sessionFormatter.getFormattedLinks(session.getLinks())
             return html.toHtmlLink()
         }
 
@@ -107,7 +108,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
     val sessionLink: String
         get() {
             val url = session.toSessionUrl()
-            return if (url.isEmpty()) "" else "<a href=\"$url\">$url</a>"
+            return sessionFormatter.getFormattedUrl(url)
         }
 
     val isFlaggedAsFavorite get() = session.highlight

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -31,7 +31,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
 
         // Session conversion functions
         private val toFeedbackUrl: Session.(String) -> String = { urlTemplate ->
-            FeedbackUrlComposer(this, urlTemplate).getFeedbackUrl()
+            FeedbackUrlComposer(urlTemplate).getFeedbackUrl(this)
         },
         private val toPlainText: Session.(ZoneId?) -> String = { timeZoneId ->
             SimpleSessionFormat().format(this, timeZoneId)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -1,0 +1,40 @@
+package nerd.tuxmobil.fahrplan.congress.details
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.navigation.RoomForC3NavConverter
+import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
+import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
+import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
+import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
+
+class SessionDetailsViewModelFactory(
+
+    private val appRepository: AppRepository,
+    private val alarmServices: AlarmServices
+
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return SessionDetailsViewModel(
+            repository = appRepository,
+            executionContext = AppExecutionContext,
+            alarmServices = alarmServices,
+            sessionFormatter = SessionFormatter(),
+            simpleSessionFormat = SimpleSessionFormat(),
+            jsonSessionFormat = JsonSessionFormat(),
+            feedbackUrlComposer = FeedbackUrlComposer(),
+            sessionUrlComposition = SessionUrlComposer(),
+            roomForC3NavConverter = RoomForC3NavConverter(),
+            markdownConversion = MarkdownConverter,
+            c3NavBaseUrl = BuildConfig.C3NAV_URL
+        ) as T
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatter.kt
@@ -1,0 +1,25 @@
+package nerd.tuxmobil.fahrplan.congress.details
+
+/**
+ * Session details related formatting logic.
+ */
+class SessionFormatter {
+
+    /**
+     * Returns the given [links] separated by HTML `br` entities.
+     * The original string is returned if no link separator is detected.
+     */
+    fun getFormattedLinks(links: String): String {
+        // language=regex
+        return links.replace("\\),".toRegex(), ")<br>")
+    }
+
+    /**
+     * Returns the given [url] formatted as an HTML weblink.
+     * An empty string is returned if the [url] is empty itself.
+     */
+    fun getFormattedUrl(url: String): String {
+        return if (url.isEmpty()) "" else "<a href=\"$url\">$url</a>"
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/FragmentManagerExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/FragmentManagerExtensions.kt
@@ -1,0 +1,36 @@
+package nerd.tuxmobil.fahrplan.congress.extensions
+
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+import androidx.fragment.app.commit
+
+/**
+ * Replaces the [containerViewId] with the given [fragment] and adds
+ * it to the [backstack][FragmentTransaction.addToBackStack].
+ */
+fun FragmentManager.replaceFragment(
+    @IdRes containerViewId: Int,
+    fragment: Fragment,
+    fragmentTag: String,
+    backStackStateName: String
+) {
+    commit {
+        replace(containerViewId, fragment, fragmentTag)
+        addToBackStack(backStackStateName)
+    }
+}
+
+/**
+ * Replaces the [containerViewId] with the given [fragment].
+ */
+fun FragmentManager.replaceFragment(
+    @IdRes containerViewId: Int,
+    fragment: Fragment,
+    fragmentTag: String
+) {
+    commit {
+        replace(containerViewId, fragment, fragmentTag)
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
@@ -11,6 +11,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog.OnConfirmationDialogClicked
 
 class StarredListActivity :
@@ -44,7 +45,9 @@ class StarredListActivity :
     }
 
     override fun onSessionListClick(sessionId: String) {
-        SessionDetailsActivity.start(this, sessionId)
+        if (AppRepository.updateSelectedSessionId(sessionId)) {
+            SessionDetailsActivity.start(this)
+        }
     }
 
     override fun onAccepted(dlgId: Int) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -17,7 +17,9 @@ import android.widget.HeaderViewListAdapter
 import android.widget.ListView
 import android.widget.Toast
 import androidx.annotation.CallSuper
+import androidx.annotation.IdRes
 import androidx.annotation.MainThread
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
@@ -25,6 +27,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -53,8 +56,11 @@ class StarredListFragment :
         const val DELETE_ALL_FAVORITES_REQUEST_CODE = 19126
 
         @JvmStatic
-        fun newInstance(sidePane: Boolean): StarredListFragment {
-            return StarredListFragment().withArguments(BundleKeys.SIDEPANE to sidePane)
+        fun replace(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sidePane: Boolean) {
+            val fragment = StarredListFragment().withArguments(
+                BundleKeys.SIDEPANE to sidePane
+            )
+            fragmentManager.replaceFragment(containerViewId, fragment, FRAGMENT_TAG, FRAGMENT_TAG)
         }
 
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -14,6 +14,7 @@ class SharedPreferencesRepository(val context: Context) {
         const val DISPLAY_DAY_INDEX_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.DISPLAY_DAY_INDEX"
         const val ENGELSYSTEM_SHIFTS_HASH_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_HASH"
         const val SCHEDULE_LAST_FETCHED_AT_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT"
+        const val SELECTED_SESSION_ID_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SELECTED_SESSION_ID_KEY"
 
     }
 
@@ -112,5 +113,12 @@ class SharedPreferencesRepository(val context: Context) {
     fun setLastEngelsystemShiftsHash(hash: Int) = preferences.edit {
         putInt(ENGELSYSTEM_SHIFTS_HASH_KEY, hash)
     }
+
+    fun getSelectedSessionId() =
+        preferences.getString(SELECTED_SESSION_ID_KEY, "")!!
+
+    fun setSelectedSessionId(sessionId: String): Boolean = preferences.edit()
+        .putString(SELECTED_SESSION_ID_KEY, sessionId)
+        .commit()
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -470,6 +470,7 @@ object AppRepository {
         val toBeUpdated = toBeUpdatedSessionsDatabaseModel.map { it.sessionId to it.toContentValues() }
         val toBeDeleted = toBeDeletedSessions.map { it.sessionId }
         sessionsDatabaseRepository.updateSessions(toBeUpdated, toBeDeleted)
+        refreshStarredSessions()
         refreshChangedSessions()
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -138,6 +138,28 @@ object AppRepository {
             .flowOn(executionContext.database)
     }
 
+    private val refreshSelectedSessionSignal = MutableSharedFlow<Unit>()
+
+    private fun refreshSelectedSession() {
+        logging.d(javaClass.simpleName, "Refreshing selected session ...")
+        val requestIdentifier = "refreshSelectedSession"
+        parentJobs[requestIdentifier] = databaseScope.launchNamed(requestIdentifier) {
+            refreshSelectedSessionSignal.emit(Unit)
+        }
+    }
+
+    /**
+     * Emits all sessions from the database which have been favored aka. starred but no canceled.
+     * The returned list might be empty.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val selectedSession: Flow<Session> by lazy {
+        refreshSelectedSessionSignal
+            .onStart { emit(Unit) }
+            .mapLatest { loadSelectedSession() }
+            .flowOn(executionContext.database)
+    }
+
     @JvmOverloads
     fun initialize(
             context: Context,
@@ -309,6 +331,15 @@ object AppRepository {
     }
 
     /**
+     * Loads the session which has been selected at last.
+     */
+    @WorkerThread
+    fun loadSelectedSession(): Session {
+        val sessionId = readSelectedSessionId()
+        return readSessionBySessionId(sessionId)
+    }
+
+    /**
      * Loads all sessions from the database which have not been canceled.
      * The returned list might be empty.
      */
@@ -397,12 +428,15 @@ object AppRepository {
             alarmsDatabaseRepository.deleteForAlarmId(alarmId)
 
     fun deleteAlarmForSessionId(sessionId: String) =
-            alarmsDatabaseRepository.deleteForSessionId(sessionId)
+        alarmsDatabaseRepository.deleteForSessionId(sessionId).also {
+            refreshSelectedSession()
+        }
 
     fun updateAlarm(alarm: Alarm) {
         val alarmDatabaseModel = alarm.toAlarmDatabaseModel()
         val values = alarmDatabaseModel.toContentValues()
         alarmsDatabaseRepository.update(values, alarm.sessionId)
+        refreshSelectedSession()
     }
 
     fun readHighlightSessionIds() = readHighlights()
@@ -420,15 +454,17 @@ object AppRepository {
         val values = highlightDatabaseModel.toContentValues()
         highlightsDatabaseRepository.update(values, session.sessionId)
         refreshStarredSessions()
+        refreshSelectedSession()
     }
 
     @WorkerThread
     fun deleteAllHighlights() {
         highlightsDatabaseRepository.deleteAll()
         refreshStarredSessions()
+        refreshSelectedSession()
     }
 
-    fun readSessionBySessionId(sessionId: String): Session {
+    private fun readSessionBySessionId(sessionId: String): Session {
         val session = sessionsDatabaseRepository.querySessionBySessionId(sessionId).toSessionAppModel()
 
         val highlight = highlightsDatabaseRepository.queryBySessionId(sessionId.toInt())
@@ -453,6 +489,21 @@ object AppRepository {
     private fun readSessionsOrderedByDateUtcExcludingEngelsystemShifts() =
             sessionsDatabaseRepository.querySessionsWithoutRoom(ENGELSYSTEM_ROOM_NAME).toSessionsAppModel()
 
+    private fun readSelectedSessionId(): String {
+        val id = sharedPreferencesRepository.getSelectedSessionId()
+        check(id.isNotEmpty()) { "Selected session is empty." }
+        return id
+    }
+
+    fun updateSelectedSessionId(sessionId: String): Boolean {
+        val isSet = sharedPreferencesRepository.setSelectedSessionId(sessionId).onFailure {
+            error("Error persisting selected session ID '$sessionId'.")
+        }
+        return isSet.also {
+            refreshSelectedSession()
+        }
+    }
+
     fun readLastEngelsystemShiftsHash() =
             sharedPreferencesRepository.getLastEngelsystemShiftsHash()
 
@@ -472,6 +523,7 @@ object AppRepository {
         sessionsDatabaseRepository.updateSessions(toBeUpdated, toBeDeleted)
         refreshStarredSessions()
         refreshChangedSessions()
+        refreshSelectedSession()
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -374,12 +374,14 @@ public class MainActivity extends BaseActivity implements
     }
 
     public void openSessionDetails(@NonNull String sessionId) {
-        FragmentContainerView sidePane = findViewById(R.id.detail);
-        MyApp.LogDebug(LOG_TAG, "openSessionDetails sidePane=" + sidePane);
-        if (sidePane != null) {
-            SessionDetailsFragment.replaceAtBackStack(getSupportFragmentManager(), R.id.detail, sessionId, true);
-        } else {
-            SessionDetailsActivity.startForResult(this, sessionId);
+        if (appRepository.updateSelectedSessionId(sessionId)) {
+            FragmentContainerView sidePane = findViewById(R.id.detail);
+            MyApp.LogDebug(LOG_TAG, "openSessionDetails sidePane=" + sidePane);
+            if (sidePane != null) {
+                SessionDetailsFragment.replaceAtBackStack(getSupportFragmentManager(), R.id.detail, true);
+            } else {
+                SessionDetailsActivity.startForResult(this);
+            }
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.java
@@ -377,15 +377,7 @@ public class MainActivity extends BaseActivity implements
         FragmentContainerView sidePane = findViewById(R.id.detail);
         MyApp.LogDebug(LOG_TAG, "openSessionDetails sidePane=" + sidePane);
         if (sidePane != null) {
-            FragmentManager fm = getSupportFragmentManager();
-            fm.popBackStack(SessionDetailsFragment.FRAGMENT_TAG, FragmentManager.POP_BACK_STACK_INCLUSIVE);
-            Bundle args = new Bundle();
-            args.putString(BundleKeys.SESSION_ID, sessionId);
-            args.putBoolean(BundleKeys.SIDEPANE, true);
-            SessionDetailsFragment fragment = new SessionDetailsFragment();
-            fragment.setArguments(args);
-            replaceFragment(R.id.detail, fragment,
-                    SessionDetailsFragment.FRAGMENT_TAG, SessionDetailsFragment.FRAGMENT_TAG);
+            SessionDetailsFragment.replaceAtBackStack(getSupportFragmentManager(), R.id.detail, sessionId, true);
         } else {
             SessionDetailsActivity.startForResult(this, sessionId);
         }
@@ -486,8 +478,7 @@ public class MainActivity extends BaseActivity implements
         } else if (!isScreenLocked) {
             sidePane.setVisibility(View.VISIBLE);
             isFavoritesInSidePane = true;
-            replaceFragment(R.id.detail, StarredListFragment.newInstance(true),
-                    StarredListFragment.FRAGMENT_TAG, StarredListFragment.FRAGMENT_TAG);
+            StarredListFragment.replace(getSupportFragmentManager(), R.id.detail, true);
         }
     }
 
@@ -497,8 +488,7 @@ public class MainActivity extends BaseActivity implements
             ChangeListActivity.start(this);
         } else {
             sidePane.setVisibility(View.VISIBLE);
-            replaceFragment(R.id.detail, ChangeListFragment.newInstance(true),
-                    ChangeListFragment.FRAGMENT_TAG, ChangeListFragment.FRAGMENT_TAG);
+            ChangeListFragment.replace(getSupportFragmentManager(), R.id.detail, true);
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -7,7 +7,6 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 
 class FeedbackUrlComposer(
 
-        private val session: Session,
         private val frabScheduleFeedbackUrlFormatString: String = BuildConfig.SCHEDULE_FEEDBACK_URL
 
 ) {
@@ -16,27 +15,30 @@ class FeedbackUrlComposer(
      * Returns the feedback URL for the [session] if it can be composed
      * otherwise an empty string.
      *
-     * The [Frab schedule feedback URL][frabScheduleFeedbackUrl] is
+     * The [Frab schedule feedback URL][getFrabScheduleFeedbackUrl] is
      * composed from the session id.
      * For sessions extracted from the wiki of the Chaos Communication Congress
      * aka. "self organized sessions" an empty string is returned because
      * there is no feedback system for them.
      */
-    fun getFeedbackUrl(): String {
+    fun getFeedbackUrl(session: Session): String {
         if (session.originatesFromWiki) {
             return NO_URL
         }
         return if (session.originatesFromPretalx) {
             session.pretalxScheduleFeedbackUrl
         } else {
-            session.frabScheduleFeedbackUrl
+            getFrabScheduleFeedbackUrl(session.sessionId, frabScheduleFeedbackUrlFormatString)
         }
     }
 
-    private val Session.frabScheduleFeedbackUrl
-        get() =
-            if (frabScheduleFeedbackUrlFormatString.isEmpty()) NO_URL
-            else String.format(frabScheduleFeedbackUrlFormatString, sessionId)
+    private fun getFrabScheduleFeedbackUrl(sessionId: String, frabScheduleFeedbackUrlFormatString: String): String {
+        return if (frabScheduleFeedbackUrlFormatString.isEmpty()) {
+            NO_URL
+        } else {
+            String.format(frabScheduleFeedbackUrlFormatString, sessionId)
+        }
+    }
 
     private val Session.pretalxScheduleFeedbackUrl
         get() = "$url$PRETALX_SCHEDULE_FEEDBACK_URL_SUFFIX"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatterTest.kt
@@ -1,0 +1,45 @@
+package nerd.tuxmobil.fahrplan.congress.details
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SessionFormatterTest {
+
+    private val formatter = SessionFormatter()
+
+    @Test
+    fun `getFormattedLinks returns an empty string`() {
+        val links = ""
+        val expected = ""
+        assertThat(formatter.getFormattedLinks(links)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getFormattedLinks returns the given unmodified string`() {
+        val links = "[VOC projects](https://www.voc.com/projects/)"
+        val expected = "[VOC projects](https://www.voc.com/projects/)"
+        assertThat(formatter.getFormattedLinks(links)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getFormattedLinks returns a br separated string`() {
+        val links = "[VOC projects](https://www.voc.com/projects/),[POC](https://poc.com/QXut1XBymAk)"
+        val expected = "[VOC projects](https://www.voc.com/projects/)<br>[POC](https://poc.com/QXut1XBymAk)"
+        assertThat(formatter.getFormattedLinks(links)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getFormattedUrl returns an empty string`() {
+        val url = ""
+        val expected = ""
+        assertThat(formatter.getFormattedUrl(url)).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getFormattedUrl returns an HTML formatted weblink`() {
+        val url = "https://example.com/talk.html"
+        val expected = """<a href="https://example.com/talk.html">https://example.com/talk.html</a>"""
+        assertThat(formatter.getFormattedUrl(url)).isEqualTo(expected)
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -30,26 +30,26 @@ class FeedbackUrlComposerTest {
 
     @Test
     fun getFeedbackUrlWithFrabSessionWithoutScheduleFeedbackUrl() {
-        assertThat(FeedbackUrlComposer(FRAB_SESSION, "")
-                .getFeedbackUrl()).isEmpty()
+        assertThat(FeedbackUrlComposer("")
+                .getFeedbackUrl(FRAB_SESSION)).isEmpty()
     }
 
     @Test
     fun getFeedbackUrlWithFrabSessionWithFrabScheduleFeedbackUrl() {
-        assertThat(FeedbackUrlComposer(FRAB_SESSION, FRAB_SCHEDULE_FEEDBACK_URL)
-                .getFeedbackUrl()).isEqualTo("https://frab.cccv.de/en/35C3/public/events/9985/feedback/new")
+        assertThat(FeedbackUrlComposer(FRAB_SCHEDULE_FEEDBACK_URL)
+                .getFeedbackUrl(FRAB_SESSION)).isEqualTo("https://frab.cccv.de/en/35C3/public/events/9985/feedback/new")
     }
 
     @Test
     fun getFeedbackUrlWithPretalxSessionWithFrabScheduleFeedbackUrl() {
-        assertThat(FeedbackUrlComposer(PRETALX_SESSION, FRAB_SCHEDULE_FEEDBACK_URL)
-                .getFeedbackUrl()).isEqualTo("https://talks.mrmcd.net/2019/talk/9XL7SP/feedback/")
+        assertThat(FeedbackUrlComposer(FRAB_SCHEDULE_FEEDBACK_URL)
+                .getFeedbackUrl(PRETALX_SESSION)).isEqualTo("https://talks.mrmcd.net/2019/talk/9XL7SP/feedback/")
     }
 
     @Test
     fun getFeedbackUrlWithWikiSession() {
-        assertThat(FeedbackUrlComposer(WIKI_SESSION, "")
-                .getFeedbackUrl()).isEqualTo("")
+        assertThat(FeedbackUrlComposer("")
+                .getFeedbackUrl(WIKI_SESSION)).isEqualTo("")
     }
 
 }


### PR DESCRIPTION
# Description
+ Unidirectional data flow is now used for the `SessionDetailsFragment`.
+ `Flow` is used to emit sessions from the `AppRepository` to the `ViewModel`.
+ The `AppRepository#selectedSession` `Flow` is refreshed whenever the schedule is updated, the session selection changes, the session is un/favored or and alarm is added resp. removed.
+ `SharedPreferences` are used to persist the session selection.
+ `LiveData` is used to post data from the `ViewModel` to the `Fragment`.
+ Refactor `FeedbackUrlComposer` so it can be used with constructor injection.

# Motivation
- This hopefully resolves a couple of random issues which occur when sessions are updated while the user interacts with the UI.
- Other screens will be refactored in the following.

# Testing
- This can be tested with the recently added "schedule refresh interval" developer option, see #407.
- A schedule URL which shuffles schedule files in short intervals is available upon interest.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)
- :heavy_check_mark: Nexus 9 emulator (tablet), Android 5.1 (API 22)

# Related
- [Issue #246: Migrate to data driven architecture](https://github.com/EventFahrplan/EventFahrplan/issues/246)
- [Pull request #404: Let AppRepository be the single source of truth for favorites screen.](https://github.com/EventFahrplan/EventFahrplan/pull/404)
- [Pull request #410: Let AppRepository be the single source of truth for changes screen.](https://github.com/EventFahrplan/EventFahrplan/pull/410)