### PR TITLE
Let AppRepository be the single source of truth for schedule screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.java
@@ -12,18 +12,12 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging;
-import nerd.tuxmobil.fahrplan.congress.models.DateInfos;
-import nerd.tuxmobil.fahrplan.congress.models.Meta;
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame;
 
 public class MyApp extends Application {
 
     public static final boolean DEBUG = false;
-
-    public static Meta meta;
-
-    public static DateInfos dateInfos = null;
 
     private static final long FIRST_DAY_START = getMilliseconds("Europe/Paris",
             BuildConfig.SCHEDULE_FIRST_DAY_START_YEAR,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -72,8 +72,6 @@ public final class AlarmReceiver extends BroadcastReceiver {
 
             appRepository.deleteAlarmForSessionId(sessionId);
 
-            appRepository.notifyAlarmsChanged();
-
         } else if (ALARM_DISMISSED.equals(intent.getAction())) {
             onSessionAlarmNotificationDismissed(intent);
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -125,7 +125,6 @@ class AlarmServices @VisibleForTesting constructor(
         scheduleSessionAlarm(schedulableAlarm, true)
         repository.updateAlarm(alarm)
         session.hasAlarm = true
-        repository.notifyAlarmsChanged()
     }
 
     /**
@@ -142,7 +141,6 @@ class AlarmServices @VisibleForTesting constructor(
             repository.deleteAlarmForSessionId(sessionId)
         }
         session.hasAlarm = false
-        repository.notifyAlarmsChanged()
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -93,6 +93,7 @@ public class UpdateService extends SafeJobIntentService {
             MyApp.task_running = TASKS.FETCH;
             String url = appRepository.readScheduleUrl();
             appRepository.loadSchedule(url,
+                    false,
                     fetchScheduleResult -> {
                         onGotResponse(fetchScheduleResult);
                         return Unit.INSTANCE;
@@ -126,6 +127,7 @@ public class UpdateService extends SafeJobIntentService {
 
     @Override
     public void onDestroy() {
+        // TODO Wrap onHandleWork into blocking CountDownLatch to prevent canceling all AppRepository jobs
         appRepository.cancelLoading();
         super.onDestroy();
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.java
@@ -1,7 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.base;
 
-import android.os.Bundle;
-import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 
@@ -15,15 +13,9 @@ import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
-import kotlin.Unit;
-import nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService;
-import nerd.tuxmobil.fahrplan.congress.net.ConnectivityObserver;
-import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper;
 
 public abstract class BaseActivity extends AppCompatActivity {
-
-    private ConnectivityObserver connectivityObserver;
 
     public BaseActivity() {
         super();
@@ -34,22 +26,6 @@ public abstract class BaseActivity extends AppCompatActivity {
         super(contentLayoutId);
     }
 
-    @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        connectivityObserver = new ConnectivityObserver(this, () -> {
-            Log.d(getClass().getSimpleName(), "Network is available.");
-            startUpdateService();
-            return Unit.INSTANCE;
-        });
-        connectivityObserver.start();
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        connectivityObserver.stop();
-    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -60,13 +36,6 @@ public abstract class BaseActivity extends AppCompatActivity {
                 return ActivityHelper.navigateUp(this);
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private void startUpdateService() {
-        boolean isAutoUpdateEnabled = AppRepository.INSTANCE.readAutoUpdateEnabled();
-        if (isAutoUpdateEnabled) {
-            UpdateService.start(this);
-        }
     }
 
     protected void addFragment(@IdRes int containerViewId,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatistic.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatistic.kt
@@ -6,10 +6,11 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 /**
  * Statistic about session changes (canceled, changed, new).
  */
-class ChangeStatistic private constructor(
+@Suppress("DataClassPrivateConstructor")
+data class ChangeStatistic private constructor(
 
-        val sessions: List<Session>,
-        val logging: Logging
+        private val sessions: List<Session>,
+        private val logging: Logging
 
 ) {
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -163,7 +163,6 @@ class SessionDetailsViewModel(
                 highlight = true // Required: Update property because updateHighlight refers to its value!
             }
             repository.updateHighlight(favoredSession)
-            repository.notifyHighlightsChanged() // TODO Remove when FahrplanFragment uses Flow
         }
     }
 
@@ -173,7 +172,6 @@ class SessionDetailsViewModel(
                 highlight = false // Required: Update property because updateHighlight refers to its value!
             }
             repository.updateHighlight(unfavoredSession)
-            repository.notifyHighlightsChanged() // TODO Remove when FahrplanFragment uses Flow
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -39,14 +39,12 @@ class StarredListViewModel(
     fun delete(session: Session) {
         viewModelScope.launch(executionContext.database) {
             repository.updateHighlight(session)
-            repository.notifyHighlightsChanged() // TODO Remove when FahrplanFragment uses Flow
         }
     }
 
     fun deleteAll() {
         viewModelScope.launch(executionContext.database) {
             repository.deleteAllHighlights()
-            repository.notifyHighlightsChanged() // TODO Remove when FahrplanFragment uses Flow
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ErrorMessage.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ErrorMessage.kt
@@ -17,6 +17,7 @@ sealed interface ErrorMessage {
     fun show(context: Context, shouldShowLong: Boolean) {
         when (this) {
             is TitledMessage -> {
+                // TODO Replace with DialogFragment to survive orientation change
                 AlertDialog.Builder(context)
                     .setTitle(title)
                     .setMessage(message)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -687,6 +687,7 @@ object AppRepository {
     fun readAlternativeHighlightingEnabled() =
             sharedPreferencesRepository.isAlternativeHighlightingEnabled()
 
+    @WorkerThread
     fun readAutoUpdateEnabled() =
             sharedPreferencesRepository.isAutoUpdateEnabled()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -272,7 +272,7 @@ object AppRepository {
         val url = readEngelsystemShiftsUrl()
         if (url.isEmpty()) {
             logging.d(javaClass.simpleName, "Engelsystem shifts URL is empty.")
-            // TODO Cancel or remote shifts from database?
+            // TODO Cancel or remove shifts from database?
             return
         }
         val requestIdentifier = "loadShifts"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/LoadScheduleState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/LoadScheduleState.kt
@@ -1,0 +1,32 @@
+package nerd.tuxmobil.fahrplan.congress.repositories
+
+import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
+import nerd.tuxmobil.fahrplan.congress.net.ParseResult
+
+sealed interface LoadScheduleState {
+
+    object InitialFetching : LoadScheduleState
+
+    object Fetching : LoadScheduleState
+
+    object FetchSuccess : LoadScheduleState
+
+    data class FetchFailure(
+        val httpStatus: HttpStatus,
+        val hostName: String,
+        val exceptionMessage: String,
+        val isUserRequest: Boolean
+    ) : LoadScheduleState
+
+    object InitialParsing : LoadScheduleState
+
+    object Parsing : LoadScheduleState
+
+    object ParseSuccess : LoadScheduleState
+
+    // TODO Merge ParseResult innards into ParseFailure class
+    data class ParseFailure(
+        val parseResult: ParseResult
+    ) : LoadScheduleState
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/OnSessionsChangeListener.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/OnSessionsChangeListener.kt
@@ -1,7 +1,0 @@
-package nerd.tuxmobil.fahrplan.congress.repositories
-
-@Deprecated("Replace this with a push-based update mechanism")
-interface OnSessionsChangeListener {
-    fun onAlarmsChanged()
-    fun onHighlightsChanged()
-}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -254,6 +254,23 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         super.onPause()
     }
 
+    /**
+     * Updates the session data in the schedule view.
+     *
+     * The [forceReload] parameter is used to avoid unneeded data loading (see [loadSessions]) and
+     * unneeded rendering of the RecyclerView columns for each room (see [addRoomColumns]).
+     *
+     * Use cases of [forceReload]:
+     * - false: a schedule is present and re-fetching it is in progress (see [onResume])
+     * - true: a [sessionId] is present in session alarm notification Intent (see [onResume])
+     * - true: user chooses another day (see [chooseDay])
+     * - true: parsing finished successfully AND
+     *     - no schedule is present OR
+     *     - the schedule version changed OR
+     *     - Engelsystem shifts changed
+     *   (see [onParseDone])
+     * - false: when parsing finished successfully (see [onParseDone])
+     */
     private fun viewDay(forceReload: Boolean) {
         Log.d(LOG_TAG, "viewDay($forceReload)")
         val layoutRoot = requireView()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -274,7 +274,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     private fun viewDay(forceReload: Boolean) {
         Log.d(LOG_TAG, "viewDay($forceReload)")
         val layoutRoot = requireView()
-        val boxHeight = getNormalizedBoxHeight(displayDensityScale)
+        val boxHeight = getNormalizedBoxHeight()
         val horizontalScroller = layoutRoot.requireViewByIdCompat<HorizontalSnapScrollView>(R.id.horizScroller)
         horizontalScroller.scrollTo(0, 0)
         loadSessions(appRepository, dayIndex, forceReload)
@@ -347,7 +347,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val columnsLayout = horizontalScroller.getChildAt(0) as LinearLayout
         columnsLayout.removeAllViews()
         adapterByRoomIndex.clear()
-        val boxHeight = getNormalizedBoxHeight(displayDensityScale)
+        val boxHeight = getNormalizedBoxHeight()
         val layoutCalculator = LayoutCalculator(boxHeight)
         val context = horizontalScroller.context
         val roomDataList = scheduleData.roomDataList
@@ -450,7 +450,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     }
 
     private fun scrollTo(session: Session) {
-        val height = getNormalizedBoxHeight(displayDensityScale)
+        val height = getNormalizedBoxHeight()
         val pos = scrollAmountCalculator!!.calculateScrollAmount(conference!!, session, height)
         MyApp.LogDebug(LOG_TAG, "Position is $pos")
         val layoutRootView = requireView()
@@ -476,7 +476,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     }
 
     private fun fillTimes() {
-        val normalizedBoxHeight = getNormalizedBoxHeight(displayDensityScale)
+        val normalizedBoxHeight = getNormalizedBoxHeight()
         val earliestSession = appRepository.loadEarliestSession()
         val firstDayStartDay = earliestSession.startTimeMoment.monthDay
         val useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled()
@@ -506,10 +506,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             return (factor * displayDensityScale).toInt()
         }
 
-    private fun getNormalizedBoxHeight(scale: Float): Int {
+    private fun getNormalizedBoxHeight(): Int {
         val orientationText = if (requireContext().isLandscape()) "landscape" else "other orientation"
         MyApp.LogDebug(LOG_TAG, orientationText)
-        return (resources.getInteger(R.integer.box_height) * scale).toInt()
+        return (resources.getInteger(R.integer.box_height) * displayDensityScale).toInt()
     }
 
     private fun loadSessions(appRepository: AppRepository, dayIndex: Int, forceReload: Boolean) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -53,6 +53,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.net.ConnectivityObserver
 import nerd.tuxmobil.fahrplan.congress.net.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
@@ -95,6 +96,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     private lateinit var inflater: LayoutInflater
     private lateinit var sessionViewDrawer: SessionViewDrawer
     private lateinit var errorMessageFactory: ErrorMessage.Factory
+    private lateinit var connectivityObserver: ConnectivityObserver
     private lateinit var roomTitleTypeFace: Typeface
     private lateinit var contextMenuView: View
     private lateinit var viewModel: FahrplanViewModel
@@ -129,6 +131,11 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         roomTitleTypeFace = TypefaceFactory.getNewInstance(context).getTypeface(Font.Roboto.Light)
         sessionViewDrawer = SessionViewDrawer(context, { sessionPadding })
         errorMessageFactory = ErrorMessage.Factory(context)
+        connectivityObserver = ConnectivityObserver(context, onConnectionAvailable = {
+            Log.d(LOG_TAG, "Network is available.")
+            viewModel.requestScheduleAutoUpdate()
+        })
+        connectivityObserver.start()
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -202,6 +209,11 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             intent.removeExtra(BUNDLE_KEY_SESSION_ALARM_SESSION_ID) // jump to given sessionId only once
         }
         Logging.get().d(LOG_TAG, "onResume")
+    }
+
+    override fun onDestroy() {
+        connectivityObserver.stop()
+        super.onDestroy()
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -33,6 +33,7 @@ import androidx.core.widget.NestedScrollView
 import androidx.core.widget.NestedScrollView.OnScrollChangeListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutParams
@@ -40,7 +41,6 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.MyApp
-import nerd.tuxmobil.fahrplan.congress.MyApp.TASKS
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
@@ -50,22 +50,16 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys.BUNDLE_KEY_SESSION_AL
 import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
 import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
+import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.net.ErrorMessage
-import nerd.tuxmobil.fahrplan.congress.net.ParseResult
-import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import nerd.tuxmobil.fahrplan.congress.repositories.OnSessionsChangeListener
-import nerd.tuxmobil.fahrplan.congress.repositories.SessionsTransformer
-import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
-import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
-import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 import org.ligi.tracedroid.logging.Log
-import kotlin.collections.set
 
 class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
@@ -96,50 +90,30 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         const val FIFTEEN_MINUTES = 15
         const val BOX_HEIGHT_MULTIPLIER = 3
 
-        private val sessionsTransformer = SessionsTransformer.createSessionsTransformer()
-
     }
 
-    private lateinit var appRepository: AppRepository
     private lateinit var inflater: LayoutInflater
-    private lateinit var alarmServices: AlarmServices
     private lateinit var sessionViewDrawer: SessionViewDrawer
-    private lateinit var navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator
     private lateinit var errorMessageFactory: ErrorMessage.Factory
     private lateinit var roomTitleTypeFace: Typeface
     private lateinit var contextMenuView: View
-    private var conference: Conference? = null
-    private var scrollAmountCalculator: ScrollAmountCalculator? = null
+    private lateinit var viewModel: FahrplanViewModel
+
     private var onSessionClickListener: OnSessionClickListener? = null
-
-    private var dayIndex = 1 // XML values start with 1
-    private var sessionId: String? = null
     private var lastSelectedSession: Session? = null
-    private var scheduleData: ScheduleData? = null
-
     private var displayDensityScale = 0f
-    private val adapterByRoomIndex = mutableMapOf</* roomIndex */ Int, SessionViewColumnAdapter>()
-    private var preserveVerticalScrollPosition = false
-
-    private val onSessionsChangeListener: OnSessionsChangeListener = object : OnSessionsChangeListener {
-        override fun onAlarmsChanged() {
-            requireActivity().runOnUiThread { reloadAlarms() }
-        }
-
-        override fun onHighlightsChanged() {
-            requireActivity().runOnUiThread { reloadHighlights() }
-        }
-    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        appRepository = AppRepository
-        alarmServices = AlarmServices.newInstance(context, appRepository)
-        navigationMenuEntriesGenerator = NavigationMenuEntriesGenerator(dayString = getString(R.string.day), todayString = getString(R.string.today))
+        val appRepository = AppRepository
+        val alarmServices = AlarmServices.newInstance(context, appRepository)
+        val menuEntriesGenerator = NavigationMenuEntriesGenerator(dayString = getString(R.string.day), todayString = getString(R.string.today))
+        val viewModelFactory = FahrplanViewModelFactory(appRepository, alarmServices, menuEntriesGenerator)
+        viewModel = ViewModelProvider(this, viewModelFactory).get(FahrplanViewModel::class.java)
         onSessionClickListener = if (context is OnSessionClickListener) {
             context
         } else {
-            throw IllegalStateException("$context must implement OnSessionClickListener")
+            error("$context must implement OnSessionClickListener")
         }
     }
 
@@ -161,13 +135,14 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val layoutRootView = inflater.inflate(R.layout.schedule, container, false)
         val verticalScrollView = layoutRootView.requireViewByIdCompat<NestedScrollView>(R.id.verticalScrollView)
         verticalScrollView.setOnScrollChangeListener(
-            OnScrollChangeListener { _, _, _, _, _ -> preserveVerticalScrollPosition = true }
+            OnScrollChangeListener { _, _, _, _, _ -> viewModel.preserveVerticalScrollPosition = true }
         )
         return layoutRootView
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        observeViewModel()
         displayDensityScale = resources.displayMetrics.density
 
         val roomScroller = view.requireViewByIdCompat<HorizontalScrollView>(R.id.roomScroller)
@@ -175,23 +150,38 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         snapScroller.setChildScroller(roomScroller)
         roomScroller.setOnTouchListener { _, _ -> true }
 
-        dayIndex = appRepository.readDisplayDayIndex()
         inflater = view.context.getLayoutInflater()
-
-        val intent = requireActivity().intent
-        sessionId = intent.getStringExtra(BUNDLE_KEY_SESSION_ALARM_SESSION_ID)
-        if (sessionId != null) {
-            MyApp.LogDebug(LOG_TAG, "Open with sessionId '$sessionId'.")
-            dayIndex = intent.getIntExtra(BUNDLE_KEY_SESSION_ALARM_DAY_INDEX, dayIndex)
-            MyApp.LogDebug(LOG_TAG, "dayIndex = $dayIndex")
-        }
-        if (MyApp.meta.numDays > 1) {
-            buildNavigationMenu()
-        }
     }
 
-    private fun saveCurrentDay(day: Int) {
-        appRepository.updateDisplayDayIndex(day)
+    private fun observeViewModel() {
+        viewModel.fahrplanParameter.observe(viewLifecycleOwner) { (scheduleData, numDays, dayIndex, menuEntries) ->
+            menuEntries?.let { buildNavigationMenu(it, numDays) }
+            viewModel.fillTimes(Moment.now(), getNormalizedBoxHeight())
+            viewDay(scheduleData, numDays, dayIndex)
+        }
+        viewModel.fahrplanEmptyParameter.observe(viewLifecycleOwner) { (scheduleVersion) ->
+            val errorMessage = errorMessageFactory.getMessageForEmptySchedule(scheduleVersion)
+            errorMessage.show(requireContext(), shouldShowLong = false)
+        }
+        viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
+            SessionSharer.shareSimple(requireContext(), formattedSession)
+        }
+        viewModel.shareJson.observe(viewLifecycleOwner) { jsonFormattedSession ->
+            val context = requireContext()
+            if (!SessionSharer.shareJson(context, jsonFormattedSession)) {
+                Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
+            }
+        }
+        viewModel.timeTextViewParameters.observe(viewLifecycleOwner) { timeTextViewParameters ->
+            fillTimes(timeTextViewParameters)
+        }
+        viewModel.scrollToCurrentSessionParameter.observe(viewLifecycleOwner) { (scheduleData, dateInfos) ->
+            val boxHeight = getNormalizedBoxHeight()
+            scrollToCurrent(boxHeight, scheduleData, dateInfos)
+        }
+        viewModel.scrollToSessionParameter.observe(viewLifecycleOwner) { (sessionId, verticalPosition, roomIndex) ->
+            scrollTo(sessionId, verticalPosition, roomIndex)
+        }
     }
 
     override fun onResume() {
@@ -200,119 +190,49 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val activity = requireActivity()
         activity.invalidateOptionsMenu()
         val intent = activity.intent
-        Log.d(LOG_TAG, "sessionId = $sessionId")
-        sessionId = intent.getStringExtra(BUNDLE_KEY_SESSION_ALARM_SESSION_ID)
+        // TODO Consume session alarm in MainActivity and let it orchestrate its fragments
+        val sessionId = intent.getStringExtra(BUNDLE_KEY_SESSION_ALARM_SESSION_ID)
         // TODO Analyzing https://github.com/EventFahrplan/EventFahrplan/issues/402
         Log.d(LOG_TAG, "sessionId = $sessionId (after loading from bundle)")
         if (sessionId != null) {
             Log.d(LOG_TAG, "Open with sessionId '$sessionId'.")
-            dayIndex = intent.getIntExtra(BUNDLE_KEY_SESSION_ALARM_DAY_INDEX, dayIndex)
-            Log.d(LOG_TAG, "day index = $dayIndex")
-            saveCurrentDay(dayIndex)
-        }
-        Log.d(LOG_TAG, "MyApp.task_running = ${MyApp.task_running}")
-        when (MyApp.task_running) {
-            TASKS.FETCH -> {
-                Log.d(LOG_TAG, "fetch was pending, restart")
-                if (MyApp.meta.numDays != 0) {
-                    viewDay(false)
-                }
-            }
-            TASKS.PARSE -> {
-                Log.d(LOG_TAG, "parse was pending, restart")
-            }
-            TASKS.NONE -> {
-                Log.d(LOG_TAG, "meta.getNumDays() = ${MyApp.meta.numDays}")
-                if (MyApp.meta.numDays != 0) {
-                    // auf jeden Fall reload, wenn mit Session ID gestartet
-                    viewDay(sessionId != null)
-                }
-            }
-            else -> {
-                // Nothing to do here.
-            }
-        }
-        if (sessionId != null && scheduleData != null) {
-            val session = scheduleData!!.findSession(sessionId!!)
-            if (session != null) {
-                scrollTo(session)
-                val sidePaneView = activity.findViewById<FragmentContainerView?>(R.id.detail)
-                if (sidePaneView != null && onSessionClickListener != null) {
-                    onSessionClickListener!!.onSessionClick(sessionId!!)
-                }
-            }
+            val sessionAlarmDayIndex = intent.getIntExtra(BUNDLE_KEY_SESSION_ALARM_DAY_INDEX, -1)
+            viewModel.saveSelectedDayIndex(sessionAlarmDayIndex)
+            viewModel.scrollToSession(sessionId, getNormalizedBoxHeight())
             intent.removeExtra(BUNDLE_KEY_SESSION_ALARM_SESSION_ID) // jump to given sessionId only once
         }
-        if (conference != null) {
-            fillTimes()
-        }
-        appRepository.setOnSessionsChangeListener(onSessionsChangeListener)
-    }
-
-    override fun onPause() {
-        appRepository.removeOnSessionsChangeListener(onSessionsChangeListener)
-        super.onPause()
+        Logging.get().d(LOG_TAG, "onResume")
     }
 
     /**
      * Updates the session data in the schedule view.
-     *
-     * The [forceReload] parameter is used to avoid unneeded data loading (see [loadSessions]) and
-     * unneeded rendering of the RecyclerView columns for each room (see [addRoomColumns]).
-     *
-     * Use cases of [forceReload]:
-     * - false: a schedule is present and re-fetching it is in progress (see [onResume])
-     * - true: a [sessionId] is present in session alarm notification Intent (see [onResume])
-     * - true: user chooses another day (see [chooseDay])
-     * - true: parsing finished successfully AND
-     *     - no schedule is present OR
-     *     - the schedule version changed OR
-     *     - Engelsystem shifts changed
-     *   (see [onParseDone])
-     * - false: when parsing finished successfully (see [onParseDone])
      */
-    private fun viewDay(forceReload: Boolean) {
-        Log.d(LOG_TAG, "viewDay($forceReload)")
+    private fun viewDay(scheduleData: ScheduleData, numDays: Int, dayIndex: Int) {
         val layoutRoot = requireView()
-        val boxHeight = getNormalizedBoxHeight()
         val horizontalScroller = layoutRoot.requireViewByIdCompat<HorizontalSnapScrollView>(R.id.horizScroller)
         horizontalScroller.scrollTo(0, 0)
-        loadSessions(appRepository, dayIndex, forceReload)
-
-        val sessionsOfDay = scheduleData!!.allSessions
-        if (sessionsOfDay.isEmpty()) {
-            val scheduleVersion = appRepository.readMeta().version
-            val errorMessage = errorMessageFactory.getMessageForEmptySchedule(scheduleVersion)
-            errorMessage.show(requireContext(), shouldShowLong = false)
-        } else {
-            // TODO: Move this to AppRepository and include the result in ScheduleData
-            conference = Conference.ofSessions(sessionsOfDay)
-            MyApp.LogDebug(LOG_TAG, "Conference = $conference")
-        }
-
-        val roomCount = scheduleData!!.roomCount
+        val roomCount = scheduleData.roomCount
         horizontalScroller.setRoomsCount(roomCount)
+
         val roomScroller = layoutRoot.requireViewByIdCompat<HorizontalScrollView>(R.id.roomScroller)
         val roomTitlesRowLayout = roomScroller.getChildAt(0) as LinearLayout
         val columnWidth = horizontalScroller.columnWidth
-        addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData!!.roomNames)
-        addRoomColumns(horizontalScroller, columnWidth, scheduleData!!, forceReload)
+        addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.roomNames)
+        addRoomColumns(horizontalScroller, columnWidth, scheduleData)
 
         MainActivity.instance.shouldScheduleScrollToCurrentTimeSlot {
-            if (!preserveVerticalScrollPosition) {
-                scrollToCurrent(boxHeight)
-                preserveVerticalScrollPosition = false
+            if (!viewModel.preserveVerticalScrollPosition) {
+                viewModel.scrollToCurrentSession()
+                viewModel.preserveVerticalScrollPosition = false
             }
-            Unit
         }
-        updateNavigationMenuSelection()
+        updateNavigationMenuSelection(numDays, dayIndex)
     }
 
-    private fun updateNavigationMenuSelection() {
+    private fun updateNavigationMenuSelection(numDays: Int, dayIndex: Int) {
         val activity = requireActivity() as AppCompatActivity
         val actionbar = activity.supportActionBar
-        Log.d(LOG_TAG, "MyApp.meta = ${MyApp.meta}")
-        if (actionbar != null && MyApp.meta.numDays > 1) {
+        if (actionbar != null && numDays > 1) {
             actionbar.setSelectedNavigationItem(dayIndex - 1)
         }
     }
@@ -325,35 +245,19 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     private fun addRoomColumns(
         horizontalScroller: HorizontalSnapScrollView,
         columnWidth: Int,
-        scheduleData: ScheduleData,
-        forceReload: Boolean
+        scheduleData: ScheduleData
     ) {
-        val columnIndexLeft = horizontalScroller.columnIndex
-        val columnIndexRight = horizontalScroller.lastVisibleColumnIndex
-
-        // whenever possible, just update recycler views
-        if (!forceReload && adapterByRoomIndex.isNotEmpty()) {
-            for (roomIndex in columnIndexLeft..columnIndexRight) {
-                try {
-                    adapterByRoomIndex[roomIndex]!!.notifyDataSetChanged()
-                } catch (e: NullPointerException) {
-                    // TODO Analyzing https://github.com/EventFahrplan/EventFahrplan/issues/402
-                    Log.e(LOG_TAG, "adapterByRoomIndex keys = ${adapterByRoomIndex.keys}")
-                    throw e
-                }
-            }
-            return
-        }
         val columnsLayout = horizontalScroller.getChildAt(0) as LinearLayout
+        // TODO Optimization: Track room names and check if they can be re-used with the updated scheduleData
         columnsLayout.removeAllViews()
-        adapterByRoomIndex.clear()
         val boxHeight = getNormalizedBoxHeight()
         val layoutCalculator = LayoutCalculator(boxHeight)
         val context = horizontalScroller.context
         val roomDataList = scheduleData.roomDataList
+        val conference = Conference.ofSessions(scheduleData.allSessions)
         for (roomIndex in roomDataList.indices) {
             val roomData = roomDataList[roomIndex]
-            val layoutParamsBySession = layoutCalculator.calculateLayoutParams(roomData, conference!!)
+            val layoutParamsBySession = layoutCalculator.calculateLayoutParams(roomData, conference)
             val columnRecyclerView = RecyclerView(context).apply {
                 setHasFixedSize(true)
                 setFadingEdgeLength(0)
@@ -369,7 +273,6 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 eventsHandler = this
             )
             columnRecyclerView.adapter = adapter
-            adapterByRoomIndex[roomIndex] = adapter
             columnsLayout.addView(columnRecyclerView)
         }
     }
@@ -410,12 +313,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     /**
      * Jump to current time or session, if we are on today's session list
+     * Scrolling to a session as an reaction to tapping a session alarm notification
+     * is handled in [scrollTo].
      */
-    private fun scrollToCurrent(boxHeight: Int) {
-        val currentDayIndex = scheduleData!!.dayIndex
-        if (sessionId != null || currentDayIndex != MyApp.dateInfos.indexOfToday) {
-            return
-        }
+    private fun scrollToCurrent(boxHeight: Int, scheduleData: ScheduleData, dateInfos: DateInfos) {
         var columnIndex = -1
         val layoutRootView = requireView()
         if (!layoutRootView.context.isLandscape()) {
@@ -424,12 +325,13 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             MyApp.LogDebug(LOG_TAG, "y pos = $columnIndex")
         }
         val nowMoment = Moment.now()
-        val scrollAmount = scrollAmountCalculator!!.calculateScrollAmount(
-            conference = conference!!,
-            dateInfos = MyApp.dateInfos,
-            scheduleData = scheduleData!!,
+        val conference = Conference.ofSessions(scheduleData.allSessions)
+        val scrollAmount = ScrollAmountCalculator(Logging.get()).calculateScrollAmount(
+            conference = conference,
+            dateInfos = dateInfos,
+            scheduleData = scheduleData,
             nowMoment = nowMoment,
-            currentDayIndex = currentDayIndex,
+            currentDayIndex = scheduleData.dayIndex,
             boxHeight = boxHeight,
             columnIndex = columnIndex
         )
@@ -449,45 +351,21 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         bellView.isVisible = session.hasAlarm
     }
 
-    private fun scrollTo(session: Session) {
-        val height = getNormalizedBoxHeight()
-        val pos = scrollAmountCalculator!!.calculateScrollAmount(conference!!, session, height)
-        MyApp.LogDebug(LOG_TAG, "Position is $pos")
+    private fun scrollTo(sessionId: String, verticalPosition: Int, roomIndex: Int) {
         val layoutRootView = requireView()
         layoutRootView.requireViewByIdCompat<NestedScrollView>(R.id.verticalScrollView).apply {
-            post { scrollTo(0, pos) }
+            post { scrollTo(0, verticalPosition) }
         }
         val horizontalSnapScrollView = layoutRootView.findViewById<HorizontalSnapScrollView?>(R.id.horizScroller)
-        if (horizontalSnapScrollView != null) {
-            val horizontalPos = scheduleData!!.findRoomIndex(session)
-            MyApp.LogDebug(LOG_TAG, "Scroll horizontal to $horizontalPos")
-            horizontalSnapScrollView.post { horizontalSnapScrollView.scrollToColumn(horizontalPos, false) }
+        horizontalSnapScrollView?.post { horizontalSnapScrollView.scrollToColumn(roomIndex, false) }
+        val activity = requireActivity()
+        val sidePaneView = activity.findViewById<FragmentContainerView?>(R.id.detail)
+        if (sidePaneView != null && onSessionClickListener != null) {
+            onSessionClickListener!!.onSessionClick(sessionId)
         }
     }
 
-    private fun chooseDay(chosenDay: Int) {
-        if (chosenDay + 1 != dayIndex) {
-            dayIndex = chosenDay + 1
-            saveCurrentDay(dayIndex)
-            preserveVerticalScrollPosition = false
-            viewDay(forceReload = true)
-            fillTimes()
-        }
-    }
-
-    private fun fillTimes() {
-        val normalizedBoxHeight = getNormalizedBoxHeight()
-        val earliestSession = appRepository.loadEarliestSession()
-        val firstDayStartDay = earliestSession.startTimeMoment.monthDay
-        val useDeviceTimeZone = appRepository.readUseDeviceTimeZoneEnabled()
-        val parameters = TimeTextViewParameter.parametersOf(
-            nowMoment = Moment.now(),
-            conference = conference!!,
-            firstDayStartDay = firstDayStartDay,
-            dayIndex = dayIndex,
-            normalizedBoxHeight = normalizedBoxHeight,
-            useDeviceTimeZone = useDeviceTimeZone
-        )
+    private fun fillTimes(parameters: List<TimeTextViewParameter>) {
         val timeTextColumn = requireView().requireViewByIdCompat<LinearLayout>(R.id.times_layout)
         timeTextColumn.removeAllViews()
         var timeTextView: View
@@ -512,38 +390,6 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         return (resources.getInteger(R.integer.box_height) * displayDensityScale).toInt()
     }
 
-    private fun loadSessions(appRepository: AppRepository, dayIndex: Int, forceReload: Boolean) {
-        MyApp.LogDebug(LOG_TAG, "load sessions of dayIndex $dayIndex")
-        if (!forceReload && scheduleData != null && scheduleData!!.dayIndex == dayIndex) {
-            return
-        }
-        val sessions = appRepository.loadUncanceledSessionsForDayIndex(dayIndex)
-        scheduleData = sessionsTransformer.transformSessions(dayIndex, sessions)
-        scrollAmountCalculator = ScrollAmountCalculator(Logging.get())
-    }
-
-    private fun reloadAlarms() {
-        if (scheduleData == null) {
-            return
-        }
-        val alarmSessionIds = appRepository.readAlarmSessionIds()
-        for (session in scheduleData!!.allSessions) {
-            session.hasAlarm = alarmSessionIds.contains(session.sessionId)
-        }
-        refreshViews()
-    }
-
-    private fun reloadHighlights() {
-        if (scheduleData == null) {
-            return
-        }
-        val highlightSessionIds = appRepository.readHighlightSessionIds()
-        for (session in scheduleData!!.allSessions) {
-            session.highlight = highlightSessionIds.contains(session.sessionId)
-        }
-        refreshViews()
-    }
-
     override fun onClick(view: View) {
         val session = checkNotNull(view.tag) {
             "A session must be assigned to the 'tag' attribute of the session view."
@@ -552,9 +398,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         onSessionClickListener?.onSessionClick(session.sessionId)
     }
 
-    private fun buildNavigationMenu() {
-        val numDays = MyApp.meta.numDays
-        val dayMenuEntries = navigationMenuEntriesGenerator.getDayMenuEntries(numDays, MyApp.dateInfos).toTypedArray()
+    private fun buildNavigationMenu(dayMenuEntries: List<String?>, numDays: Int) {
         val actionBar = (requireActivity() as AppCompatActivity).supportActionBar
         actionBar!!.navigationMode = NAVIGATION_MODE_LIST
         val arrayAdapter = ArrayAdapter(
@@ -564,43 +408,6 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         )
         arrayAdapter.setDropDownViewResource(R.layout.support_simple_spinner_dropdown_list_item)
         actionBar.setListNavigationCallbacks(arrayAdapter, OnDaySelectedListener(numDays))
-    }
-
-    fun onParseDone(result: ParseResult) {
-        val activity = requireActivity()
-        val lastShiftsHash = appRepository.readLastEngelsystemShiftsHash()
-        val currentShiftsHash = appRepository.readEngelsystemShiftsHash()
-        MyApp.LogDebug(LOG_TAG, "Shifts hash (OLD) = $lastShiftsHash")
-        MyApp.LogDebug(LOG_TAG, "Shifts hash (NEW) = $currentShiftsHash")
-        val shiftsChanged = currentShiftsHash != lastShiftsHash
-        if (shiftsChanged) {
-            appRepository.updateLastEngelsystemShiftsHash(currentShiftsHash)
-        }
-        if (result.isSuccess) {
-            if (MyApp.meta.numDays == 0 || (result is ParseScheduleResult && result.version != MyApp.meta.version) || shiftsChanged) {
-                MyApp.meta = appRepository.readMeta()
-                FahrplanMisc.createDateInfos(appRepository.readDateInfos())
-                if (MyApp.meta.numDays > 1) {
-                    buildNavigationMenu()
-                }
-                dayIndex = appRepository.readDisplayDayIndex()
-                if (dayIndex > MyApp.meta.numDays) {
-                    dayIndex = 1
-                }
-                viewDay(true)
-                if (conference == null) {
-                    Log.e(javaClass.simpleName, "Error displaying schedule. Conference is null.")
-                } else {
-                    fillTimes()
-                }
-            } else {
-                viewDay(false)
-            }
-        } else {
-            val errorMessage = errorMessageFactory.getMessageForParsingResult(result)
-            errorMessage.show(requireContext(), shouldShowLong = true)
-        }
-        activity.invalidateOptionsMenu()
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -620,7 +427,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             Log.e(javaClass.simpleName, "onAlarmTimesIndexPicked: session: null. alarmTimesIndex: $alarmTimesIndex")
             throw NullPointerException("Session is null.")
         } else {
-            alarmServices.addSessionAlarm(lastSelectedSession!!, alarmTimesIndex)
+            viewModel.addAlarm(lastSelectedSession!!, alarmTimesIndex)
             setBell(lastSelectedSession!!)
             updateMenuItems()
         }
@@ -635,7 +442,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         when (menuItemIndex) {
             CONTEXT_MENU_ITEM_ID_FAVORITES -> {
                 session.highlight = !session.highlight
-                appRepository.updateHighlight(session)
+                viewModel.updateFavorStatus(session)
                 sessionViewDrawer.setSessionBackground(session, contextMenuView)
                 SessionViewDrawer.setSessionTextColor(session, contextMenuView)
                 updateMenuItems()
@@ -644,7 +451,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 showAlarmTimePicker()
             }
             CONTEXT_MENU_ITEM_ID_DELETE_ALARM -> {
-                alarmServices.deleteSessionAlarm(session)
+                viewModel.deleteAlarm(session)
                 setBell(session)
                 updateMenuItems()
             }
@@ -653,21 +460,14 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             }
             CONTEXT_MENU_ITEM_ID_SHARE -> {
                 if (!BuildConfig.ENABLE_CHAOSFLIX_EXPORT) {
-                    val timeZoneId = appRepository.readMeta().timeZoneId
-                    val formattedSession = SimpleSessionFormat().format(session, timeZoneId)
-                    SessionSharer.shareSimple(context, formattedSession)
+                    viewModel.share(session)
                 }
             }
             CONTEXT_MENU_ITEM_ID_SHARE_TEXT -> {
-                val timeZoneId = appRepository.readMeta().timeZoneId
-                val formattedSession = SimpleSessionFormat().format(session, timeZoneId)
-                SessionSharer.shareSimple(context, formattedSession)
+                viewModel.share(session)
             }
             CONTEXT_MENU_ITEM_ID_SHARE_JSON -> {
-                val jsonFormattedSession = JsonSessionFormat().format(session)
-                if (!SessionSharer.shareJson(context, jsonFormattedSession)) {
-                    Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
-                }
+                viewModel.shareToChaosflix(session)
             }
         }
         return true
@@ -680,9 +480,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     override fun onOptionsItemSelected(menuItem: MenuItem): Boolean {
         return if (menuItem.itemId == R.id.menu_item_refresh) {
-            // TODO Replace MainActivity reference with viewModel.
-            val activity = requireActivity() as MainActivity
-            activity.fetchFahrplan()
+            viewModel.requestScheduleUpdate(isUserRequest = true)
             true
         } else {
             super.onOptionsItemSelected(menuItem)
@@ -719,26 +517,6 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         }
     }
 
-    private fun getSessionView(session: Session): View? {
-        val verticalScrollView = requireView().findViewById<NestedScrollView?>(R.id.verticalScrollView)
-            ?: return null
-        return verticalScrollView.findViewWithTag(session)
-    }
-
-    private fun refreshViews() {
-        if (scheduleData == null) {
-            return
-        }
-        for (session in scheduleData!!.allSessions) {
-            setBell(session)
-            val sessionView = getSessionView(session)
-            if (sessionView != null) {
-                sessionViewDrawer.setSessionBackground(session, sessionView)
-                SessionViewDrawer.setSessionTextColor(session, sessionView)
-            }
-        }
-    }
-
     private inner class OnDaySelectedListener(private val numDays: Int) : OnNavigationListener {
 
         private var isSynthetic = true
@@ -749,7 +527,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 return true
             }
             if (itemPosition < numDays) {
-                chooseDay(itemPosition)
+                viewModel.selectDay(itemPosition)
                 return true
             }
             return false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -579,7 +579,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         if (result.isSuccess) {
             if (MyApp.meta.numDays == 0 || (result is ParseScheduleResult && result.version != MyApp.meta.version) || shiftsChanged) {
                 MyApp.meta = appRepository.readMeta()
-                FahrplanMisc.loadDays(appRepository)
+                FahrplanMisc.createDateInfos(appRepository.readDateInfos())
                 if (MyApp.meta.numDays > 1) {
                     buildNavigationMenu()
                 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -1,0 +1,245 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent
+import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanEmptyParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToCurrentSessionParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToSessionParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
+import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
+import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
+import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
+
+internal class FahrplanViewModel(
+
+    private val repository: AppRepository,
+    private val executionContext: ExecutionContext,
+    private val logging: Logging,
+    private val alarmServices: AlarmServices,
+    private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
+    private val simpleSessionFormat: SimpleSessionFormat,
+    private val jsonSessionFormat: JsonSessionFormat,
+    private val scrollAmountCalculator: ScrollAmountCalculator
+
+) : ViewModel() {
+
+    private companion object {
+        const val LOG_TAG = "FahrplanViewModel"
+    }
+
+    private val mutableFahrplanParameter = MutableLiveData<FahrplanParameter>()
+    val fahrplanParameter: LiveData<FahrplanParameter> = mutableFahrplanParameter
+
+    val fahrplanEmptyParameter = SingleLiveEvent<FahrplanEmptyParameter>()
+
+    val shareSimple = SingleLiveEvent<String>()
+    val shareJson = SingleLiveEvent<String>()
+
+    private val mutableTimeTextViewParameters = MutableLiveData<List<TimeTextViewParameter>>()
+    val timeTextViewParameters: LiveData<List<TimeTextViewParameter>> = mutableTimeTextViewParameters
+
+    val scrollToCurrentSessionParameter = SingleLiveEvent<ScrollToCurrentSessionParameter>()
+    val scrollToSessionParameter = SingleLiveEvent<ScrollToSessionParameter>()
+
+    var preserveVerticalScrollPosition: Boolean = false
+
+    init {
+        updateUncanceledSessions()
+    }
+
+    private fun updateUncanceledSessions() {
+        launch {
+            repository.uncanceledSessionsForDayIndex.collect { scheduleData ->
+                val sessions = scheduleData.allSessions
+                if (sessions.isEmpty()) {
+                    val scheduleVersion = repository.readMeta().version
+                    if (scheduleVersion.isNotEmpty()) {
+                        fahrplanEmptyParameter.postValue(FahrplanEmptyParameter(scheduleVersion))
+                    } // else: Nothing to do because schedule has not been loaded yet
+                } else {
+                    val fahrplanParameter = scheduleData.toFahrplanParameter()
+                    mutableFahrplanParameter.postValue(fahrplanParameter)
+                }
+            }
+        }
+    }
+
+    private fun ScheduleData.toFahrplanParameter(): FahrplanParameter {
+        val dayIndex = repository.readDisplayDayIndex()
+        val numDays = repository.readMeta().numDays
+        val dateInfos = FahrplanMisc.createDateInfos(repository.readDateInfos())
+        val dayMenuEntries = if (numDays > 1) {
+            navigationMenuEntriesGenerator.getDayMenuEntries(numDays, dateInfos)
+        } else {
+            null
+        }
+        return FahrplanParameter(
+            scheduleData = this,
+            numDays = numDays,
+            dayIndex = dayIndex,
+            dayMenuEntries = dayMenuEntries
+        ).also {
+            logging.d(LOG_TAG, "Loaded ${allSessions.size} uncanceled sessions.")
+        }
+    }
+
+    /**
+     * Requests loading the schedule from the [AppRepository] to update the UI. UI components must
+     * observe the respective properties exposed by the [AppRepository] to receive schedule updates.
+     * The [isUserRequest] must be set to `true` if the requests originates from a manual
+     * interaction of the user with the UI; otherwise `false`.
+     */
+    fun requestScheduleUpdate(isUserRequest: Boolean) {
+        launch {
+            repository.loadSchedule(
+                isUserRequest = isUserRequest,
+                onFetchingDone = {},
+                onParsingDone = {},
+                onLoadingShiftsDone = {}
+            )
+        }
+    }
+
+    /**
+     * Requests loading the schedule from the [AppRepository] if [automatic schedule updates]
+     * [AppRepository.readAutoUpdateEnabled] are enabled. Also see: [requestScheduleUpdate].
+     */
+    fun requestScheduleAutoUpdate() {
+        launch {
+            if (repository.readAutoUpdateEnabled()) {
+                requestScheduleUpdate(isUserRequest = false)
+            }
+        }
+    }
+
+    fun fillTimes(nowMoment: Moment, normalizedBoxHeight: Int) {
+        launch {
+            repository.uncanceledSessionsForDayIndex.collect { scheduleData ->
+                val sessions = scheduleData.allSessions
+                if (sessions.isNotEmpty()) {
+                    val parameters = sessions.toTimeTextViewParameters(nowMoment, normalizedBoxHeight)
+                    mutableTimeTextViewParameters.postValue(parameters)
+                }
+            }
+        }
+    }
+
+    private fun List<Session>.toTimeTextViewParameters(nowMoment: Moment, normalizedBoxHeight: Int): List<TimeTextViewParameter> {
+        val earliestSession = repository.loadEarliestSession()
+        val firstDayStartDay = earliestSession.startTimeMoment.monthDay
+        val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
+        val dayIndex = repository.readDisplayDayIndex()
+        val conference = Conference.ofSessions(this)
+        return TimeTextViewParameter.parametersOf(
+            nowMoment,
+            conference,
+            firstDayStartDay,
+            dayIndex,
+            normalizedBoxHeight,
+            useDeviceTimeZone
+        )
+    }
+
+    fun updateFavorStatus(session: Session) {
+        launch {
+            repository.updateHighlight(session)
+        }
+    }
+
+    fun addAlarm(session: Session, alarmTimesIndex: Int) {
+        launch {
+            alarmServices.addSessionAlarm(session, alarmTimesIndex)
+        }
+    }
+
+    fun deleteAlarm(session: Session) {
+        launch {
+            alarmServices.deleteSessionAlarm(session)
+        }
+    }
+
+    fun share(session: Session) {
+        launch {
+            val timeZoneId = repository.readMeta().timeZoneId
+            simpleSessionFormat.format(session, timeZoneId).let { formattedSession ->
+                shareSimple.postValue(formattedSession)
+            }
+        }
+    }
+
+    fun shareToChaosflix(session: Session) {
+        jsonSessionFormat.format(session).let { formattedSession ->
+            shareJson.postValue(formattedSession)
+        }
+    }
+
+    fun selectDay(dayItemPosition: Int) {
+        launch {
+            val dayIndex = repository.readDisplayDayIndex()
+            if (dayItemPosition + 1 != dayIndex) {
+                saveSelectedDayIndex(dayItemPosition + 1)
+                preserveVerticalScrollPosition = false
+            }
+        }
+    }
+
+    fun saveSelectedDayIndex(dayIndex: Int) {
+        launch {
+            repository.updateDisplayDayIndex(dayIndex)
+        }
+    }
+
+    fun scrollToCurrentSession() {
+        launch {
+            val scheduleData = repository.loadUncanceledSessionsForDayIndex()
+            val sessions = scheduleData.allSessions
+            if (sessions.isNotEmpty()) {
+                val dateInfos = FahrplanMisc.createDateInfos(repository.readDateInfos())
+                if (scheduleData.dayIndex == dateInfos.indexOfToday) {
+                    val parameter = ScrollToCurrentSessionParameter(scheduleData, dateInfos)
+                    scrollToCurrentSessionParameter.postValue(parameter)
+                }
+            }
+        }
+    }
+
+    fun scrollToSession(sessionId: String, boxHeight: Int) {
+        launch {
+            val scheduleData = repository.loadUncanceledSessionsForDayIndex()
+            val sessions = scheduleData.allSessions
+            if (sessions.isNotEmpty()) {
+                val session = scheduleData.findSession(sessionId)
+                if (session != null) {
+                    val conference = Conference.ofSessions(sessions)
+                    val verticalPosition = scrollAmountCalculator.calculateScrollAmount(conference, session, boxHeight)
+                    val roomIndex = scheduleData.findRoomIndex(session)
+                    val parameter = ScrollToSessionParameter(
+                        sessionId = sessionId,
+                        verticalPosition = verticalPosition,
+                        roomIndex = roomIndex
+                    )
+                    scrollToSessionParameter.postValue(parameter)
+                }
+            }
+        }
+    }
+
+    private fun launch(block: suspend CoroutineScope.() -> Unit) {
+        viewModelScope.launch(executionContext.database, block = block)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
@@ -1,0 +1,35 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import info.metadude.android.eventfahrplan.commons.logging.Logging
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
+import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
+
+internal class FahrplanViewModelFactory(
+
+    private val repository: AppRepository,
+    private val alarmServices: AlarmServices,
+    private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator
+
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        val logging = Logging.get()
+        return FahrplanViewModel(
+            repository = repository,
+            executionContext = AppExecutionContext,
+            logging = logging,
+            alarmServices = alarmServices,
+            navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
+            simpleSessionFormat = SimpleSessionFormat(),
+            jsonSessionFormat = JsonSessionFormat(),
+            scrollAmountCalculator = ScrollAmountCalculator(logging)
+        ) as T
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -140,7 +140,7 @@ class MainActivity : BaseActivity(),
         TraceDroidEmailSender.sendStackTraces(this)
         resetProgressDialog()
         MyApp.meta = appRepository.readMeta()
-        FahrplanMisc.loadDays(appRepository)
+        FahrplanMisc.createDateInfos(appRepository.readDateInfos())
 
         MyApp.LogDebug(LOG_TAG, "task_running: ${MyApp.task_running}")
         when (MyApp.task_running) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -1,0 +1,152 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent
+import info.metadude.android.eventfahrplan.commons.logging.Logging
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import nerd.tuxmobil.fahrplan.congress.changes.ChangeStatistic
+import nerd.tuxmobil.fahrplan.congress.models.Meta
+import nerd.tuxmobil.fahrplan.congress.net.ParseResult
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Fetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialFetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialParsing
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.LoadScheduleUiState
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScheduleChangesParameter
+
+class MainViewModel(
+
+    private val repository: AppRepository,
+    private val executionContext: ExecutionContext,
+    private val logging: Logging
+
+) : ViewModel() {
+
+    val loadScheduleUiState = SingleLiveEvent<LoadScheduleUiState>()
+    val fetchFailure = SingleLiveEvent<FetchFailure?>()
+    val parseFailure = SingleLiveEvent<ParseResult?>()
+    val scheduleChangesParameter = SingleLiveEvent<ScheduleChangesParameter>()
+
+    val showAbout = SingleLiveEvent<Meta>()
+    val openSessionDetails = SingleLiveEvent<Unit>()
+
+    init {
+        observeLoadScheduleState()
+    }
+
+    private fun observeLoadScheduleState() {
+        launch {
+            repository.loadScheduleState.collect { state ->
+                val uiState = state.toUiState()
+                loadScheduleUiState.postValue(uiState)
+                state.handleFailureStates()
+            }
+        }
+    }
+
+    private fun LoadScheduleState.toUiState() = when (this) {
+        InitialFetching -> LoadScheduleUiState.Initializing.InitialFetching
+        Fetching -> LoadScheduleUiState.Active.Fetching
+        FetchSuccess -> LoadScheduleUiState.Success.FetchSuccess
+        is FetchFailure -> {
+            if (isUserRequest) {
+                LoadScheduleUiState.Failure.UserTriggeredFetchFailure
+            } else {
+                // Don't bother the user with schedule up-to-date messages.
+                LoadScheduleUiState.Failure.SilentFetchFailure
+            }
+        }
+        InitialParsing -> LoadScheduleUiState.Initializing.InitialParsing
+        Parsing -> LoadScheduleUiState.Active.Parsing
+        ParseSuccess -> LoadScheduleUiState.Success.ParseSuccess.also {
+            onParsingDone()
+        }
+        is ParseFailure -> LoadScheduleUiState.Failure.ParseFailure
+    }
+
+    private fun LoadScheduleState.handleFailureStates() = when (this) {
+        is FetchFailure -> {
+            if (isUserRequest) {
+                fetchFailure.postValue(this)
+            } else {
+                // Don't bother the user with schedule up-to-date messages.
+            }
+        }
+        is ParseFailure -> {
+            parseFailure.postValue(parseResult)
+        }
+        else -> {
+            fetchFailure.postValue(null)
+            parseFailure.postValue(null)
+        }
+    }
+
+    private fun onParsingDone() {
+        if (!repository.readScheduleChangesSeen()) {
+            val scheduleVersion = repository.readMeta().version
+            val sessions = repository.loadChangedSessions()
+            val statistic = ChangeStatistic.of(sessions, logging)
+            val parameter = ScheduleChangesParameter(scheduleVersion, statistic)
+            scheduleChangesParameter.postValue(parameter)
+        }
+    }
+
+    /**
+     * Requests loading the schedule from the [AppRepository] to update the UI. UI components must
+     * observe the respective properties exposed by the [AppRepository] to receive schedule updates.
+     * The [isUserRequest] must be set to `true` if the requests originates from a manual
+     * interaction of the user with the UI; otherwise `false`.
+     */
+    fun requestScheduleUpdate(isUserRequest: Boolean) {
+        launch {
+            repository.loadSchedule(
+                isUserRequest = isUserRequest,
+                onFetchingDone = {},
+                onParsingDone = {},
+                onLoadingShiftsDone = {}
+            )
+        }
+    }
+
+    fun cancelLoading() {
+        // AppRepository wraps the call in a CoroutineScope itself.
+        repository.cancelLoading()
+    }
+
+    fun deleteSessionAlarmNotificationId(notificationId: Int) {
+        launch {
+            repository.deleteSessionAlarmNotificationId(notificationId)
+        }
+    }
+
+    fun showAboutDialog() {
+        launch {
+            val meta = repository.readMeta()
+            showAbout.postValue(meta)
+        }
+    }
+
+    fun openSessionDetails(sessionId: String) {
+        launch {
+            val isUpdated = repository.updateSelectedSessionId(sessionId)
+            if (isUpdated) {
+                openSessionDetails.postValue(Unit)
+            }
+        }
+    }
+
+    private fun launch(block: suspend CoroutineScope.() -> Unit) {
+        viewModelScope.launch(executionContext.database, block = block)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelFactory.kt
@@ -1,0 +1,25 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import info.metadude.android.eventfahrplan.commons.logging.Logging
+import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+
+class MainViewModelFactory(
+
+    private val repository: AppRepository
+
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        val logging = Logging.get()
+        return MainViewModel(
+            repository = repository,
+            executionContext = AppExecutionContext,
+            logging = logging
+        ) as T
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
@@ -36,7 +36,6 @@ internal class NavigationMenuEntriesGenerator @JvmOverloads constructor(
      * of the first object must be 1 as defined in the schedule XML. The list cannot be null nor empty.
      * @param currentDate A moment instance representing the day of interest.
      */
-    @JvmOverloads
     fun getDayMenuEntries(
         numDays: Int,
         dateInfos: DateInfos?,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanEmptyParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanEmptyParameter.kt
@@ -1,0 +1,14 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
+
+/**
+ * Payload of the observable [fahrplanEmptyParameter][FahrplanViewModel.fahrplanEmptyParameter]
+ * property in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
+ */
+data class FahrplanEmptyParameter(
+
+    val scheduleVersion: String
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
@@ -1,0 +1,18 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
+
+/**
+ * Payload of the observable [fahrplanParameter][FahrplanViewModel.fahrplanParameter] property
+ * in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
+ */
+data class FahrplanParameter(
+
+    val scheduleData: ScheduleData,
+    val numDays: Int,
+    val dayIndex: Int,
+    val dayMenuEntries: List<String>?
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/LoadScheduleUiState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/LoadScheduleUiState.kt
@@ -1,0 +1,48 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity
+import nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel
+
+/**
+ * Payload of the observable [loadScheduleUiState][MainViewModel.loadScheduleUiState] property
+ * in the [MainViewModel] which is observed by the [MainActivity].
+ */
+sealed interface LoadScheduleUiState {
+
+    sealed interface Initializing : LoadScheduleUiState {
+        val progressInfo: Int
+
+        object InitialFetching : Initializing {
+            override val progressInfo = R.string.progress_loading_data
+        }
+
+        object InitialParsing : Initializing {
+            override val progressInfo = R.string.progress_processing_data
+        }
+
+    }
+
+    sealed interface Active : LoadScheduleUiState {
+
+        object Fetching : Active
+        object Parsing : Active
+
+    }
+
+    sealed interface Success : LoadScheduleUiState {
+
+        object FetchSuccess : Success
+        object ParseSuccess : Success
+
+    }
+
+    sealed interface Failure : LoadScheduleUiState {
+
+        object SilentFetchFailure : Failure
+        object UserTriggeredFetchFailure : Failure
+        object ParseFailure : Failure
+
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScheduleChangesParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScheduleChangesParameter.kt
@@ -1,0 +1,16 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.changes.ChangeStatistic
+import nerd.tuxmobil.fahrplan.congress.schedule.MainActivity
+import nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel
+
+/**
+ * Payload of the observable [scheduleChangesParameter][MainViewModel.scheduleChangesParameter]
+ * property in the [MainViewModel] which is observed by the [MainActivity].
+ */
+data class ScheduleChangesParameter(
+
+    val scheduleVersion: String,
+    val changeStatistic: ChangeStatistic
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToCurrentSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToCurrentSessionParameter.kt
@@ -1,0 +1,17 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
+
+/**
+ * Payload of the observable [scrollToCurrentSessionParameter][FahrplanViewModel.scrollToCurrentSessionParameter]
+ * property in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
+ */
+data class ScrollToCurrentSessionParameter(
+
+    val scheduleData: ScheduleData,
+    val dateInfos: DateInfos
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToSessionParameter.kt
@@ -1,0 +1,16 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
+
+/**
+ * Payload of the observable [scrollToSessionParameter][FahrplanViewModel.scrollToSessionParameter]
+ * property in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
+ */
+data class ScrollToSessionParameter(
+
+    val sessionId: String,
+    val verticalPosition: Int,
+    val roomIndex: Int
+
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameter.kt
@@ -1,17 +1,24 @@
-package nerd.tuxmobil.fahrplan.congress.schedule
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
 
 import androidx.annotation.LayoutRes
+import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.schedule.Conference
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.Companion.BOX_HEIGHT_MULTIPLIER
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.Companion.FIFTEEN_MINUTES
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
+import nerd.tuxmobil.fahrplan.congress.schedule.TimeSegment
 
 /**
+ * Payload of the observable [timeTextViewParameters][FahrplanViewModel.timeTextViewParameters]
+ * property in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
  * Parameters to be used to inflate and configure a time text view.
  */
 @Suppress("DataClassPrivateConstructor")
-internal data class TimeTextViewParameter private constructor(
+internal data class TimeTextViewParameter @VisibleForTesting constructor(
 
         @LayoutRes
         val layout: Int,
@@ -25,7 +32,6 @@ internal data class TimeTextViewParameter private constructor(
         /**
          * Returns a list of parameters to be used to inflate and configure a time text view.
          */
-        @JvmStatic
         fun parametersOf(
                 nowMoment: Moment,
                 conference: Conference,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.java
@@ -16,24 +16,28 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmUpdater;
 import nerd.tuxmobil.fahrplan.congress.extensions.Contexts;
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo;
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos;
-import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository;
 
 
 public class FahrplanMisc {
 
     private static final String LOG_TAG = "FahrplanMisc";
 
-    public static void loadDays(@NonNull AppRepository appRepository) {
-        MyApp.dateInfos = new DateInfos();
-        List<DateInfo> dateInfos = appRepository.readDateInfos();
+    /**
+     * Returns a {@link DateInfos} instance composed from the given {@code dateInfos} list.
+     * Duplicate {@link DateInfo} entries are removed.
+     */
+    @NonNull
+    public static DateInfos createDateInfos(@NonNull List<DateInfo> dateInfos) {
+        DateInfos infos = new DateInfos();
         for (DateInfo dateInfo : dateInfos) {
-            if (!MyApp.dateInfos.contains(dateInfo)) {
-                MyApp.dateInfos.add(dateInfo);
+            if (!infos.contains(dateInfo)) {
+                infos.add(dateInfo);
             }
         }
-        for (DateInfo dateInfo : MyApp.dateInfos) {
+        for (DateInfo dateInfo : infos) {
             MyApp.LogDebug(LOG_TAG, "DateInfo: " + dateInfo);
         }
+        return infos;
     }
 
     public static long setUpdateAlarm(Context context, boolean initial) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/TypefaceFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/TypefaceFactory.kt
@@ -17,7 +17,6 @@ class TypefaceFactory private constructor(
 
     companion object {
 
-        @JvmStatic
         fun getNewInstance(context: Context) = TypefaceFactory(context.assets)
 
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -64,7 +64,6 @@ class AlarmServicesTest {
         alarmServices.addSessionAlarm(session, alarmTimesValues.indexOf("60"))
         // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
         assertThat(session.hasAlarm).isTrue()
-        verifyInvokedOnce(repository).notifyAlarmsChanged()
     }
 
     @Test
@@ -97,7 +96,6 @@ class AlarmServicesTest {
         verifyNoInteractions(formattingDelegate)
         verifyInvokedOnce(repository).deleteAlarmForSessionId("S3")
         assertThat(session.hasAlarm).isFalse()
-        verifyInvokedOnce(repository).notifyAlarmsChanged()
     }
 
     @Test
@@ -112,7 +110,6 @@ class AlarmServicesTest {
         verifyNoInteractions(pendingIntentDelegate)
         verifyNoInteractions(formattingDelegate)
         assertThat(session.hasAlarm).isFalse()
-        verifyInvokedOnce(repository).notifyAlarmsChanged()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -46,7 +46,8 @@ class AlarmUpdaterTest {
                 metaDatabaseRepository = mock(),
                 scheduleNetworkRepository = mock(),
                 engelsystemNetworkRepository = mock(),
-                sharedPreferencesRepository = sharedPreferencesRepository
+                sharedPreferencesRepository = sharedPreferencesRepository,
+                sessionsTransformer = mock()
             )
             return this
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -277,7 +277,6 @@ class SessionDetailsViewModelTest {
         viewModel.favorSession()
         verifyInvokedOnce(repository).loadSelectedSession()
         verifyInvokedOnce(repository).updateHighlight(expectedSession)
-        verifyInvokedOnce(repository).notifyHighlightsChanged()
     }
 
     @Test
@@ -289,7 +288,6 @@ class SessionDetailsViewModelTest {
         viewModel.unfavorSession()
         verifyInvokedOnce(repository).loadSelectedSession()
         verifyInvokedOnce(repository).updateHighlight(expectedSession)
-        verifyInvokedOnce(repository).notifyHighlightsChanged()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
@@ -73,7 +73,6 @@ class StarredListViewModelTest {
         val viewModel = createViewModel(repository)
         viewModel.delete(Session("42"))
         verifyInvokedOnce(repository).updateHighlight(any())
-        verifyInvokedOnce(repository).notifyHighlightsChanged()
     }
 
     @Test
@@ -82,7 +81,6 @@ class StarredListViewModelTest {
         val viewModel = createViewModel(repository)
         viewModel.deleteAll()
         verifyInvokedOnce(repository).deleteAllHighlights()
-        verifyInvokedOnce(repository).notifyHighlightsChanged()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -44,7 +44,8 @@ class AppRepositorySessionsTest {
                     metaDatabaseRepository = mock(),
                     scheduleNetworkRepository = mock(),
                     engelsystemNetworkRepository = mock(),
-                    sharedPreferencesRepository = mock()
+                    sharedPreferencesRepository = mock(),
+                    sessionsTransformer = mock()
             )
             return this
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -1,0 +1,390 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.assertLiveData
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import nerd.tuxmobil.fahrplan.congress.NoLogging
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.models.DateInfo
+import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import nerd.tuxmobil.fahrplan.congress.models.Meta
+import nerd.tuxmobil.fahrplan.congress.models.RoomData
+import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanEmptyParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToCurrentSessionParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToSessionParameter
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
+import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
+import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.threeten.bp.ZoneOffset
+
+class FahrplanViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherTestRule = MainDispatcherTestRule()
+
+    private val simpleSessionFormat = mock<SimpleSessionFormat>()
+    private val jsonSessionFormat = mock<JsonSessionFormat>()
+    private val scrollAmountCalculator = mock<ScrollAmountCalculator>()
+
+    @Test
+    fun `fahrplanParameter neither posts to fahrplanParameter nor fahrplanEmptyParameter properties`() {
+        val repository = createRepository(uncanceledSessionsForDayIndexFlow = emptyFlow())
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.fahrplanParameter).isNull()
+        assertLiveData(viewModel.fahrplanEmptyParameter).isNull()
+        verifyInvokedNever(repository).readMeta()
+        verifyInvokedNever(repository).readDisplayDayIndex()
+        verifyInvokedNever(repository).readDateInfos()
+    }
+
+    @Test
+    fun `updateUncanceledSessions posts FahrplanEmptyParameter to fahrplanEmptyParameter property`() {
+        val scheduleData = ScheduleData(0, emptyList())
+        val repository = createRepository(
+            uncanceledSessionsForDayIndexFlow = flowOf(scheduleData),
+            meta = Meta(version = "test-version")
+        )
+        val viewModel = createViewModel(repository)
+        val expected = FahrplanEmptyParameter("test-version")
+        assertLiveData(viewModel.fahrplanEmptyParameter).isEqualTo(expected)
+        assertThat(viewModel.fahrplanParameter.value).isNull()
+        verifyInvokedOnce(repository).readMeta()
+        verifyInvokedNever(repository).readDisplayDayIndex()
+        verifyInvokedNever(repository).readDateInfos()
+    }
+
+    @Test
+    fun `updateUncanceledSessions never posts to fahrplanEmptyParameter property when schedule has never been loaded`() {
+        val scheduleData = ScheduleData(0, emptyList())
+        val repository = createRepository(
+            uncanceledSessionsForDayIndexFlow = flowOf(scheduleData),
+            meta = Meta(version = "")
+        )
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.fahrplanEmptyParameter).isNull()
+        assertLiveData(viewModel.fahrplanParameter).isNull()
+        verifyInvokedOnce(repository).readMeta()
+        verifyInvokedNever(repository).readDisplayDayIndex()
+        verifyInvokedNever(repository).readDateInfos()
+    }
+
+    @Test
+    fun `updateUncanceledSessions posts FahrplanParameter to fahrplanParameter property`() {
+        val repository = createRepository(
+            uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData("session-01")),
+            meta = Meta(numDays = 1),
+            displayDayIndex = 2
+        )
+        val menuEntriesGenerator = mock<NavigationMenuEntriesGenerator>()
+        val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
+        val expected = FahrplanParameter(
+            scheduleData = createScheduleData("session-01"),
+            numDays = 1,
+            dayIndex = 2,
+            dayMenuEntries = null
+        )
+        assertLiveData(viewModel.fahrplanParameter).isEqualTo(expected)
+        assertThat(viewModel.fahrplanEmptyParameter.value).isNull()
+        verifyInvokedNever(menuEntriesGenerator).getDayMenuEntries(any(), anyOrNull(), any())
+        verifyInvokedOnce(repository).readDisplayDayIndex()
+        verifyInvokedOnce(repository).readMeta()
+        verifyInvokedOnce(repository).readDateInfos()
+    }
+
+    @Test
+    fun `updateUncanceledSessions generates navigation menu entries`() {
+        val repository = createRepository(
+            uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData("session-01")),
+            meta = Meta(numDays = 2),
+            displayDayIndex = 0
+        )
+        val menuEntriesGenerator = mock<NavigationMenuEntriesGenerator> {
+            on { getDayMenuEntries(any(), anyOrNull(), any()) } doReturn listOf("Day 1", "Day 2")
+        }
+        val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
+        val expected = FahrplanParameter(
+            scheduleData = createScheduleData("session-01"),
+            numDays = 2,
+            dayIndex = 0,
+            dayMenuEntries = listOf("Day 1", "Day 2")
+        )
+        assertLiveData(viewModel.fahrplanParameter).isEqualTo(expected)
+        assertThat(viewModel.fahrplanEmptyParameter.value).isNull()
+        verifyInvokedOnce(menuEntriesGenerator).getDayMenuEntries(any(), anyOrNull(), any())
+        verifyInvokedOnce(repository).readDisplayDayIndex()
+        verifyInvokedOnce(repository).readMeta()
+        verifyInvokedOnce(repository).readDateInfos()
+    }
+
+    @Test
+    fun `requestScheduleUpdate invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.requestScheduleUpdate(isUserRequest = true)
+        verifyInvokedOnce(repository).loadSchedule(isUserRequest = true, onFetchingDone = {}, onParsingDone = {}, onLoadingShiftsDone = {})
+    }
+
+    @Test
+    fun `requestScheduleAutoUpdate invokes repository function`() {
+        val repository = createRepository(isAutoUpdateEnabled = true)
+        val viewModel = createViewModel(repository)
+        viewModel.requestScheduleAutoUpdate()
+        verifyInvokedOnce(repository).loadSchedule(isUserRequest = false, onFetchingDone = {}, onParsingDone = {}, onLoadingShiftsDone = {})
+    }
+
+    @Test
+    fun `requestScheduleAutoUpdate never invokes repository function`() {
+        val repository = createRepository(isAutoUpdateEnabled = false)
+        val viewModel = createViewModel(repository)
+        viewModel.requestScheduleAutoUpdate()
+        verifyInvokedNever(repository).loadSchedule(isUserRequest = false, onFetchingDone = {}, onParsingDone = {}, onLoadingShiftsDone = {})
+    }
+
+    @Test
+    fun `fillTimes posts TimeTextViewParameter to timeTextViewParameters property`() {
+        val startsAt = 1582963200000L // February 29, 2020 08:00:00 AM GMT
+        val earliestSession = mock<Session> {
+            on { startTimeMoment } doReturn Moment.ofEpochMilli(startsAt)
+        }
+        val session = Session("session-01").apply {
+            dateUTC = startsAt
+            duration = 30
+            timeZoneOffset = ZoneOffset.UTC
+        }
+        val repository = createRepository(
+            uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData(session)),
+            earliestSession = earliestSession
+        )
+        val viewModel = createViewModel(repository)
+        viewModel.fillTimes(nowMoment = mock(), normalizedBoxHeight = 42)
+        val expected = listOf(
+            TimeTextViewParameter(R.layout.time_layout, height = 126, titleText = "08:00"),
+            TimeTextViewParameter(R.layout.time_layout, height = 126, titleText = "08:15")
+        )
+        assertLiveData(viewModel.timeTextViewParameters).isEqualTo(expected)
+        verifyInvokedOnce(repository).loadEarliestSession()
+        verifyInvokedOnce(repository).readUseDeviceTimeZoneEnabled()
+        verify(repository, times(2)).readDisplayDayIndex()
+    }
+
+    @Test
+    fun `updateFavorStatus invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.updateFavorStatus(Session("session-52"))
+        verifyInvokedOnce(repository).updateHighlight(Session("session-52"))
+    }
+
+    @Test
+    fun `addAlarm invokes alarmService function`() {
+        val repository = createRepository()
+        val alarmServices = mock<AlarmServices>()
+        val viewModel = createViewModel(repository, alarmServices)
+        val session = Session("session-97")
+        viewModel.addAlarm(session, alarmTimesIndex = 0)
+        verifyInvokedOnce(alarmServices).addSessionAlarm(session, alarmTimesIndex = 0)
+    }
+
+    @Test
+    fun `deleteAlarm invokes alarmService function`() {
+        val repository = createRepository()
+        val alarmServices = mock<AlarmServices>()
+        val viewModel = createViewModel(repository, alarmServices)
+        val session = Session("session-97")
+        viewModel.deleteAlarm(session)
+        verifyInvokedOnce(alarmServices).deleteSessionAlarm(session)
+    }
+
+    @Test
+    fun `share posts to shareSimple property`() {
+        val repository = createRepository()
+        val fakeSessionFormat = mock<SimpleSessionFormat> {
+            on { format(any<Session>(), anyOrNull()) } doReturn "session-61"
+        }
+        val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
+        viewModel.share(Session("61"))
+        assertLiveData(viewModel.shareSimple).isEqualTo("session-61")
+        verifyInvokedOnce(repository).readMeta()
+    }
+
+    @Test
+    fun `shareToChaosflix posts to shareJson property`() {
+        val repository = createRepository()
+        val fakeSessionFormat = mock<JsonSessionFormat> {
+            on { format(any<Session>()) } doReturn "session-62"
+        }
+        val viewModel = createViewModel(repository, jsonSessionFormat = fakeSessionFormat)
+        viewModel.shareToChaosflix(Session("62"))
+        assertLiveData(viewModel.shareJson).isEqualTo("session-62")
+    }
+
+    @Test
+    fun `selectDay updates preserveVerticalScrollPosition property when displayDayIndex changes`() {
+        val repository = createRepository(displayDayIndex = 1)
+        val viewModel = createViewModel(repository)
+        viewModel.preserveVerticalScrollPosition = true
+        viewModel.selectDay(dayItemPosition = 3)
+        assertThat(viewModel.preserveVerticalScrollPosition).isFalse()
+        verifyInvokedOnce(repository).readDisplayDayIndex()
+        verifyInvokedOnce(repository).updateDisplayDayIndex(displayDayIndex = 4)
+    }
+
+    @Test
+    fun `selectDay never updates preserveVerticalScrollPosition property when displayDayIndex is the same`() {
+        val repository = createRepository(displayDayIndex = 4)
+        val viewModel = createViewModel(repository)
+        viewModel.preserveVerticalScrollPosition = true
+        viewModel.selectDay(dayItemPosition = 3)
+        assertThat(viewModel.preserveVerticalScrollPosition).isTrue()
+        verifyInvokedOnce(repository).readDisplayDayIndex()
+        verifyInvokedNever(repository).updateDisplayDayIndex(displayDayIndex = any())
+    }
+
+    @Test
+    fun `saveSelectedDayIndex invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.saveSelectedDayIndex(dayIndex = 2)
+        verifyInvokedOnce(repository).updateDisplayDayIndex(displayDayIndex = 2)
+    }
+
+    @Test
+    fun `scrollToCurrentSession never posts to scrollToCurrentSessionParameter property when sessions is empty`() {
+        val scheduleData = ScheduleData(0, emptyList())
+        val repository = createRepository(uncanceledSessionsForDayIndexFlow = flowOf(scheduleData))
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToCurrentSession()
+        verifyInvokedNever(repository).readDisplayDayIndex()
+        assertLiveData(viewModel.scrollToCurrentSessionParameter).isNull()
+    }
+
+    @Test
+    fun `scrollToCurrentSession posts to scrollToCurrentSessionParameter property when session is present and day indices match`() {
+        val scheduleData = createScheduleData(Session("session-31"), dayIndex = 3)
+        val nowMoment = Moment.now().startOfDay() // depends DateInfos.getIndexOfToday
+        val repository = createRepository(
+            loadUncanceledSessionsForDayIndex = scheduleData,
+            dateInfos = DateInfos().apply { add(DateInfo(3, nowMoment)) }
+        )
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToCurrentSession()
+        val expected = ScrollToCurrentSessionParameter(
+            scheduleData = createScheduleData(Session("session-31"), dayIndex = 3),
+            dateInfos = DateInfos().apply { add(DateInfo(3, nowMoment)) }
+        )
+        assertLiveData(viewModel.scrollToCurrentSessionParameter).isEqualTo(expected)
+    }
+
+    @Test
+    fun `scrollToCurrentSession never posts to scrollToCurrentSessionParameter property when day indices mismatch`() {
+        val scheduleData = createScheduleData(Session("session-21"), dayIndex = 2)
+        val nowMoment = Moment.now().startOfDay() // depends DateInfos.getIndexOfToday
+        val repository = createRepository(
+            loadUncanceledSessionsForDayIndex = scheduleData,
+            dateInfos = DateInfos().apply { add(DateInfo(3, nowMoment)) }
+        )
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToCurrentSession()
+        assertLiveData(viewModel.scrollToCurrentSessionParameter).isNull()
+    }
+
+    @Test
+    fun `scrollToSession never posts to scrollToSessionParameter property when sessions is empty`() {
+        val scheduleData = ScheduleData(0, emptyList())
+        val repository = createRepository(uncanceledSessionsForDayIndexFlow = flowOf(scheduleData))
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToSession("session-27", boxHeight = 42)
+        assertLiveData(viewModel.scrollToSessionParameter).isNull()
+    }
+
+    @Test
+    fun `scrollToSession never posts to scrollToSessionParameter property when session can not be found`() {
+        val scheduleData = createScheduleData("session-01")
+        val repository = createRepository(uncanceledSessionsForDayIndexFlow = flowOf(scheduleData))
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToSession("session-27", boxHeight = 42)
+        assertLiveData(viewModel.scrollToSessionParameter).isNull()
+        verifyInvokedOnce(repository).readDisplayDayIndex()
+    }
+
+    @Test
+    fun `scrollToSession posts to scrollToSessionParameter property when session is present and matched`() {
+        val scheduleData = createScheduleData("session-02")
+        val repository = createRepository(loadUncanceledSessionsForDayIndex = scheduleData)
+        val viewModel = createViewModel(repository)
+        viewModel.scrollToSession("session-02", boxHeight = 42)
+        val expected = ScrollToSessionParameter(sessionId = "session-02", verticalPosition = 0, roomIndex = 0)
+        assertLiveData(viewModel.scrollToSessionParameter).isEqualTo(expected)
+    }
+
+    private fun createRepository(
+        uncanceledSessionsForDayIndexFlow: Flow<ScheduleData> = emptyFlow(),
+        loadUncanceledSessionsForDayIndex: ScheduleData = mock(),
+        meta: Meta = Meta(numDays = 0, version = "test-version"),
+        isAutoUpdateEnabled: Boolean = true,
+        displayDayIndex: Int = 0,
+        earliestSession: Session = Session(""),
+        dateInfos: DateInfos = DateInfos()
+    ) = mock<AppRepository> {
+        on { uncanceledSessionsForDayIndex } doReturn uncanceledSessionsForDayIndexFlow
+        on { loadUncanceledSessionsForDayIndex() } doReturn loadUncanceledSessionsForDayIndex
+        on { readMeta() } doReturn meta
+        on { readAutoUpdateEnabled() } doReturn isAutoUpdateEnabled
+        on { readDisplayDayIndex() } doReturn displayDayIndex
+        on { loadEarliestSession() } doReturn earliestSession
+        on { readDateInfos() } doReturn dateInfos
+    }
+
+    private fun createScheduleData(sessionId: String? = null): ScheduleData {
+        val session = if (sessionId == null) null else Session(sessionId)
+        return createScheduleData(session)
+    }
+
+    private fun createScheduleData(session: Session? = null, dayIndex: Int = 0): ScheduleData {
+        val sessions = if (session == null) emptyList() else listOf(session)
+        val roomDataList = listOf(RoomData(roomName = "", sessions))
+        return ScheduleData(dayIndex = dayIndex, roomDataList)
+    }
+
+    private fun createViewModel(
+        repository: AppRepository,
+        alarmServices: AlarmServices = mock(),
+        navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator = mock(),
+        simpleSessionFormat: SimpleSessionFormat = this.simpleSessionFormat,
+        jsonSessionFormat: JsonSessionFormat = this.jsonSessionFormat
+    ) = FahrplanViewModel(
+        repository = repository,
+        executionContext = TestExecutionContext,
+        logging = NoLogging,
+        alarmServices = alarmServices,
+        navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
+        simpleSessionFormat = simpleSessionFormat,
+        jsonSessionFormat = jsonSessionFormat,
+        scrollAmountCalculator = scrollAmountCalculator
+    )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
@@ -1,0 +1,256 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.assertLiveData
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import nerd.tuxmobil.fahrplan.congress.NoLogging
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import nerd.tuxmobil.fahrplan.congress.changes.ChangeStatistic
+import nerd.tuxmobil.fahrplan.congress.models.Meta
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
+import nerd.tuxmobil.fahrplan.congress.net.ParseResult
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Fetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialFetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialParsing
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.LoadScheduleUiState
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScheduleChangesParameter
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class MainViewModelTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherTestRule = MainDispatcherTestRule()
+
+    private val logging = NoLogging
+
+    @Test
+    fun `initialization does not affect properties`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isNull()
+        assertLiveData(viewModel.scheduleChangesParameter).isNull()
+        assertLiveData(viewModel.showAbout).isNull()
+        assertLiveData(viewModel.openSessionDetails).isNull()
+        assertLiveData(viewModel.fetchFailure).isNull()
+        assertLiveData(viewModel.parseFailure).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `InitialFetching posts to loadScheduleUiState property`() {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(InitialFetching))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Initializing.InitialFetching)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `Fetching posts to loadScheduleUiState property`() {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(Fetching))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Active.Fetching)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `FetchSuccess posts to loadScheduleUiState property`() {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(FetchSuccess))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Success.FetchSuccess)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `FetchFailure posts to loadScheduleUiState and fetchFailure properties when the user triggered the action`() {
+        val status = FetchFailure(HttpStatus.HTTP_DNS_FAILURE, "localhost", "some-error", isUserRequest = true)
+        val repository = createRepository(loadScheduleStateFlow = flowOf(status))
+        val viewModel = createViewModel(repository)
+        val expectedFailure = FetchFailure(HttpStatus.HTTP_DNS_FAILURE, "localhost", "some-error", isUserRequest = true)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Failure.UserTriggeredFetchFailure)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isEqualTo(expectedFailure)
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `FetchFailure silently posts to loadScheduleUiState property when the user did not trigger the action`() {
+        val status = FetchFailure(HttpStatus.HTTP_DNS_FAILURE, "localhost", "some-error", isUserRequest = false)
+        val repository = createRepository(loadScheduleStateFlow = flowOf(status))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Failure.SilentFetchFailure)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `InitialParsing posts to loadScheduleUiState property`() {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(InitialParsing))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Initializing.InitialParsing)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `Parsing posts to loadScheduleUiState property`() {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(Parsing))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Active.Parsing)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `ParseSuccess posts to loadScheduleUiState property`() {
+        val repository = createRepository(
+            loadScheduleStateFlow = flowOf(ParseSuccess),
+            scheduleChangesSeen = true
+        )
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Success.ParseSuccess)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `ParseSuccess posts to loadScheduleUiState and to scheduleChangesParameter properties`() {
+        val repository = createRepository(
+            loadScheduleStateFlow = flowOf(ParseSuccess),
+            scheduleChangesSeen = false,
+            changedSessions = listOf(Session("changed-01").apply { changedIsNew = true })
+        )
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Success.ParseSuccess)
+        val expectedSessions = listOf(Session("changed-01").apply { changedIsNew = true })
+        val expectedChangeStatistic = ChangeStatistic.of(expectedSessions, logging)
+        val expectedScheduleChangesParameter = ScheduleChangesParameter(scheduleVersion = "", expectedChangeStatistic)
+        assertLiveData(viewModel.scheduleChangesParameter).isEqualTo(expectedScheduleChangesParameter)
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isNull()
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `ParseFailure posts to loadScheduleUiState and parseFailure properties`() {
+        val parseResult = TestParseResult()
+        val repository = createRepository(loadScheduleStateFlow = flowOf(ParseFailure(parseResult)))
+        val viewModel = createViewModel(repository)
+        assertLiveData(viewModel.loadScheduleUiState).isEqualTo(LoadScheduleUiState.Failure.ParseFailure)
+        assertThat(viewModel.scheduleChangesParameter.value).isNull()
+        assertThat(viewModel.fetchFailure.value).isNull()
+        assertThat(viewModel.parseFailure.value).isEqualTo(parseResult)
+        verifyInvokedOnce(repository).loadScheduleState
+    }
+
+    @Test
+    fun `requestScheduleUpdate invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.requestScheduleUpdate(isUserRequest = true)
+        verifyInvokedOnce(repository).loadSchedule(isUserRequest = true, onFetchingDone = {}, onParsingDone = {}, onLoadingShiftsDone = {})
+    }
+
+    @Test
+    fun `cancelLoading invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.cancelLoading()
+        verifyInvokedOnce(repository).cancelLoading()
+    }
+
+    @Test
+    fun `deleteSessionAlarmNotificationId invokes repository function`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.deleteSessionAlarmNotificationId(7)
+        verifyInvokedOnce(repository).deleteSessionAlarmNotificationId(7)
+    }
+
+    @Test
+    fun `showAboutDialog posts to showAbout property`() {
+        val repository = createRepository()
+        val viewModel = createViewModel(repository)
+        viewModel.showAboutDialog()
+        assertLiveData(viewModel.showAbout).isEqualTo(Meta(version = ""))
+    }
+
+    @Test
+    fun `openSessionDetails posts to openSessionDetails property`() {
+        val repository = createRepository(updatedSelectedSessionId = true)
+        val viewModel = createViewModel(repository)
+        viewModel.openSessionDetails("S1")
+        assertLiveData(viewModel.openSessionDetails).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `openSessionDetails does not post to openSessionDetails property`() {
+        val repository = createRepository(updatedSelectedSessionId = false)
+        val viewModel = createViewModel(repository)
+        viewModel.openSessionDetails("S1")
+        assertLiveData(viewModel.openSessionDetails).isNull()
+    }
+
+    private class TestParseResult(
+        override val isSuccess: Boolean = false
+    ) : ParseResult
+
+    private fun createRepository(
+        loadScheduleStateFlow: Flow<LoadScheduleState> = emptyFlow(),
+        scheduleChangesSeen: Boolean = true,
+        changedSessions: List<Session> = emptyList(),
+        updatedSelectedSessionId: Boolean = false
+    ) = mock<AppRepository> {
+        on { loadScheduleState } doReturn loadScheduleStateFlow
+        on { readScheduleChangesSeen() } doReturn scheduleChangesSeen
+        on { readMeta() } doReturn Meta(version = "")
+        on { loadChangedSessions() } doReturn changedSessions
+        on { updateSelectedSessionId(any()) } doReturn updatedSelectedSessionId
+    }
+
+    private fun createViewModel(
+        repository: AppRepository,
+    ) = MainViewModel(
+        repository = repository,
+        executionContext = TestExecutionContext,
+        logging = logging
+    )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -1,11 +1,13 @@
-package nerd.tuxmobil.fahrplan.congress.schedule
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
 
 import androidx.annotation.LayoutRes
+import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.schedule.Conference
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
@@ -1,0 +1,30 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.models.DateInfo
+import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import org.junit.Test
+
+class FahrplanMiscTest {
+
+    @Test
+    fun `createDateInfos returns empty DateInfos`() {
+        assertThat(FahrplanMisc.createDateInfos(emptyList())).isEqualTo(DateInfos())
+    }
+
+    @Test
+    fun `createDateInfos returns DateInfos without duplicates`() {
+        val dateInfos = DateInfos()
+        dateInfos.add(DateInfo(0, Moment.ofEpochMilli(100)))
+        dateInfos.add(DateInfo(1, Moment.ofEpochMilli(200)))
+        dateInfos.add(DateInfo(1, Moment.ofEpochMilli(300)))
+        dateInfos.add(DateInfo(0, Moment.ofEpochMilli(100)))
+        val expectedDateInfos = DateInfos()
+        expectedDateInfos.add(DateInfo(0, Moment.ofEpochMilli(100)))
+        expectedDateInfos.add(DateInfo(1, Moment.ofEpochMilli(200)))
+        expectedDateInfos.add(DateInfo(1, Moment.ofEpochMilli(300)))
+        assertThat(FahrplanMisc.createDateInfos(dateInfos)).isEqualTo(expectedDateInfos)
+    }
+
+}

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -98,8 +98,8 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
 
     private void notifyActivity() {
         if (result) {
-            listener.onUpdateSessions(sessions);
             listener.onUpdateMeta(meta);
+            listener.onUpdateSessions(sessions);
         }
         listener.onParseDone(result, meta.getVersion());
         completed = false;


### PR DESCRIPTION
# Description
+ Unidirectional data flow is now used for the `FahrplanFragment` and `MainActivity`.
+ Flow is used to emit data from the repository to the `ViewModel`.
+ The `AppRepository#uncanceledSessionsForDayIndex` `Flow` is refreshed whenever the schedule or _Engelsystem_ shifts are updated.
+ The `AppRepository#loadScheduleState` `Flow` is updated during fetching, parsing and persisting schedule and _Engelsystem_ shifts.
+ `LiveData` is used to post data from the `ViewModel` to the `Fragment` or `Activity`.
+ Unneeded re-rendering schedule data in a few cases is lost in this branch. See `FahrplanFragment#viewDay` and its `forceReload` parameter in the respective commit.
+ Add a couple of TODOs for follow-up refactorings unrelated to this branch.
+ Fix generating navigation menu entries.
+ Load schedule data only when schedule screen is created.

# Motivation
- This hopefully resolves a couple of random issues which occur when sessions are updated while the user interacts with the UI.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 emulator (tablet), Android 5.1.1 (API 22)
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)

# :construction_worker: TODOs / known issues
- [x] Drop debug logging commit.
- [x] Update KDoc of `FahrplanFragment#viewDay`.
- [x] Day menu does not inflate at first install/start.

# Related
- [Issue #246: Migrate to data driven architecture](https://github.com/EventFahrplan/EventFahrplan/issues/246)
- [Pull request #422: Prepare schedule screen rewrite (unidirectional data flow)](https://github.com/EventFahrplan/EventFahrplan/pull/422)
- [Pull request #414: Let AppRepository be the single source of truth for details screen](https://github.com/EventFahrplan/EventFahrplan/pull/414)
- [Pull request #410: Let AppRepository be the single source of truth for changes screen](https://github.com/EventFahrplan/EventFahrplan/pull/410)
- [Pull request #404: Let AppRepository be the single source of truth for favorites screen](https://github.com/EventFahrplan/EventFahrplan/pull/404)