### PR TITLE
Ease translation process by excluding library names.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.java
@@ -139,6 +139,11 @@ public class AboutDialog extends DialogFragment {
         String googlePlayListingTitle = getString(R.string.about_google_play_listing);
         TextViewExtensions.setLinkText(googlePlayStore, googlePlayUrl, googlePlayListingTitle, movementMethod, linkTextColor);
 
+        TextView librariesStatement = requireViewByIdCompat(view, R.id.about_libraries_view);
+        String libraryNames = getString(R.string.about_libraries_names);
+        String librariesStatementText = getString(R.string.about_libraries_statement, libraryNames);
+        librariesStatement.setText(librariesStatementText);
+
         TextView dataPrivacyStatement = requireViewByIdCompat(view, R.id.about_data_privacy_statement_view);
         String dataPrivacyStatementGermanUrl = BuildConfig.DATA_PRIVACY_STATEMENT_DE_URL;
         String dataPrivacyStatementGermanTitle = getString(R.string.about_data_privacy_statement_german);

--- a/app/src/main/res/layout/about_dialog.xml
+++ b/app/src/main/res/layout/about_dialog.xml
@@ -171,6 +171,7 @@
         <include layout="@layout/horizontal_line" />
 
         <TextView
+            android:id="@+id/about_libraries_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingLeft="16dp"
@@ -178,7 +179,7 @@
             android:paddingRight="16dp"
             android:paddingBottom="10dp"
             android:singleLine="false"
-            android:text="@string/libraries" />
+            tools:text="@string/about_libraries_statement" />
 
         <include layout="@layout/horizontal_line" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -88,11 +88,9 @@
     <string name="choose_alarm_time">Wähle die Alarmzeit</string>
     <string name="reminders">Alarme</string>
     <string name="usage">Hinweis:\n\nLange auf Vortrag tippen, um einen Alarm einzustellen.</string>
-    <string name="libraries">
-		Die Anwendung nutzt folgende Bibliotheken:
-		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-		Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
-	</string>
+    <string name="about_libraries_statement">
+        Die Anwendung nutzt folgende Bibliotheken: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
+    </string>
     <string name="about_data_privacy_statement_german">Datenschutzerklärung</string>
     <string name="about_f_droid_listing">Eintrag bei F-Droid</string>
     <string name="about_google_play_listing">Eintrag bei Google Play</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -93,10 +93,8 @@
     <string name="choose_alarm_time">Escoja tiempo de alarma</string>
     <string name="reminders">Alarmas</string>
     <string name="usage">Nota:\n\nPresione unos segundos en una clase para poner alarma</string>
-    <string name="libraries">
-      Esta aplicación utiliza las siguientes librerías:
-      Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, 
-      Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
+    <string name="about_libraries_statement">
+        Esta aplicación utiliza las siguientes librerías: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_data_privacy_statement_german">Declaración de privacidad de datos (Alemán)</string>
     <string name="about_f_droid_listing">Listado de F-Droid</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -65,6 +65,7 @@
     <string name="starred_sessions">Favoris</string>
     <string name="general_settings">Général</string>
     <string name="no_favorites">Aucune conférence dans les favoris</string>
+    <string name="about_libraries_statement">Cette application utilise les librairies suivantes : <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g></string>
     <string name="about_data_privacy_statement_german">Déclaration de protection des données (en allemand)</string>
     <string name="about_f_droid_listing">Page sur le F-Droid</string>
     <string name="about_google_play_listing">Page sur le Play Google</string>
@@ -99,7 +100,6 @@
     </string>
     <string name="add_to_calendar_failed">L’ajout de l’évènement au calendrier a échoué.</string>
     <string name="alarms_empty">Il n’y a aucun rappel à afficher. Veuillez noter que vous pouvez définir des rappels individuels pour chaque élément dans le programme. Appuyez simplement sur l’icône du rappel dans la barre d’action.</string>
-    <string name="libraries">Cette application utilise les librairies suivantes : Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid</string>
     <string name="usage">Note :
 \n
 \nAppuyez longuement sur une conférence pour définir un rappel.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="OK">OK</string>
+    <string name="about_libraries_statement">Questa applicazione usa le librerie seguenti: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g></string>
     <string name="about_data_privacy_statement_german">Informativa sulla protezione dei dati (Tedesco)</string>
     <string name="about_issues_or_feature_requests">Assistenza o suggerimento di nuove funzionalità</string>
     <string name="add_to_calendar_failed">Impossibile aggiungere un evento al calendario</string>
@@ -50,7 +51,6 @@
     <string name="session_list_item_no_video_content_description">Senza registrazione video</string>
     <string name="session_list_item_video_content_description">Con registrazione video</string>
     <string name="session_list_item_without_video_content_description">Senza registrazione video</string>
-    <string name="libraries">Questa applicazione usa le librerie seguenti: Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder, Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid</string>
     <string name="load_data">Caricare</string>
     <string name="menu_item_title_about">Info</string>
     <string name="menu_item_title_add_to_calendar">Aggiungere al calendario</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -78,10 +78,8 @@
     <string name="choose_alarm_time">アラーム時間を選択</string>
     <string name="reminders">アラーム</string>
     <string name="usage">注：アラームを設定するには、講義を長押しします。</string>
-    <string name="libraries">
-        このアプリは次のライブラリを使用しています。
-        Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-        Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
+    <string name="about_libraries_statement">
+        このアプリは次のライブラリを使用しています。 <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_data_privacy_statement_german">データプライバシーステートメント（ドイツ語）</string>
     <string name="about_f_droid_listing">F-Droidのリスト</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -83,11 +83,9 @@
     <string name="choose_alarm_time">Kies alarmtijd</string>
     <string name="reminders">Alarmen</string>
     <string name="usage">Tip:\n\nLang indrukken op een evenement om een alarm aan te zetten.</string>
-    <string name="libraries">
-		Deze applicatie gebruikt de volgende software-bibliotheken:
-		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-		Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
-	</string>
+    <string name="about_libraries_statement">
+        Deze applicatie gebruikt de volgende software-bibliotheken: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
+    </string>
     <string name="about_data_privacy_statement_german">Data privacy verklaring (Duits)</string>
     <string name="about_f_droid_listing">F-Droid vermelding</string>
     <string name="about_google_play_listing">Google Play vermelding</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -90,10 +90,8 @@
     <string name="choose_alarm_time">Wybierz czas przypomnienia</string>
     <string name="reminders">Przypomnienia</string>
     <string name="usage">Wskazówka:\n\nPrzytrzymaj dłużej na wykładzie aby ustawić przypomnienie.</string>
-    <string name="libraries">
-        Ten program używa następujących bibliotek:
-        Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-        Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
+    <string name="about_libraries_statement">
+        Ten program używa następujących bibliotek: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_data_privacy_statement_german">Oświadczenie o prywatności danych (w języku niemieckim)</string>
     <string name="about_f_droid_listing">Strona na F-Droid</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -80,11 +80,9 @@
     <string name="choose_alarm_time">Escolha o horário do alerta</string>
     <string name="reminders">Alertas</string>
     <string name="usage">Dica:\n\nMantenha pressionado na palestra para ajustar um alerta.</string>
-    <string name="libraries">
-		Este aplicativo usa as seguintes bibliotecas:
-		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-		Engelsystem, Espresso, Markwon, OkHttp, SnackEngage e TraceDroid
-	</string>
+    <string name="about_libraries_statement">
+        Este aplicativo usa as seguintes bibliotecas: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
+    </string>
     <string name="about_data_privacy_statement_german">Declaração de privacidade (Alemão)</string>
     <string name="about_f_droid_listing">Listagem da F-Droid</string>
     <string name="about_google_play_listing">Listagem da Google Play</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -80,10 +80,8 @@
     <string name="choose_alarm_time">Выбрать время напоминания</string>
     <string name="reminders">Напоминания</string>
     <string name="usage">Примечание:\n\nДолгое нажатие на лекцию установит напоминание.</string>
-    <string name="libraries">
-        Это приложение использует следующие библиотеки:
-        Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-        Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
+    <string name="about_libraries_statement">
+        Это приложение использует следующие библиотеки: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_data_privacy_statement_german">Политика конфиденциальности (German)</string>
     <string name="about_f_droid_listing">Запись в F-Droid</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -66,11 +66,6 @@
     <string name="choose_alarm_time">Välj alarm tid</string>
     <string name="reminders">Alarm</string>
     <string name="usage">Tips: Håll inne på en föreläsning för att sätta ett alarm.</string>
-    <string name="libraries">
-        Denna appen använder följande bibliotek:
-        Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
-        Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
-    </string>
     <string name="schedule_parsing_error_generic">Okänt fel när schemat skulle tolkas</string>
     <string name="schedule_parsing_error_with_version">Tolkningsfel för schema version %s</string>
     <string name="trace_droid_button_title_later">Kanske senare</string>
@@ -103,6 +98,9 @@
     </plurals>
     <string name="schedule_updated_to">
         Uppdaterade till <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g>
+    </string>
+    <string name="about_libraries_statement">
+        Denna appen använder följande bibliotek: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_data_privacy_statement_german">Sekretesspolicy (Tyska)</string>
     <string name="about_f_droid_listing">F-Droid</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,8 +93,10 @@
     <string name="choose_alarm_time">Choose alarm time</string>
     <string name="reminders">Alarms</string>
     <string name="usage">Note:\n\nLong-press on a lecture to set an alarm.</string>
-    <string name="libraries">
-		This application uses the following libraries:
+    <string name="about_libraries_statement">
+        This application uses the following libraries: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
+    </string>
+    <string name="about_libraries_names" translatable="false">
 		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
 	</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
         This application uses the following libraries: <xliff:g example="Kotlin, Espresso" id="libs">%s</xliff:g>
     </string>
     <string name="about_libraries_names" translatable="false">
-		Kotlin, Google Support Library, BetterLinkMovementMethod, Email Intent Builder,
+		Kotlin, Google AndroidX library, BetterLinkMovementMethod, Email Intent Builder,
 		Engelsystem, Espresso, Markwon, OkHttp, SnackEngage, TraceDroid
 	</string>
     <string name="about_data_privacy_statement_german">Data privacy statement (German)</string>


### PR DESCRIPTION
# Description
- Ease translation process by excluding library names.
- Update the name of the Google library being used.

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)