### PR TITLE
Fix display errors in the favorites scroll bar and the change screen

### DIFF
--- a/app/src/main/res/layout/fragment_favorites_list.xml
+++ b/app/src/main/res/layout/fragment_favorites_list.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="@drawable/favorites_background"
+    android:orientation="vertical"
     tools:context=".changes.ChangeListFragment">
 
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingLeft="@dimen/activity_padding"
         android:paddingRight="@dimen/activity_padding"
         android:scrollbarStyle="outsideOverlay"
-        tools:listitem="@layout/session_list_item"
-        android:layout_height="match_parent"/>
+        tools:listitem="@layout/session_list_item" />
 
     <TextView
         android:id="@android:id/empty"

--- a/app/src/main/res/layout/fragment_favorites_list.xml
+++ b/app/src/main/res/layout/fragment_favorites_list.xml
@@ -13,8 +13,6 @@
         android:layout_width="match_parent"
         android:paddingLeft="@dimen/activity_padding"
         android:paddingRight="@dimen/activity_padding"
-        android:layout_marginLeft="-16dp"
-        android:layout_marginRight="-16dp"
         android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item"
         android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/fragment_favorites_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_favorites_list_narrow.xml
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="@drawable/favorites_background"
+    android:orientation="vertical"
     tools:context=".changes.ChangeListFragment">
 
     <ListView
         android:id="@android:id/list"
-        android:scrollbarStyle="outsideOverlay"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingLeft="@dimen/list_pane_leftright_padding"
         android:paddingRight="@dimen/list_pane_leftright_padding"
-        tools:listitem="@layout/session_list_item"
-        android:layout_height="match_parent"/>
+        android:scrollbarStyle="outsideOverlay"
+        tools:listitem="@layout/session_list_item" />
 
     <TextView
         android:id="@android:id/empty"

--- a/app/src/main/res/layout/fragment_session_list.xml
+++ b/app/src/main/res/layout/fragment_session_list.xml
@@ -13,8 +13,6 @@
         android:layout_width="match_parent"
         android:paddingLeft="@dimen/activity_padding"
         android:paddingRight="@dimen/activity_padding"
-        android:layout_marginLeft="-16dp"
-        android:layout_marginRight="-16dp"
         android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item"
         android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/fragment_session_list.xml
+++ b/app/src/main/res/layout/fragment_session_list.xml
@@ -11,11 +11,11 @@
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingLeft="@dimen/activity_padding"
         android:paddingRight="@dimen/activity_padding"
         android:scrollbarStyle="outsideOverlay"
-        tools:listitem="@layout/session_list_item"
-        android:layout_height="match_parent"/>
+        tools:listitem="@layout/session_list_item" />
 
     <TextView
         android:id="@android:id/empty"

--- a/app/src/main/res/layout/fragment_session_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_session_list_narrow.xml
@@ -10,12 +10,12 @@
 
     <ListView
         android:id="@android:id/list"
-        android:scrollbarStyle="outsideOverlay"
         android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:paddingLeft="@dimen/list_pane_leftright_padding"
         android:paddingRight="@dimen/list_pane_leftright_padding"
-        tools:listitem="@layout/session_list_item"
-        android:layout_height="match_parent"/>
+        android:scrollbarStyle="outsideOverlay"
+        tools:listitem="@layout/session_list_item" />
 
     <TextView
         android:id="@android:id/empty"


### PR DESCRIPTION
# Description
- This pull request addresses issue #7
- Removed some margins that did not seem to affect the layout, but caused the ScrollBars to be moved off the screen and thus not displayed

# Screenshots
- I changed the background color for these shots to gray because the scrollbars are not visible when the background is completely white.
- Also, I am only showing screenshots when the user is scrolling, since thats the only time they are shown.

## Details Page / before and after
![b1](https://user-images.githubusercontent.com/144518/147841918-ef408586-de95-4096-a684-ebc32f15ef34.png) ![a1](https://user-images.githubusercontent.com/144518/147841927-e13bafd9-1b35-45f4-8e42-97c678747422.png)

## Favorites Page / before and after
![b2](https://user-images.githubusercontent.com/144518/147841920-3bc22b8a-dd49-474b-9683-e46fdafecd00.png) ![a2](https://user-images.githubusercontent.com/144518/147841930-2e6f18e3-7e54-4be4-9c97-53754b9c5353.png)

# Testing
- Pixel 2, API lvl 31 Emulator
- Pixel 5, API lvl 24 Emulator
- Pixel 3a API lvl 31

Resolves #7 
