### PR TITLE
Fix crash when tapping feedback icon in details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -35,6 +35,7 @@ import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
+import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -143,7 +144,9 @@ class SessionDetailsFragment : Fragment() {
             updateOptionsMenu()
         }
         viewModel.openFeedBack.observe(viewLifecycleOwner) { uri ->
-            startActivity(Intent(Intent.ACTION_VIEW, uri))
+            requireContext().startActivity(Intent(Intent.ACTION_VIEW, uri)) {
+                Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
+            }
         }
         viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
             SessionSharer.shareSimple(requireContext(), formattedSession)


### PR DESCRIPTION
# Error
- `ActivityNotFoundException`

# Reported on
- Google Pixel 6, Android 12 (SDK 31)

# Stacktrace

``` java
android.content.ActivityNotFoundException: 
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2087)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1747)
  at android.app.Activity.startActivityForResult (Activity.java:5404)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:597)
  at android.app.Activity.startActivityForResult (Activity.java:5362)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:583)
  at android.app.Activity.startActivity (Activity.java:5748)
  at androidx.core.content.ContextCompat$Api16Impl.startActivity (ContextCompat.java:828)
  at androidx.core.content.ContextCompat.startActivity (ContextCompat.java:276)
  at androidx.fragment.app.FragmentHostCallback.onStartActivityFromFragment (FragmentHostCallback.java:166)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1377)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1365)
  at nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment.observeViewModel$lambda-1 (SessionDetailsFragment.kt:146)
  at nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment.$r8$lambda$r_zZ4HlPoGXe7bHlfQR0T-j5g1I (SessionDetailsFragment.kt)
  at nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment$$InternalSyntheticLambda$0$1f18c64cecf2fd62560d8bdc888a82d4cbc97090b9255ed3c187e546a8bad334$1.onChanged (SessionDetailsFragment.java:4)
  at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent.observe$lambda-0 (SingleLiveEvent.kt:35)
  at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent.$r8$lambda$R4VvfbnaBQKPFs7sUmvWf3XXN0M (SingleLiveEvent.kt)
  at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent$$InternalSyntheticLambda$1$e4b55c4c7fcf0d9120a42641b19c3051d936bc9a00692d6a6da39848fab07acc$0.onChanged (SingleLiveEvent.java:4)
  at androidx.lifecycle.LiveData.considerNotify (LiveData.java:133)
  at androidx.lifecycle.LiveData.dispatchingValue (LiveData.java:151)
  at androidx.lifecycle.LiveData.setValue (LiveData.java:309)
  at androidx.lifecycle.MutableLiveData.setValue (MutableLiveData.java:50)
  at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent.setValue (SingleLiveEvent.kt:43)
  at androidx.lifecycle.LiveData$1.run (LiveData.java:93)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:7839)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1003)
```