### PR TITLE
Fix IllegalArgumentException when rotating details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -119,9 +119,10 @@ class SessionDetailsFragment : Fragment() {
 
     override fun setArguments(args: Bundle?) {
         super.setArguments(args)
-        requireNotNull(args)
-        sidePane = args.getBoolean(BundleKeys.SIDEPANE, false)
-        hasArguments = true
+        if (args != null) {
+            sidePane = args.getBoolean(BundleKeys.SIDEPANE, false)
+            hasArguments = true
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
# Description
+ Present since d6583a5dd41c1ab01cb82979b18e28a5d1e52546 because `SessionDetailsFragment#replace` no longer passes arguments, see https://github.com/EventFahrplan/EventFahrplan/commit/d6583a5dd41c1ab01cb82979b18e28a5d1e52546#diff-2c858d8f76c580864264cfa11b2d681e9dfa2a7fca199e1348e475e83a15be3eL26-R25

# How to reproduce
1. Open details screen on a smartphone
2. Rotate the device

# Observed behavior
- App crashes

## Stacktrace
``` java
E  java.lang.RuntimeException: Unable to start activity ComponentInfo{
    info.metadude.android.congress.schedule.debug/nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity}: 
    java.lang.IllegalArgumentException: Required value was null.

E      at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3449)
E      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
E      at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:5456)
...
E  Caused by: java.lang.IllegalArgumentException: Required value was null.
E      at nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment.setArguments(SessionDetailsFragment.kt:122)
E      at androidx.fragment.app.FragmentStateManager.<init>(FragmentStateManager.java:89)
E      at androidx.fragment.app.FragmentManager.restoreSaveState(FragmentManager.java:2728)
E      at androidx.fragment.app.FragmentController.restoreSaveState(FragmentController.java:198)
E      at androidx.fragment.app.FragmentActivity$2.onContextAvailable(FragmentActivity.java:149)
E      at androidx.activity.contextaware.ContextAwareHelper.dispatchOnContextAvailable(ContextAwareHelper.java:99)
E      at androidx.activity.ComponentActivity.onCreate(ComponentActivity.java:322)
E      at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:273)
E      at nerd.tuxmobil.fahrplan.congress.base.BaseActivity.onCreate(BaseActivity.java:39)
E      at nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity.onCreate(SessionDetailsActivity.kt:39)
...
```

# Expected behavior
- Details screen rotates, app does not crash.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)
- :heavy_check_mark: Nexus 9 emulator (tablet), Android 5.1 (API 22)