### PR TITLE
Protect UpdateService work from being interrupted before loading is done.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -140,12 +140,6 @@ public class UpdateService extends SafeJobIntentService {
         workLatch.countDown();
     }
 
-    @Override
-    public void onDestroy() {
-        appRepository.cancelLoading();
-        super.onDestroy();
-    }
-
     private void fetchSchedule() {
         FahrplanMisc.setUpdateAlarm(this, false);
         fetchFahrplan();


### PR DESCRIPTION
# Description
- Clean up logging in `UpdateService`.
- Protect service work from being interrupted before fetching/parsing is done.
  - Without the `CountDownLatch` the `UpdateService` would cancel loading in the `AppRepository` which cancels all jobs over there. This might happen **before** any result reaches the service via the `AppRepository#loadSchedule` callbacks.
  - Don't stop the service - the system will take care of this if the service is no longer needed.
- Stop `UpdateService` from **interrupting** processes triggered by user interaction.
  - Loading (fetching/parsing) is finished when the service is destroyed.
  - Any process running in the `AppRepository` at that moment most likely originates from a user interaction with the UI.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)