### PR TITLE
Random housekeeping

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -99,7 +99,6 @@ public class AboutDialog extends DialogFragment {
         text.setText(appVersionText);
 
         View appDisclaimer = requireViewByIdCompat(view, R.id.about_app_disclaimer_view);
-        //noinspection ConstantConditions
         appDisclaimer.setVisibility(BuildConfig.SHOW_APP_DISCLAIMER ? View.VISIBLE : View.GONE);
 
         int linkTextColor = ContextCompat.getColor(view.getContext(), R.color.text_link_on_dark);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -49,24 +49,24 @@ class AlarmUpdater @JvmOverloads constructor(
         var nextFetch: Long
         when {
             conference.contains(time) -> {
-                logging.d(LOG_TAG, "START <= time < END");
+                logging.d(LOG_TAG, "START <= time < END")
                 interval = TWO_HOURS
                 nextFetch = time + interval
             }
             conference.endsBefore(time) -> {
-                logging.d(LOG_TAG, "START < END <= time");
+                logging.d(LOG_TAG, "START < END <= time")
                 listener.onCancelAlarm()
                 return 0
             }
             else -> {
-                logging.d(LOG_TAG, "time < END");
+                logging.d(LOG_TAG, "time < END")
                 interval = ONE_DAY
                 nextFetch = time + interval
             }
         }
         val shiftedTime = time + ONE_DAY
         if (conference.startsAfter(time) && conference.startsAtOrBefore(shiftedTime)) {
-            logging.d(LOG_TAG, "time < START && START <= shiftedTime");
+            logging.d(LOG_TAG, "time < START && START <= shiftedTime")
             interval = TWO_HOURS
             nextFetch = conference.firstDayStartTime
             if (!isInitial) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
@@ -17,7 +17,7 @@ class CalendarDescriptionComposer(
     private val session: Session,
     private val sessionOnlineText: String,
     private val markdownConversion: MarkdownConversion = MarkdownConverter,
-    private val sessionUrlComposition: SessionUrlComposition = SessionUrlComposer(session)
+    private val sessionUrlComposition: SessionUrlComposition = SessionUrlComposer()
 
 ) : CalendarDescriptionComposition {
 
@@ -67,7 +67,7 @@ class CalendarDescriptionComposer(
     }
 
     private fun StringBuilder.appendSessionOnline() {
-        val sessionUrl = sessionUrlComposition.getSessionUrl()
+        val sessionUrl = sessionUrlComposition.getSessionUrl(session)
         if (sessionUrl.isNotEmpty()) {
             append("$sessionOnlineText: $sessionUrl")
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
@@ -14,7 +14,6 @@ import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
  */
 class CalendarDescriptionComposer(
 
-    private val session: Session,
     private val sessionOnlineText: String,
     private val markdownConversion: MarkdownConversion = MarkdownConverter,
     private val sessionUrlComposition: SessionUrlComposition = SessionUrlComposer()
@@ -24,49 +23,49 @@ class CalendarDescriptionComposer(
     /**
      * Returns the composed description text.
      */
-    override fun getCalendarDescription() = buildString {
-        appendSubtitle()
-        appendSpeakers()
-        appendAbstract()
-        appendDescription()
+    override fun getCalendarDescription(session: Session) = buildString {
+        appendSubtitle(session)
+        appendSpeakers(session)
+        appendAbstract(session)
+        appendDescription(session)
         if (session.getLinks().containsWikiLink()) {
             // TODO: It seems that wiki links are no longer added to the links XML attribute.
             // Therefore, this code path might be removed in the future.
             // To be verified with VOC wiki scripts.
-            appendWikiLinks()
+            appendWikiLinks(session)
         } else {
-            appendLinks()
-            appendSessionOnline()
+            appendLinks(session)
+            appendSessionOnline(session)
         }
     }
 
-    private fun StringBuilder.appendSubtitle() {
+    private fun StringBuilder.appendSubtitle(session: Session) {
         appendParagraphIfNotEmpty(session.subtitle.orEmpty())
     }
 
-    private fun StringBuilder.appendSpeakers() {
+    private fun StringBuilder.appendSpeakers(session: Session) {
         appendParagraphIfNotEmpty(session.formattedSpeakers)
     }
 
-    private fun StringBuilder.appendAbstract() {
+    private fun StringBuilder.appendAbstract(session: Session) {
         appendMarkdownParagraphIfNotEmpty(session.abstractt.orEmpty())
     }
 
-    private fun StringBuilder.appendDescription() {
+    private fun StringBuilder.appendDescription(session: Session) {
         appendMarkdownParagraphIfNotEmpty(session.description.orEmpty())
     }
 
-    private fun StringBuilder.appendWikiLinks() {
+    private fun StringBuilder.appendWikiLinks(session: Session) {
         val links = session.getLinks().separateByHtmlLineBreaks()
         append(markdownConversion.markdownLinksToHtmlLinks(links))
     }
 
-    private fun StringBuilder.appendLinks() {
+    private fun StringBuilder.appendLinks(session: Session) {
         val links = session.getLinks().separateByHtmlLineBreaks()
         appendMarkdownParagraphIfNotEmpty(markdownConversion.markdownLinksToHtmlLinks(links))
     }
 
-    private fun StringBuilder.appendSessionOnline() {
+    private fun StringBuilder.appendSessionOnline(session: Session) {
         val sessionUrl = sessionUrlComposition.getSessionUrl(session)
         if (sessionUrl.isNotEmpty()) {
             append("$sessionOnlineText: $sessionUrl")
@@ -101,6 +100,6 @@ class CalendarDescriptionComposer(
 
 interface CalendarDescriptionComposition {
 
-    fun getCalendarDescription(): String
+    fun getCalendarDescription(session: Session): String
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
@@ -13,7 +13,6 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 class CalendarSharing @JvmOverloads constructor(
 
     val context: Context,
-    val session: Session,
     private val calendarDescriptionComposition: CalendarDescriptionComposition = CalendarDescriptionComposer(
         context.getString(R.string.session_details_section_title_session_online)
     ),
@@ -23,7 +22,7 @@ class CalendarSharing @JvmOverloads constructor(
 
 ) {
 
-    fun addToCalendar() {
+    fun addToCalendar(session: Session) {
         val intent = session.toCalendarInsertIntent()
         context.startActivity(intent) {
             // TODO Updating a calendar event is broken. Always creates new entries.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
@@ -15,7 +15,7 @@ class CalendarSharing @JvmOverloads constructor(
     val context: Context,
     val session: Session,
     private val calendarDescriptionComposition: CalendarDescriptionComposition = CalendarDescriptionComposer(
-        session, context.getString(R.string.session_details_section_title_session_online)
+        context.getString(R.string.session_details_section_title_session_online)
     ),
     val onFailure: () -> Unit = {
         Toast.makeText(context, R.string.add_to_calendar_failed, Toast.LENGTH_LONG).show()
@@ -35,7 +35,7 @@ class CalendarSharing @JvmOverloads constructor(
 
     private fun Session.toCalendarInsertIntent(): Intent {
         val title = this.title
-        val description = calendarDescriptionComposition.getCalendarDescription()
+        val description = calendarDescriptionComposition.getCalendarDescription(this)
         val location = this.room
         val startTime = startTimeMilliseconds
         val endTime = startTime + this.duration * MILLISECONDS_OF_ONE_MINUTE

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.java
@@ -114,8 +114,7 @@ public class ChangeListFragment extends AbstractListFragment {
         try {
             mListener = (OnSessionListClick) context;
         } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString()
-                    + " must implement OnSessionListClick");
+            throw new ClassCastException(context + " must implement OnSessionListClick");
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -308,7 +308,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     }
 
     override fun addToCalendar(session: Session) {
-        CalendarSharing(requireContext(), session).addToCalendar()
+        CalendarSharing(requireContext()).addToCalendar(session)
     }
 
     override fun showAlarmTimePicker() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -40,7 +40,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
             JsonSessionFormat().format(this)
         },
         private val toC3NavRoomName: Session.() -> String = {
-            RoomForC3NavConverter.convert(this.room)
+            RoomForC3NavConverter().convert(this.room)
         },
         private val toFormattedZonedDateTime: Session.() -> String = {
             val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -50,7 +50,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
             markdownConversion.markdownLinksToHtmlLinks(this)
         },
         private val toSessionUrl: Session.() -> String = {
-            SessionUrlComposer(this).getSessionUrl()
+            SessionUrlComposer().getSessionUrl(this)
         }
 
 ) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -34,7 +34,7 @@ class SessionDetailsViewModel @JvmOverloads constructor(
             FeedbackUrlComposer(this, urlTemplate).getFeedbackUrl()
         },
         private val toPlainText: Session.(ZoneId?) -> String = { timeZoneId ->
-            SimpleSessionFormat.format(this, timeZoneId)
+            SimpleSessionFormat().format(this, timeZoneId)
         },
         private val toJson: Session.() -> String = {
             JsonSessionFormat().format(this)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -73,7 +73,7 @@ class StarredListViewModel(
 
     private fun List<Session>.toStarredListParameter(): StarredListParameter {
         val numDays = if (isEmpty()) 0 else repository.readMeta().numDays
-        val useDeviceTimeZone = if (isEmpty()) false else repository.readUseDeviceTimeZoneEnabled()
+        val useDeviceTimeZone = isNotEmpty() && repository.readUseDeviceTimeZoneEnabled()
         return StarredListParameter(this, numDays, useDeviceTimeZone).also {
             logging.d(LOG_TAG, "Loaded $size starred sessions.")
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelFactory.kt
@@ -21,7 +21,7 @@ class StarredListViewModelFactory(
             repository = appRepository,
             executionContext = AppExecutionContext,
             logging = logging,
-            simpleSessionFormat = SimpleSessionFormat,
+            simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat()
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -190,7 +190,7 @@ public class Session {
      * Returns the end date and time in milliseconds.
      */
     public long getEndsAtDateUtc() {
-        return dateUTC + duration * MILLISECONDS_OF_ONE_MINUTE;
+        return dateUTC + (long) duration * MILLISECONDS_OF_ONE_MINUTE;
     }
 
     @SuppressWarnings("RedundantIfStatement")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverter.kt
@@ -1,10 +1,12 @@
 package nerd.tuxmobil.fahrplan.congress.navigation
 
-object RoomForC3NavConverter {
+class RoomForC3NavConverter {
 
-    private const val EMPTY_STRING = ""
+    companion object {
 
-    private val ROOM_TO_C3NAV_MAPPING = mapOf(
+        private const val EMPTY_STRING = ""
+
+        private val ROOM_TO_C3NAV_MAPPING = mapOf(
             "ADA" to "hall-a",
             "BORG" to "hall-b",
             "CLARKE" to "hall-c",
@@ -87,9 +89,10 @@ object RoomForC3NavConverter {
             "VINTAGE COMPUTING CLUSTER" to "vintage",
             "WIKIPAKA WG: BIBLIOTHEK" to "wikipaka-library",
             "WIKIPAKA WG: ESSZIMMER" to "wikipaka-dining"
-    )
+        )
 
-    @JvmStatic
+    }
+
     fun convert(room: String?) = when {
         room != null && EMPTY_STRING != room -> {
             val c3navName = ROOM_TO_C3NAV_MAPPING[room.uppercase()]

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/DatabaseScope.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/DatabaseScope.kt
@@ -32,6 +32,7 @@ class DatabaseScope private constructor(
         return scope.launch(context = CoroutineName(name), block = block)
     }
 
+    @Suppress("unused")
     suspend fun <T> withUiContext(block: suspend CoroutineScope.() -> T) =
         executionContext.withUiContext(block)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -744,7 +744,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                 }
             case CONTEXT_MENU_ITEM_ID_SHARE_TEXT:
                 ZoneId timeZoneId = appRepository.readMeta().getTimeZoneId();
-                String formattedSession = SimpleSessionFormat.format(session, timeZoneId);
+                String formattedSession = new SimpleSessionFormat().format(session, timeZoneId);
                 SessionSharer.shareSimple(context, formattedSession);
                 break;
             case CONTEXT_MENU_ITEM_ID_SHARE_JSON:

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -338,7 +338,6 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
         // whenever possible, just update recycler views
         if (!forceReload && !adapterByRoomIndex.isEmpty()) {
             for (int roomIndex = columnIndexLeft; roomIndex <= columnIndexRight; roomIndex++) {
-                //noinspection ConstantConditions
                 try {
                     adapterByRoomIndex.get(roomIndex).notifyDataSetChanged();
                 } catch (NullPointerException e) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -736,7 +736,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                 updateMenuItems();
                 break;
             case CONTEXT_MENU_ITEM_ID_ADD_TO_CALENDAR:
-                new CalendarSharing(context, session).addToCalendar();
+                new CalendarSharing(context).addToCalendar(session);
                 break;
             case CONTEXT_MENU_ITEM_ID_SHARE:
                 if (BuildConfig.ENABLE_CHAOSFLIX_EXPORT) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -52,7 +52,7 @@ object SimpleSessionFormat {
         if (!session.getLinks().containsWikiLink()) {
             append(LINE_BREAK)
             append(LINE_BREAK)
-            val sessionUrl = SessionUrlComposer(session).getSessionUrl()
+            val sessionUrl = SessionUrlComposer().getSessionUrl(session)
             append(sessionUrl)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -6,14 +6,15 @@ import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 import org.threeten.bp.ZoneId
 
-object SimpleSessionFormat {
+class SimpleSessionFormat {
 
-    private const val LINE_BREAK = "\n"
-    private const val COMMA = ","
-    private const val SPACE = " "
-    private const val HORIZONTAL_DIVIDERS = "---"
+    companion object {
+        private const val LINE_BREAK = "\n"
+        private const val COMMA = ","
+        private const val SPACE = " "
+        private const val HORIZONTAL_DIVIDERS = "---"
+    }
 
-    @JvmStatic
     fun format(session: Session, timeZoneId: ZoneId?): String {
         val builder = StringBuilder()
         builder.appendSession(session, timeZoneId)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -7,7 +7,6 @@ import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 
 class SessionUrlComposer @JvmOverloads constructor(
 
-        private val session: Session,
         private val sessionUrlTemplate: String = BuildConfig.EVENT_URL,
         private val serverBackEndType: String = BuildConfig.SERVER_BACKEND_TYPE,
         private val specialRoomNames: Set<String> = setOf(
@@ -29,19 +28,16 @@ class SessionUrlComposer @JvmOverloads constructor(
      * it is returned. If there is no URL defined then no composition is tried but instead
      * an empty string is returned.
      */
-    override fun getSessionUrl() = session.sessionUrl
-
-    private val Session.sessionUrl: String
-        get() = when (serverBackEndType) {
+    override fun getSessionUrl(session: Session): String = when (serverBackEndType) {
             PENTABARF.name -> getComposedSessionUrl(session.slug)
-            else -> if (url.isNullOrEmpty()) {
-                if (specialRoomNames.contains(room)) {
+            else -> if (session.url.isNullOrEmpty()) {
+                if (specialRoomNames.contains(session.room)) {
                     NO_URL
                 } else {
-                    getComposedSessionUrl(sessionId)
+                    getComposedSessionUrl(session.sessionId)
                 }
             } else {
-                url
+                session.url
             }
         }
 
@@ -56,6 +52,6 @@ class SessionUrlComposer @JvmOverloads constructor(
 
 interface SessionUrlComposition {
 
-    fun getSessionUrl(): String
+    fun getSessionUrl(session: Session): String
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -10,7 +10,6 @@ import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mockito.verify
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -94,8 +93,8 @@ class AlarmUpdaterTest {
         // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(1451212200000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451212200000L + 7200000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451212200000L + 7200000L)
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
     }
 
@@ -106,7 +105,7 @@ class AlarmUpdaterTest {
         // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, false)
         assertThat(interval).isEqualTo(0)
-        verify(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onCancelAlarm()
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
         verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
     }
@@ -116,7 +115,7 @@ class AlarmUpdaterTest {
         // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, true)
         assertThat(interval).isEqualTo(0)
-        verify(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onCancelAlarm()
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
         verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
     }
@@ -128,8 +127,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, false)
         assertThat(interval).isEqualTo(7200000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
         verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
     }
 
@@ -138,8 +137,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
     }
 
@@ -150,8 +149,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, false)
         assertThat(interval).isEqualTo(7200000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
         verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
     }
 
@@ -160,8 +159,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
     }
 
@@ -183,8 +182,8 @@ class AlarmUpdaterTest {
         // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(1451084399000L, true)
         assertThat(interval).isEqualTo(86400000L)
-        verify(mockListener).onCancelAlarm()
-        verify(mockListener).onRescheduleInitialAlarm(86400000L, 1451084399000L + 86400000L)
+        verifyInvokedOnce(mockListener).onCancelAlarm()
+        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(86400000L, 1451084399000L + 86400000L)
         verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -114,12 +114,12 @@ class CalendarDescriptionComposerTest {
     }
 
     private fun createComposer(session: Session): CalendarDescriptionComposer {
-        return CalendarDescriptionComposer(session, "Session online", sessionUrlComposition = FakeSessionUrlComposer(session))
+        return CalendarDescriptionComposer(session, "Session online", sessionUrlComposition = FakeSessionUrlComposer())
     }
 
-    private class FakeSessionUrlComposer(val session: Session) : SessionUrlComposition {
+    private class FakeSessionUrlComposer : SessionUrlComposition {
 
-        override fun getSessionUrl(): String {
+        override fun getSessionUrl(session: Session): String {
             return "https://events.ccc.de/congress/2021/Fahrplan/events/${session.sessionId}.html"
         }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -15,7 +15,7 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns session online`() {
         val session = createSession()
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
             """.trimIndent())
     }
@@ -23,7 +23,7 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns subtitle and session online`() {
         val session = createSession(subtitle = "Lorem ipsum dolor")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Lorem ipsum dolor
 
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
@@ -33,7 +33,7 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns speakers and session online`() {
         val session = createSession(speakers = "Ada Lovelace;Albert Einstein")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Ada Lovelace, Albert Einstein
 
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
@@ -43,7 +43,7 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns abstract and session online`() {
         val session = createSession(abstract = "Lorem ipsum dolor sit amet.")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Lorem ipsum dolor sit amet.
 
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
@@ -53,7 +53,7 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns description and session online`() {
         val session = createSession(description = "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
@@ -65,7 +65,7 @@ class CalendarDescriptionComposerTest {
         val session = createSession(links = "[https://c3voc.de](https://c3voc.de)," +
                 "[https://events.ccc.de/congress/2017/wiki/index.php/Session:A/V_Angel_Meeting]" +
                 "(https://events.ccc.de/congress/2017/wiki/index.php/Session:A/V_Angel_Meeting)")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             <a href="https://c3voc.de">https://c3voc.de</a><br><a href="https://events.ccc.de/congress/2017/wiki/index.php/Session:A/V_Angel_Meeting">https://events.ccc.de/congress/2017/wiki/index.php/Session:A/V_Angel_Meeting</a>
             """.trimIndent())
     }
@@ -74,7 +74,7 @@ class CalendarDescriptionComposerTest {
     fun `getCalendarDescription returns links`() {
         val session = createSession(links = "[OpenStreetMap](https://openstreetmap.org)," +
                 "[https://overpass-turbo.eu](https://overpass-turbo.eu)")
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             <a href="https://openstreetmap.org">OpenStreetMap</a><br><a href="https://overpass-turbo.eu">https://overpass-turbo.eu</a>
 
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
@@ -90,7 +90,7 @@ class CalendarDescriptionComposerTest {
             description = "Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
             links = "[Engelsystem](https://engelsystem.de)"
         )
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Lorem ipsum dolor
 
             Ada Lovelace, Albert Einstein
@@ -108,13 +108,13 @@ class CalendarDescriptionComposerTest {
     @Test
     fun `getCalendarDescription returns session online with uninitialized session`() {
         val session = createSession(subtitle = null, speakers = null, abstract = null, description = null, links = null)
-        assertThat(createComposer(session).getCalendarDescription()).isEqualTo("""
+        assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
             """.trimIndent())
     }
 
-    private fun createComposer(session: Session): CalendarDescriptionComposer {
-        return CalendarDescriptionComposer(session, "Session online", sessionUrlComposition = FakeSessionUrlComposer())
+    private fun createComposer(): CalendarDescriptionComposer {
+        return CalendarDescriptionComposer("Session online", sessionUrlComposition = FakeSessionUrlComposer())
     }
 
     private class FakeSessionUrlComposer : SessionUrlComposition {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -26,7 +26,8 @@ class CalendarSharingTest {
 
     @Test
     fun `addToCalendar composes and emits a calendar insert intent`() {
-        CalendarSharing(context, createSession(), FakeComposer, onFailure).addToCalendar()
+        val session = createSession()
+        CalendarSharing(context, FakeComposer, onFailure).addToCalendar(session)
         verify(context).startActivity(argThat(InsertIntentMatcher()))
         verify(onFailure, never()).invoke()
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -9,10 +9,10 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.After
 import org.junit.Test
 import org.mockito.ArgumentMatcher
-import org.mockito.Mockito.validateMockitoUsage
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.validateMockitoUsage
 import org.mockito.kotlin.verify
 
 /**

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -55,7 +55,7 @@ class CalendarSharingTest {
     }
 
     private object FakeComposer : CalendarDescriptionComposition {
-        override fun getCalendarDescription() = "Lorem ipsum dolor"
+        override fun getCalendarDescription(session: Session) = "Lorem ipsum dolor"
     }
 
     private fun createSession() = Session("2342").apply {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -9,7 +9,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -34,7 +34,7 @@ class SessionDetailsViewModelTest {
 
     @Before
     fun setUp() {
-        whenever(repository.readSessionBySessionId(anyString())) doReturn actualSession
+        whenever(repository.readSessionBySessionId(any())) doReturn actualSession
         whenever(repository.readMeta()) doReturn meta
         whenever(meta.timeZoneId) doReturn NO_TIME_ZONE_ID
         // ViewModel must be initialized after stubbing the repository.

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
@@ -8,8 +8,8 @@ import androidx.core.text.set
 import androidx.core.text.toSpannable
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.mockito.ArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 
@@ -27,12 +27,12 @@ class TextViewExtensionsTest {
                 movementMethod = movementMethod,
                 linkTextColor = 23
         )
-        val linkTextSpannableCaptor = ArgumentCaptor.forClass(Spannable::class.java)
+        val linkTextSpannableCaptor = argumentCaptor<Spannable>()
         verify(textView).setText(linkTextSpannableCaptor.capture(), any())
         verify(textView).movementMethod = movementMethod
         verify(textView).setLinkTextColor(23)
         val linkText = urlTitle.toSpannable().apply { set(0, urlTitle.length, URLSpan(plainLinkUrl)) }
-        assertThat(linkTextSpannableCaptor.value.toString()).isEqualTo(linkText.toString())
+        assertThat(linkTextSpannableCaptor.lastValue.toString()).isEqualTo(linkText.toString())
     }
 
     @Test
@@ -45,12 +45,12 @@ class TextViewExtensionsTest {
                 movementMethod = movementMethod,
                 linkTextColor = 23
         )
-        val linkTextSpannableCaptor = ArgumentCaptor.forClass(Spannable::class.java)
+        val linkTextSpannableCaptor = argumentCaptor<Spannable>()
         verify(textView).setText(linkTextSpannableCaptor.capture(), any())
         verify(textView).movementMethod = movementMethod
         verify(textView).setLinkTextColor(23)
         val linkText = plainLinkUrl.toSpannable().apply { set(0, plainLinkUrl.length, URLSpan(plainLinkUrl)) }
-        assertThat(linkTextSpannableCaptor.value.toString()).isEqualTo(linkText.toString())
+        assertThat(linkTextSpannableCaptor.lastValue.toString()).isEqualTo(linkText.toString())
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverterTest.kt
@@ -35,7 +35,7 @@ class RoomForC3NavConverterTest(
 
     @Test
     fun convert() {
-        assertThat(RoomForC3NavConverter.convert(room)).isEqualTo(expectedText)
+        assertThat(RoomForC3NavConverter().convert(room)).isEqualTo(expectedText)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -13,7 +13,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -151,18 +151,18 @@ class AppRepositorySessionsTest {
 
     @Test
     fun `loadUncanceledSessionsForDayIndex passes through an empty list`() {
-        whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(anyInt())) doReturn emptyList()
+        whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(any())) doReturn emptyList()
         assertThat(testableAppRepository.loadUncanceledSessionsForDayIndex(0)).isEmpty()
-        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(anyInt())
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(any())
     }
 
     @Test
     fun `loadUncanceledSessionsForDayIndex filters out sessions which are canceled`() {
         val sessions = listOf(SESSION_3001, SESSION_3002)
-        whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(anyInt())) doReturn sessions.toSessionsDatabaseModel()
+        whenever(sessionsDatabaseRepository.querySessionsForDayIndexOrderedByDateUtc(any())) doReturn sessions.toSessionsDatabaseModel()
         val uncanceledSessions = testableAppRepository.loadUncanceledSessionsForDayIndex(0)
         assertThat(uncanceledSessions).containsExactly(SESSION_3001)
-        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(anyInt())
+        verifyInvokedOnce(sessionsDatabaseRepository).querySessionsForDayIndexOrderedByDateUtc(any())
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -7,10 +7,7 @@ import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnitRunner
 
-@RunWith(MockitoJUnitRunner::class)
 class LayoutCalculatorTest {
     private val conferenceDate = "2020-03-30"
     private var sessionId = 0

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -70,7 +70,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session without time zone name`() {
-        assertThat(SimpleSessionFormat.format(session1, NO_TIME_ZONE_ID)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session1, NO_TIME_ZONE_ID)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
@@ -81,7 +81,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session with time zone name`() {
-        assertThat(SimpleSessionFormat.format(session1, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session1, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
@@ -92,7 +92,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a wiki session`() {
-        assertThat(SimpleSessionFormat.format(session3, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session3, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 Angel shifts planning
                 Sonntag, 29. Dezember 2019, 09:00 MEZ (Europe/Berlin), Main hall
@@ -101,12 +101,12 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns null for an empty sessions list`() {
-        assertThat(SimpleSessionFormat.format(emptyList(), NO_TIME_ZONE_ID)).isNull()
+        assertThat(SimpleSessionFormat().format(emptyList(), NO_TIME_ZONE_ID)).isNull()
     }
 
     @Test
     fun `format returns separated multiline text for a single session`() {
-        assertThat(SimpleSessionFormat.format(listOf(session1), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(listOf(session1), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
@@ -117,7 +117,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns separated multiline text for multiple sessions`() {
-        assertThat(SimpleSessionFormat.format(listOf(session1, session2), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(listOf(session1, session2), TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
@@ -135,7 +135,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session in central european summer time`() {
-        assertThat(SimpleSessionFormat.format(session4, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session4, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
                 """
                 Central european summer time
                 Sonntag, 1. September 2019, 16:00 MESZ (Europe/Berlin), Sunshine tent

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
@@ -49,7 +49,7 @@ class SessionUrlComposerTest {
     @Test
     fun getSessionUrlWithUnknownBackend() {
         try {
-            SessionUrlComposer(FRAB_SESSION, NO_SESSION_URL_TEMPLATE, NO_SERVER_BACKEND_TYPE).getSessionUrl()
+            SessionUrlComposer(NO_SESSION_URL_TEMPLATE, NO_SERVER_BACKEND_TYPE).getSessionUrl(FRAB_SESSION)
         } catch (e: NotImplementedError) {
             assertThat(e.message).isEqualTo("Unknown server backend type: ''")
         }
@@ -57,39 +57,38 @@ class SessionUrlComposerTest {
 
     @Test
     fun getSessionUrlWithPentabarfSessionWithPentabarfBackend() {
-        assertThat(SessionUrlComposer(PENTABARF_SESSION, PENTABARF_SESSION_URL_TEMPLATE, ServerBackendType.PENTABARF.name)
-                .getSessionUrl()).isEqualTo("https://fosdem.org/2018/schedule/event/keynotes_welcome/")
+        assertThat(SessionUrlComposer(PENTABARF_SESSION_URL_TEMPLATE, ServerBackendType.PENTABARF.name)
+                .getSessionUrl(PENTABARF_SESSION)).isEqualTo("https://fosdem.org/2018/schedule/event/keynotes_welcome/")
     }
 
     @Test
     fun getSessionUrlWithFrabSessionWithFrabBackend() {
-        assertThat(SessionUrlComposer(FRAB_SESSION, FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name)
-                .getSessionUrl()).isEqualTo("https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html")
+        assertThat(SessionUrlComposer(FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name)
+                .getSessionUrl(FRAB_SESSION)).isEqualTo("https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html")
     }
 
     @Test
     fun getSessionUrlWithPretalxSessionWithFrabBackend() {
-        assertThat(SessionUrlComposer(PRETALX_SESSION, FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name)
-                .getSessionUrl()).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB")
+        assertThat(SessionUrlComposer(FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name)
+                .getSessionUrl(PRETALX_SESSION)).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB")
     }
 
     @Test
     fun getSessionUrlWithPretalxSessionWithPretalxBackend() {
-        assertThat(SessionUrlComposer(PRETALX_SESSION, NO_SESSION_URL_TEMPLATE, ServerBackendType.PRETALX.name)
-                .getSessionUrl()).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB")
+        assertThat(SessionUrlComposer(NO_SESSION_URL_TEMPLATE, ServerBackendType.PRETALX.name)
+                .getSessionUrl(PRETALX_SESSION)).isEqualTo("https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB")
     }
 
     @Test
     fun getSessionUrlWithShiftSessionWithUrl() {
-        assertThat(SessionUrlComposer(ENGELSYSTEM_SHIFT_SESSION_WITH_URL, FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
-                .getSessionUrl()).isEqualTo("https://helpful.to/the/angel")
+        assertThat(SessionUrlComposer(FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
+                .getSessionUrl(ENGELSYSTEM_SHIFT_SESSION_WITH_URL)).isEqualTo("https://helpful.to/the/angel")
     }
 
     @Test
     fun getSessionUrlWithShiftSessionWithoutUrl() {
-        assertThat(SessionUrlComposer(ENGELSYSTEM_SHIFT_SESSION_WITHOUT_URL, FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
-                .getSessionUrl()).isEqualTo(NO_URL)
+        assertThat(SessionUrlComposer(FRAB_SESSION_URL_TEMPLATE, ServerBackendType.FRAB.name, setOf(AppRepository.ENGELSYSTEM_ROOM_NAME))
+                .getSessionUrl(ENGELSYSTEM_SHIFT_SESSION_WITHOUT_URL)).isEqualTo(NO_URL)
     }
 
 }
-


### PR DESCRIPTION
# Description
- Use functions provided by `mockito-kotlin` where possible.
- Remove unneeded runner definition.
- Clarify invocation count.
- Clean up code and address lint warnings.
- Preliminary refactoring to enable constructor injection and mocking.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)