### PR TITLE
Cover code which is used to add and delete session alarms

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.alarms;
 
 import android.app.Activity;
-import android.app.AlarmManager;
 import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
@@ -29,7 +28,6 @@ import info.metadude.android.eventfahrplan.database.sqliteopenhelper.AlarmsDBOpe
 import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.base.ActionBarListActivity;
-import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 
@@ -118,8 +116,7 @@ public class AlarmList extends ActionBarListActivity {
         long startTime = cursor.getLong(cursor.getColumnIndex(AlarmsTable.Columns.TIME));
         Log.d(getClass().getSimpleName(), "deleteAlarm: session: " + sessionId);
         SchedulableAlarm alarm = new SchedulableAlarm(day, sessionId, title, startTime);
-        AlarmManager alarmManager = Contexts.getAlarmManager(this);
-        new AlarmServices(alarmManager).discardSessionAlarm(this, alarm);
+        AlarmServices.newInstance(this, appRepository).discardSessionAlarm(this, alarm);
 
         int alarmId = cursor.getInt(cursor.getColumnIndex(Columns.ID));
         db.delete(AlarmsTable.NAME, Columns.ID + " = ?", new String[]{String.valueOf(alarmId)});

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmList.java
@@ -116,7 +116,7 @@ public class AlarmList extends ActionBarListActivity {
         long startTime = cursor.getLong(cursor.getColumnIndex(AlarmsTable.Columns.TIME));
         Log.d(getClass().getSimpleName(), "deleteAlarm: session: " + sessionId);
         SchedulableAlarm alarm = new SchedulableAlarm(day, sessionId, title, startTime);
-        AlarmServices.newInstance(this, appRepository).discardSessionAlarm(this, alarm);
+        AlarmServices.newInstance(this, appRepository).discardSessionAlarm(alarm);
 
         int alarmId = cursor.getInt(cursor.getColumnIndex(Columns.ID));
         db.delete(AlarmsTable.NAME, Columns.ID + " = ?", new String[]{String.valueOf(alarmId)});

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -122,7 +122,7 @@ class AlarmServices @VisibleForTesting constructor(
         val day = session.day
         val alarm = Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText)
         val schedulableAlarm = alarm.toSchedulableAlarm()
-        scheduleSessionAlarm(context, schedulableAlarm, true)
+        scheduleSessionAlarm(schedulableAlarm, true)
         repository.updateAlarm(alarm)
         session.hasAlarm = true
         repository.notifyAlarmsChanged()
@@ -138,7 +138,7 @@ class AlarmServices @VisibleForTesting constructor(
             // Delete any previous alarms of this session.
             val alarm = alarms[0]
             val schedulableAlarm = alarm.toSchedulableAlarm()
-            discardSessionAlarm(context, schedulableAlarm)
+            discardSessionAlarm(schedulableAlarm)
             repository.deleteAlarmForSessionId(sessionId)
         }
         session.hasAlarm = false
@@ -150,7 +150,7 @@ class AlarmServices @VisibleForTesting constructor(
      * Existing alarms for the associated session are discarded if configured via [discardExisting].
      */
     @JvmOverloads
-    fun scheduleSessionAlarm(context: Context, alarm: SchedulableAlarm, discardExisting: Boolean = false) {
+    fun scheduleSessionAlarm(alarm: SchedulableAlarm, discardExisting: Boolean = false) {
         val intent = AlarmReceiver.AlarmIntentBuilder()
                 .setContext(context)
                 .setSessionId(alarm.sessionId)
@@ -170,7 +170,7 @@ class AlarmServices @VisibleForTesting constructor(
     /**
      * Discards the given [alarm] via the [AlarmManager].
      */
-    fun discardSessionAlarm(context: Context, alarm: SchedulableAlarm) {
+    fun discardSessionAlarm(alarm: SchedulableAlarm) {
         val intent = AlarmReceiver.AlarmIntentBuilder()
                 .setContext(context)
                 .setSessionId(alarm.sessionId)
@@ -185,7 +185,7 @@ class AlarmServices @VisibleForTesting constructor(
     /**
      * Discards an internal alarm used for automatic schedule updates via the [AlarmManager].
      */
-    fun discardAutoUpdateAlarm(context: Context) {
+    fun discardAutoUpdateAlarm() {
         val intent = Intent(context, AlarmReceiver::class.java)
         intent.action = AlarmReceiver.ALARM_UPDATE
         discardAlarm(context, intent)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -5,17 +5,59 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
+import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toSchedulableAlarm
+import nerd.tuxmobil.fahrplan.congress.extensions.getAlarmManager
+import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import org.threeten.bp.ZoneOffset
 
 /**
- * Alarm related actions such as scheduling and discarding alarms via the [AlarmManager][alarmManager].
+ * Alarm related actions such as adding and deleting session alarms or directly scheduling and
+ * discarding alarms via the [AlarmManager][alarmManager].
  */
-class AlarmServices @JvmOverloads constructor(
+class AlarmServices @VisibleForTesting constructor(
 
+        private val context: Context,
+        private val repository: AppRepository,
         private val alarmManager: AlarmManager,
-        private val pendingIntentDelegate: PendingIntentDelegate = PendingIntentProvider
+        private val alarmTimeValues: List<String>,
+        private val logging: Logging,
+        private val pendingIntentDelegate: PendingIntentDelegate = PendingIntentProvider,
+        private val formattingDelegate: FormattingDelegate = DateFormatterDelegate
 
 ) {
+
+    companion object {
+        private const val LOG_TAG = "AlarmServices"
+
+        /**
+         * Factory function returning an [AlarmServices] instance with sensible defaults set.
+         */
+        @JvmStatic
+        @JvmOverloads
+        fun newInstance(
+            context: Context,
+            repository: AppRepository,
+            logging: Logging = Logging.get()
+        ): AlarmServices {
+            val alarmManager = context.getAlarmManager()
+            val alarmTimesArray = context.resources.getStringArray(R.array.preference_entry_values_alarm_time)
+            return AlarmServices(
+                context = context,
+                repository = repository,
+                alarmManager = alarmManager,
+                alarmTimesArray.toList(),
+                logging = logging
+            )
+        }
+    }
 
     /**
      * Delegate to get a [PendingIntent] that will perform a broadcast.
@@ -36,6 +78,71 @@ class AlarmServices @JvmOverloads constructor(
         override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
             return PendingIntent.getBroadcast(context, DEFAULT_REQUEST_CODE, intent, NO_FLAGS)
         }
+    }
+
+    /**
+     * Delegate to get a formatted date/time.
+     */
+    interface FormattingDelegate {
+        fun getFormattedDateTimeShort(useDeviceTimeZone: Boolean, alarmTime: Long, timeZoneOffset: ZoneOffset?): String
+    }
+
+    /**
+     * [DateFormatter] delegate to handle calls to get a formatted date/time.
+     * Do not introduce any business logic here because this class is not unit tested.
+     */
+    private object DateFormatterDelegate : FormattingDelegate {
+        override fun getFormattedDateTimeShort(useDeviceTimeZone: Boolean, alarmTime: Long, timeZoneOffset: ZoneOffset?): String {
+            return DateFormatter.newInstance(useDeviceTimeZone).getFormattedDateTimeShort(alarmTime, timeZoneOffset)
+        }
+    }
+
+    /**
+     * Adds an alarm for the given [session] with the
+     * [alarm time][R.array.preference_entries_alarm_time_titles]
+     * corresponding with the given [alarmTimesIndex].
+     */
+    fun addSessionAlarm(session: Session, alarmTimesIndex: Int) {
+        logging.d(LOG_TAG, "Add alarm for session = ${session.sessionId}, alarmTimesIndex = $alarmTimesIndex.")
+        val alarmTimeStrings = ArrayList(alarmTimeValues)
+        val alarmTimes = ArrayList<Int>(alarmTimeStrings.size)
+        for (alarmTimeString in alarmTimeStrings) {
+            alarmTimes.add(alarmTimeString.toInt())
+        }
+        val sessionStartTime = session.startTimeMilliseconds
+        val alarmTimeOffset = alarmTimes[alarmTimesIndex] * Moment.MILLISECONDS_OF_ONE_MINUTE.toLong()
+        val alarmTime = sessionStartTime - alarmTimeOffset
+        val moment = Moment.ofEpochMilli(alarmTime)
+        logging.d(LOG_TAG, "Add alarm: Time = ${moment.toUtcDateTime()}, in seconds = $alarmTime.")
+        val sessionId = session.sessionId
+        val sessionTitle = session.title
+        val alarmTimeInMin = alarmTimes[alarmTimesIndex]
+        val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
+        val timeText = formattingDelegate.getFormattedDateTimeShort(useDeviceTimeZone, alarmTime, session.timeZoneOffset)
+        val day = session.day
+        val alarm = Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText)
+        val schedulableAlarm = alarm.toSchedulableAlarm()
+        scheduleSessionAlarm(context, schedulableAlarm, true)
+        repository.updateAlarm(alarm)
+        session.hasAlarm = true
+        repository.notifyAlarmsChanged()
+    }
+
+    /**
+     * Deletes the alarm for the given [session].
+     */
+    fun deleteSessionAlarm(session: Session) {
+        val sessionId = session.sessionId
+        val alarms = repository.readAlarms(sessionId)
+        if (alarms.isNotEmpty()) {
+            // Delete any previous alarms of this session.
+            val alarm = alarms[0]
+            val schedulableAlarm = alarm.toSchedulableAlarm()
+            discardSessionAlarm(context, schedulableAlarm)
+            repository.deleteAlarmForSessionId(sessionId)
+        }
+        session.hasAlarm = false
+        repository.notifyAlarmsChanged()
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -15,9 +15,8 @@ class AlarmUpdater @JvmOverloads constructor(
 ) {
 
     interface OnAlarmUpdateListener {
-        fun onCancelAlarm()
-        fun onRescheduleAlarm(interval: Long, nextFetch: Long)
-        fun onRescheduleInitialAlarm(interval: Long, nextFetch: Long)
+        fun onCancelUpdateAlarm()
+        fun onScheduleUpdateAlarm(interval: Long, nextFetch: Long)
     }
 
     companion object {
@@ -35,13 +34,9 @@ class AlarmUpdater @JvmOverloads constructor(
 
         if (shouldUseDevelopmentInterval) {
             logging.d(LOG_TAG, "Schedule refresh interval = $developmentRefreshInterval")
-            listener.onCancelAlarm()
+            listener.onCancelUpdateAlarm()
             val nextFetch = time + developmentRefreshInterval
-            if (isInitial) {
-                listener.onRescheduleInitialAlarm(developmentRefreshInterval, nextFetch)
-            } else {
-                listener.onRescheduleAlarm(developmentRefreshInterval, nextFetch)
-            }
+            listener.onScheduleUpdateAlarm(developmentRefreshInterval, nextFetch)
             return developmentRefreshInterval
         }
 
@@ -55,7 +50,7 @@ class AlarmUpdater @JvmOverloads constructor(
             }
             conference.endsBefore(time) -> {
                 logging.d(LOG_TAG, "START < END <= time")
-                listener.onCancelAlarm()
+                listener.onCancelUpdateAlarm()
                 return 0
             }
             else -> {
@@ -70,13 +65,13 @@ class AlarmUpdater @JvmOverloads constructor(
             interval = TWO_HOURS
             nextFetch = conference.firstDayStartTime
             if (!isInitial) {
-                listener.onCancelAlarm()
-                listener.onRescheduleAlarm(interval, nextFetch)
+                listener.onCancelUpdateAlarm()
+                listener.onScheduleUpdateAlarm(interval, nextFetch)
             }
         }
         if (isInitial) {
-            listener.onCancelAlarm()
-            listener.onRescheduleInitialAlarm(interval, nextFetch)
+            listener.onCancelUpdateAlarm()
+            listener.onScheduleUpdateAlarm(interval, nextFetch)
         }
         return interval
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -27,6 +27,7 @@ import io.noties.markwon.linkify.LinkifyPlugin
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.MyApp
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
@@ -36,7 +37,6 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
-import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -56,6 +56,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     private lateinit var appRepository: AppRepository
     private lateinit var sessionId: String
     private lateinit var viewModel: SessionDetailsViewModel
+    private lateinit var alarmServices: AlarmServices
     private lateinit var markwon: Markwon
     private var sidePane = false
     private var hasArguments = false
@@ -66,6 +67,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
         super.onAttach(context)
         appRepository = AppRepository
         viewModel = SessionDetailsViewModel(appRepository, sessionId, this)
+        alarmServices = AlarmServices.newInstance(context, appRepository)
         markwon = Markwon.builder(requireContext())
             .usePlugin(LinkifyPlugin.create())
             .build()
@@ -267,7 +269,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     private fun onAlarmTimesIndexPicked(alarmTimesIndex: Int) {
         val session = appRepository.readSessionBySessionId(sessionId)
         val activity = requireActivity()
-        FahrplanMisc.addAlarm(activity, appRepository, session, alarmTimesIndex)
+        alarmServices.addSessionAlarm(session, alarmTimesIndex)
         // Update the ViewModel session because refreshUI refers to its state.
         viewModel.setHasAlarm(session.hasAlarm)
         refreshUI(activity)
@@ -316,7 +318,7 @@ class SessionDetailsFragment : Fragment(), SessionDetailsViewModel.ViewActionHan
     }
 
     override fun deleteAlarm(session: Session) {
-        FahrplanMisc.deleteAlarm(requireContext(), appRepository, session)
+        alarmServices.deleteSessionAlarm(session)
     }
 
     override fun closeDetails() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.java
@@ -53,6 +53,7 @@ import kotlin.Unit;
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.MyApp;
 import nerd.tuxmobil.fahrplan.congress.R;
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices;
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment;
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing;
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys;
@@ -125,6 +126,8 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
 
     private boolean preserveVerticalScrollPosition = false;
 
+    private AlarmServices alarmServices;
+
     private final OnSessionsChangeListener onSessionsChangeListener = new OnSessionsChangeListener() {
         @Override
         public void onAlarmsChanged() {
@@ -147,6 +150,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
         appRepository = AppRepository.INSTANCE;
+        alarmServices = AlarmServices.newInstance(context, appRepository);
     }
 
     @MainThread
@@ -657,7 +661,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
             Log.e(getClass().getSimpleName(), "onAlarmTimesIndexPicked: session: null. alarmTimesIndex: " + alarmTimesIndex);
             throw new NullPointerException("Session is null.");
         }
-        FahrplanMisc.addAlarm(requireContext(), appRepository, lastSelectedSession, alarmTimesIndex);
+        alarmServices.addSessionAlarm(lastSelectedSession, alarmTimesIndex);
         setBell(lastSelectedSession);
         updateMenuItems();
     }
@@ -683,7 +687,7 @@ public class FahrplanFragment extends Fragment implements SessionViewEventsHandl
                 showAlarmTimePicker();
                 break;
             case CONTEXT_MENU_ITEM_ID_DELETE_ALARM:
-                FahrplanMisc.deleteAlarm(context, appRepository, session);
+                alarmServices.deleteSessionAlarm(session);
                 setBell(session);
                 updateMenuItems();
                 break;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -26,10 +26,10 @@ import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
-import nerd.tuxmobil.fahrplan.congress.extensions.getAlarmManager
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -71,8 +71,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 FahrplanMisc.setUpdateAlarm(activity, true)
             } else {
                 with(requireActivity()) {
-                    val alarmManager = getAlarmManager()
-                    AlarmServices(alarmManager).discardAutoUpdateAlarm(this)
+                    AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm(this)
                 }
             }
             true

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -71,7 +71,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 FahrplanMisc.setUpdateAlarm(activity, true)
             } else {
                 with(requireActivity()) {
-                    AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm(this)
+                    AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm()
                 }
             }
             true

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.system;
 
-import android.app.AlarmManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -15,7 +14,6 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmReceiver;
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices;
 import nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService;
 import nerd.tuxmobil.fahrplan.congress.dataconverters.AlarmExtensions;
-import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.Alarm;
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
@@ -44,8 +42,7 @@ public final class OnBootReceiver extends BroadcastReceiver {
 
         AppRepository appRepository = AppRepository.INSTANCE;
         List<Alarm> alarms = appRepository.readAlarms();
-        AlarmManager alarmManager = Contexts.getAlarmManager(context);
-        AlarmServices alarmServices = new AlarmServices(alarmManager);
+        AlarmServices alarmServices = AlarmServices.newInstance(context, appRepository);
         for (Alarm alarm : alarms) {
             Moment storedAlarmTime = Moment.ofEpochMilli(alarm.getStartTime());
             if (nowMoment.isBefore(storedAlarmTime)) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.java
@@ -48,7 +48,7 @@ public final class OnBootReceiver extends BroadcastReceiver {
             if (nowMoment.isBefore(storedAlarmTime)) {
                 Log.d(getClass().getSimpleName(), "Scheduling alarm for session: " + alarm.getSessionId() + ", " + alarm.getSessionTitle());
                 SchedulableAlarm schedulableAlarm = AlarmExtensions.toSchedulableAlarm(alarm);
-                alarmServices.scheduleSessionAlarm(context, schedulableAlarm);
+                alarmServices.scheduleSessionAlarm(schedulableAlarm);
             } else {
                 MyApp.LogDebug(LOG_TAG, "Deleting alarm from database: " + alarm);
                 appRepository.deleteAlarmForAlarmId(alarm.getId());

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -114,26 +114,19 @@ public class FahrplanMisc {
                 new AlarmUpdater.OnAlarmUpdateListener() {
 
                     @Override
-                    public void onCancelAlarm() {
-                        MyApp.LogDebug(LOG_TAG, "cancel alarm post congress");
+                    public void onCancelUpdateAlarm() {
+                        MyApp.LogDebug(LOG_TAG, "Canceling alarm.");
                         alarmManager.cancel(pendingintent);
                     }
 
                     @Override
-                    public void onRescheduleAlarm(long interval, long nextFetch) {
-                        MyApp.LogDebug(LOG_TAG, "update alarm to interval " + interval +
+                    public void onScheduleUpdateAlarm(long interval, long nextFetch) {
+                        MyApp.LogDebug(LOG_TAG, "Scheduling update alarm to interval " + interval +
                                 ", next in ~" + (nextFetch - now));
                         alarmManager.setInexactRepeating(
                                 AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingintent);
                     }
 
-                    @Override
-                    public void onRescheduleInitialAlarm(long interval, long nextFetch) {
-                        MyApp.LogDebug(LOG_TAG, "set initial alarm to interval " + interval +
-                                ", next in ~" + (nextFetch - now));
-                        alarmManager.setInexactRepeating(
-                                AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingintent);
-                    }
                 });
         return alarmUpdater.calculateInterval(now, initial);
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -126,7 +126,7 @@ class AlarmServicesTest {
             }
         }
         val alarmServices = createAlarmServices(pendingIntentDelegate)
-        alarmServices.scheduleSessionAlarm(mockContext, alarm, true)
+        alarmServices.scheduleSessionAlarm(alarm, true)
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
         verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
     }
@@ -142,7 +142,7 @@ class AlarmServicesTest {
             }
         }
         val alarmServices = createAlarmServices(pendingIntentDelegate)
-        alarmServices.scheduleSessionAlarm(mockContext, alarm, false)
+        alarmServices.scheduleSessionAlarm(alarm, false)
         verifyInvokedNever(alarmManager).cancel(pendingIntent)
         verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
     }
@@ -158,7 +158,7 @@ class AlarmServicesTest {
             }
         }
         val alarmServices = createAlarmServices(pendingIntentDelegate)
-        alarmServices.discardSessionAlarm(mockContext, alarm)
+        alarmServices.discardSessionAlarm(alarm)
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
 
@@ -175,7 +175,7 @@ class AlarmServicesTest {
             }
         }
         val alarmServices = createAlarmServices(pendingIntentDelegate)
-        alarmServices.discardAutoUpdateAlarm(mockContext)
+        alarmServices.discardAutoUpdateAlarm()
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -4,34 +4,128 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.content.res.Resources
+import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
+import nerd.tuxmobil.fahrplan.congress.NoLogging
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices.PendingIntentDelegate
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import org.junit.Assert.fail
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.threeten.bp.ZoneOffset
 
 class AlarmServicesTest {
 
     private var alarmManager = mock<AlarmManager>()
     private var mockContext = mock<Context>()
-    private var pendingIntent = mock<PendingIntent>()
+    private var repository = mock<AppRepository>()
+    private val alarmTimesValues = listOf("0", "10", "60")
     private val alarm = SchedulableAlarm(3, "1001", "Welcome", 700)
 
     @Test
+    fun `newInstance returns a new preconfigured instance of the AlarmServices class`() {
+        val resources = mock<Resources> {
+            on { getStringArray(any()) } doReturn arrayOf("not relevant")
+        }
+        val context = mock<Context> {
+            on { getResources() } doReturn resources
+            on { getSystemService<AlarmManager>() } doReturn mock()
+        }
+        assertThat(AlarmServices.newInstance(context, repository, NoLogging)).isInstanceOf(AlarmServices::class.java)
+    }
+
+    @Test
+    fun `addSessionAlarm schedules a session alarm`() {
+        val formattingDelegate = mock<FormattingDelegate>()
+        val alarmServices = createAlarmServices(formattingDelegate = formattingDelegate)
+        whenever(repository.readUseDeviceTimeZoneEnabled()) doReturn true
+        whenever(formattingDelegate.getFormattedDateTimeShort(any(), any(), any())) doReturn "not relevant"
+        val session = Session("S1").apply {
+            day = 1
+            hasAlarm = false
+            title = "Title"
+            dateUTC = 1536332400000L // 2018-09-07T17:00:00+02:00
+            timeZoneOffset = ZoneOffset.of("+02:00")
+        }
+
+        alarmServices.addSessionAlarm(session, alarmTimesValues.indexOf("60"))
+        // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
+        assertThat(session.hasAlarm).isTrue()
+        verifyInvokedOnce(repository).notifyAlarmsChanged()
+    }
+
+    @Test
+    fun `addSessionAlarm throws exception if alarm time index exceeds `() {
+        val pendingIntentDelegate = mock<PendingIntentDelegate>()
+        val formattingDelegate = mock<FormattingDelegate>()
+        val alarmServices = createAlarmServices(pendingIntentDelegate = pendingIntentDelegate, formattingDelegate = formattingDelegate)
+        val session = Session("S2").apply { dateUTC = 1536332400000L } // 2018-09-07T17:00:00+02:00
+
+        try {
+            alarmServices.addSessionAlarm(session, alarmTimesValues.size) // Out of bounds!
+            fail("Expect an IndexOutOfBoundsException to be thrown.")
+        } catch (e: IndexOutOfBoundsException) {
+            assertThat(e.message).isEqualTo("Index 3 out of bounds for length 3")
+        }
+        verifyNoInteractions(pendingIntentDelegate)
+        verifyNoInteractions(formattingDelegate)
+    }
+
+    @Test
+    fun `deleteSessionAlarm discards a session alarm when the alarms was scheduled`() {
+        val formattingDelegate = mock<FormattingDelegate>()
+        val alarmServices = createAlarmServices(formattingDelegate = formattingDelegate)
+        val alarm = Alarm(10, 2, 0, "S3", "Title", 1536332400000L, "Lorem ipsum")
+        whenever(repository.readAlarms(any())) doReturn listOf(alarm)
+        val session = Session("S3").apply { hasAlarm = true }
+
+        alarmServices.deleteSessionAlarm(session)
+        // AlarmServices invokes discardSessionAlarm() which is tested separately.
+        verifyNoInteractions(formattingDelegate)
+        verifyInvokedOnce(repository).deleteAlarmForSessionId("S3")
+        assertThat(session.hasAlarm).isFalse()
+        verifyInvokedOnce(repository).notifyAlarmsChanged()
+    }
+
+    @Test
+    fun `deleteSessionAlarm resets the session alarm flag when no alarms was scheduled`() {
+        val pendingIntentDelegate = mock<PendingIntentDelegate>()
+        val formattingDelegate = mock<FormattingDelegate>()
+        val alarmServices = createAlarmServices(pendingIntentDelegate = pendingIntentDelegate, formattingDelegate = formattingDelegate)
+        whenever(repository.readAlarms(any())) doReturn emptyList()
+        val session = Session("S4").apply { hasAlarm = true }
+
+        alarmServices.deleteSessionAlarm(session)
+        verifyNoInteractions(pendingIntentDelegate)
+        verifyNoInteractions(formattingDelegate)
+        assertThat(session.hasAlarm).isFalse()
+        verifyInvokedOnce(repository).notifyAlarmsChanged()
+    }
+
+    @Test
     fun `scheduleSessionAlarm invokes cancel then set when discardExisting is true`() {
+        val pendingIntent = mock<PendingIntent>()
         val pendingIntentDelegate = object : PendingIntentDelegate {
             override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
                 assertThat(context).isEqualTo(mockContext)
                 assertIntentExtras(intent, AlarmReceiver.ALARM_SESSION)
                 return pendingIntent
             }
-
         }
-        val alarmServices = AlarmServices(alarmManager, pendingIntentDelegate)
+        val alarmServices = createAlarmServices(pendingIntentDelegate)
         alarmServices.scheduleSessionAlarm(mockContext, alarm, true)
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
         verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
@@ -39,15 +133,15 @@ class AlarmServicesTest {
 
     @Test
     fun `scheduleSessionAlarm only invokes set when discardExisting is false`() {
+        val pendingIntent = mock<PendingIntent>()
         val pendingIntentDelegate = object : PendingIntentDelegate {
             override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
                 assertThat(context).isEqualTo(mockContext)
                 assertIntentExtras(intent, AlarmReceiver.ALARM_SESSION)
                 return pendingIntent
             }
-
         }
-        val alarmServices = AlarmServices(alarmManager, pendingIntentDelegate)
+        val alarmServices = createAlarmServices(pendingIntentDelegate)
         alarmServices.scheduleSessionAlarm(mockContext, alarm, false)
         verifyInvokedNever(alarmManager).cancel(pendingIntent)
         verifyInvokedOnce(alarmManager).set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
@@ -55,6 +149,7 @@ class AlarmServicesTest {
 
     @Test
     fun `discardSessionAlarm invokes cancel`() {
+        val pendingIntent = mock<PendingIntent>()
         val pendingIntentDelegate = object : PendingIntentDelegate {
             override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
                 assertThat(context).isEqualTo(mockContext)
@@ -62,7 +157,7 @@ class AlarmServicesTest {
                 return pendingIntent
             }
         }
-        val alarmServices = AlarmServices(alarmManager, pendingIntentDelegate)
+        val alarmServices = createAlarmServices(pendingIntentDelegate)
         alarmServices.discardSessionAlarm(mockContext, alarm)
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
@@ -70,6 +165,7 @@ class AlarmServicesTest {
 
     @Test
     fun `discardAutoUpdateAlarm invokes cancel`() {
+        val pendingIntent = mock<PendingIntent>()
         val pendingIntentDelegate = object : PendingIntentDelegate {
             override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
                 assertThat(context).isEqualTo(mockContext)
@@ -78,7 +174,7 @@ class AlarmServicesTest {
                 return pendingIntent
             }
         }
-        val alarmServices = AlarmServices(alarmManager, pendingIntentDelegate)
+        val alarmServices = createAlarmServices(pendingIntentDelegate)
         alarmServices.discardAutoUpdateAlarm(mockContext)
         verifyInvokedOnce(alarmManager).cancel(pendingIntent)
     }
@@ -93,5 +189,18 @@ class AlarmServicesTest {
         assertThat(intent.action).isEqualTo(action)
         assertThat(intent.data).isEqualTo("alarm://${alarm.sessionId}".toUri())
     }
+
+    private fun createAlarmServices(
+        pendingIntentDelegate: PendingIntentDelegate = mock(),
+        formattingDelegate: FormattingDelegate = mock()
+    ) = AlarmServices(
+        context = mockContext,
+        repository = repository,
+        alarmManager = alarmManager,
+        alarmTimeValues = alarmTimesValues,
+        logging = NoLogging,
+        pendingIntentDelegate = pendingIntentDelegate,
+        formattingDelegate = formattingDelegate
+    )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -61,9 +61,8 @@ class AlarmUpdaterTest {
         whenever(sharedPreferencesRepository.getScheduleRefreshInterval()).doReturn(3000)
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(3000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
-        verifyInvokedOnce(mockListener).onRescheduleAlarm(3000L, LAST_DAY_END_TIME + 3000L)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME + 3000L)
     }
 
     @Test
@@ -71,9 +70,8 @@ class AlarmUpdaterTest {
         whenever(sharedPreferencesRepository.getScheduleRefreshInterval()).doReturn(3000)
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, true)
         assertThat(interval).isEqualTo(3000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(3000L, LAST_DAY_END_TIME + 3000L)
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME + 3000L)
     }
 
     // Start <= Time < End
@@ -83,9 +81,8 @@ class AlarmUpdaterTest {
         // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(1451212200000L, false)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedNever(mockListener).onCancelAlarm()
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onCancelUpdateAlarm()
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
     }
 
     @Test
@@ -93,9 +90,8 @@ class AlarmUpdaterTest {
         // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(1451212200000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451212200000L + 7200000L)
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451212200000L + 7200000L)
     }
 
     // Time == End
@@ -105,9 +101,8 @@ class AlarmUpdaterTest {
         // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, false)
         assertThat(interval).isEqualTo(0)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
     }
 
     @Test
@@ -115,9 +110,8 @@ class AlarmUpdaterTest {
         // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, true)
         assertThat(interval).isEqualTo(0)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
     }
 
     // Time < Start, diff == 1 second
@@ -127,9 +121,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, false)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
     }
 
     @Test
@@ -137,9 +130,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
     }
 
     // Time < Start, diff == 1 day
@@ -149,9 +141,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, false)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleAlarm(7200000L, 1451170800000L)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
     }
 
     @Test
@@ -159,9 +150,8 @@ class AlarmUpdaterTest {
         // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, true)
         assertThat(interval).isEqualTo(7200000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(7200000L, 1451170800000L)
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
     }
 
     // Time < Start, diff > 1 day
@@ -172,9 +162,8 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(1451084399000L, false)
         assertThat(interval).isEqualTo(86400000L)
         // TODO Is this behavior intended?
-        verifyInvokedNever(mockListener).onCancelAlarm()
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
-        verifyInvokedNever(mockListener).onRescheduleInitialAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onCancelUpdateAlarm()
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
     }
 
     @Test
@@ -182,9 +171,8 @@ class AlarmUpdaterTest {
         // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(1451084399000L, true)
         assertThat(interval).isEqualTo(86400000L)
-        verifyInvokedOnce(mockListener).onCancelAlarm()
-        verifyInvokedOnce(mockListener).onRescheduleInitialAlarm(86400000L, 1451084399000L + 86400000L)
-        verifyInvokedNever(mockListener).onRescheduleAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(86400000L, 1451084399000L + 86400000L)
     }
 
 }


### PR DESCRIPTION
# Description
- Up to now `FahrplanMisc` provides static functions to add and delete session alarms.
- These function are **not unit tested** and hinder to test calling function in other classes.
- This branch aims at refactoring this code into a testable and mockable structure.
- Therefore, the relevant code from `FahrplanMisc` is moved into the existing `AlarmServices` class which encapsulates other functions targeting the `AlarmManager` class.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)