### PR TITLE
Append social media hashtags/handles if present when sharing a session

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,6 +86,7 @@ android {
             buildConfigField "boolean", "ENGAGE_C3NAV_APP_INSTALLATION", "false"
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
+            buildConfigField "String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", '"#camp19 #CCCamp19 #fahrplan"'
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+camp2019@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/camp2019/public/events/%s/feedback/new"'
         }
@@ -111,6 +112,7 @@ android {
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
             resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.de/36c3/shifts-json-export?key=YOUR_KEY\"")
+            buildConfigField "String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", '"#36c3 #fahrplan"'
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+36c3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/36C3/public/events/%s/feedback/new"'
         }
@@ -136,6 +138,7 @@ android {
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
             resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.rc3.world/shifts-json-export?key=YOUR_KEY\"")
+            buildConfigField "String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", '"#rC3 #fahrplan #nowhere"'
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+rc3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/rc3/public/events/%s/feedback/new"'
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.sharing
 
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
@@ -13,11 +14,21 @@ class SimpleSessionFormat {
         const val COMMA = ","
         const val SPACE = " "
         const val HORIZONTAL_DIVIDERS = "---"
+        const val NO_SOCIAL_MEDIA_HASHTAGS_HANDLES = ""
     }
 
-    fun format(session: Session, timeZoneId: ZoneId?): String {
+    fun format(
+        session: Session,
+        timeZoneId: ZoneId?,
+        socialMediaHashtagsHandles: String = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES
+    ): String {
         val builder = StringBuilder()
         builder.appendSession(session, timeZoneId)
+        if (socialMediaHashtagsHandles.isNotEmpty()) {
+            builder.append(LINE_BREAK)
+            builder.append(LINE_BREAK)
+            builder.append(socialMediaHashtagsHandles)
+        }
         return builder.toString()
     }
 
@@ -27,7 +38,7 @@ class SimpleSessionFormat {
         }
         val sessionsSize = sessions.size
         if (sessionsSize == 1) {
-            return format(sessions[0], timeZoneId)
+            return format(sessions[0], timeZoneId, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)
         }
         val builder = StringBuilder()
         for (i in 0 until sessionsSize) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -8,11 +8,11 @@ import org.threeten.bp.ZoneId
 
 class SimpleSessionFormat {
 
-    companion object {
-        private const val LINE_BREAK = "\n"
-        private const val COMMA = ","
-        private const val SPACE = " "
-        private const val HORIZONTAL_DIVIDERS = "---"
+    private companion object {
+        const val LINE_BREAK = "\n"
+        const val COMMA = ","
+        const val SPACE = " "
+        const val HORIZONTAL_DIVIDERS = "---"
     }
 
     fun format(session: Session, timeZoneId: ZoneId?): String {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -238,7 +238,7 @@ class SessionDetailsViewModelTest {
     fun `share() posts to shareSimple what simpleSessionFormat returns`() {
         val repository = createRepository()
         val fakeSessionFormat = mock<SimpleSessionFormat> {
-            on { format(any<Session>(), anyOrNull()) } doReturn "An example session"
+            on { format(any(), anyOrNull(), any()) } doReturn "An example session"
         }
         val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
         viewModel.share()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -223,7 +223,7 @@ class FahrplanViewModelTest {
     fun `share posts to shareSimple property`() {
         val repository = createRepository()
         val fakeSessionFormat = mock<SimpleSessionFormat> {
-            on { format(any<Session>(), anyOrNull()) } doReturn "session-61"
+            on { format(any(), anyOrNull(), any()) } doReturn "session-61"
         }
         val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
         viewModel.share(Session("61"))

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -18,6 +18,8 @@ class SimpleSessionFormatTest {
     private companion object {
         val NO_TIME_ZONE_ID: ZoneId? = null
         val TIME_ZONE_EUROPE_BERLIN: ZoneId = ZoneId.of("Europe/Berlin")
+        const val NO_SOCIAL_MEDIA_HASHTAGS_HANDLES = ""
+        const val SOCIAL_MEDIA_HASHTAGS_HANDLES = "#fahrplan #36c3"
     }
 
     private val systemTimezone = TimeZone.getDefault()
@@ -70,7 +72,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session without time zone name`() {
-        assertThat(SimpleSessionFormat().format(session1, NO_TIME_ZONE_ID)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session1, NO_TIME_ZONE_ID, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
@@ -81,7 +83,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session with time zone name`() {
-        assertThat(SimpleSessionFormat().format(session1, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session1, TIME_ZONE_EUROPE_BERLIN, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
                 """
                 A talk which changes your life
                 Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
@@ -91,8 +93,32 @@ class SimpleSessionFormatTest {
     }
 
     @Test
+    fun `format returns formatted multiline text for a session without social media hashtags`() {
+        assertThat(SimpleSessionFormat().format(session1, NO_TIME_ZONE_ID, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+                $expectedSession1Url
+                """.trimIndent())
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with social media hashtags`() {
+        assertThat(SimpleSessionFormat().format(session1, NO_TIME_ZONE_ID, SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
+                """
+                A talk which changes your life
+                Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+                $expectedSession1Url
+
+                #fahrplan #36c3
+                """.trimIndent())
+    }
+
+    @Test
     fun `format returns formatted multiline text for a wiki session`() {
-        assertThat(SimpleSessionFormat().format(session3, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session3, TIME_ZONE_EUROPE_BERLIN, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
                 """
                 Angel shifts planning
                 Sonntag, 29. Dezember 2019, 09:00 MEZ (Europe/Berlin), Main hall
@@ -135,7 +161,7 @@ class SimpleSessionFormatTest {
 
     @Test
     fun `format returns formatted multiline text for a session in central european summer time`() {
-        assertThat(SimpleSessionFormat().format(session4, TIME_ZONE_EUROPE_BERLIN)).isEqualTo(
+        assertThat(SimpleSessionFormat().format(session4, TIME_ZONE_EUROPE_BERLIN, NO_SOCIAL_MEDIA_HASHTAGS_HANDLES)).isEqualTo(
                 """
                 Central european summer time
                 Sonntag, 1. September 2019, 16:00 MESZ (Europe/Berlin), Sunshine tent

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -14,6 +14,7 @@ This list is for your preparation. Step 3 guides you through where to fill in th
 - Event URL, e.g. `https://awesome-event.com/2021`
 - Start and end date of the event
 - Email address for bug reports
+- Social media hashtags/handles (can be empty), e.g. `#36c3 @ccc`
 - Schedule feedback URL template (optional), e.g. `https://awesome-event.com/2021/events/%s/feedback/new`
 - Engelsystem URL (optional), e.g. `https://engelsystem.de/awesome-event/shifts-json-export?key=YOUR_KEY`
 
@@ -71,6 +72,7 @@ In some of the steps it is the easiest to copy and adapt configuration settings,
 
 The following options can be enabled via a `buildConfigField` and configured in *app/build.gradle* if needed.
 
+- Social media hashtags/handles for the event via `SOCIAL_MEDIA_HASHTAGS_HANDLES`
 - Alternative schedule URL via `ENABLE_ALTERNATIVE_SCHEDULE_URL`
 - c3nav integration via `C3NAV_URL`
 - Chaosflix export via `ENABLE_CHAOSFLIX_EXPORT`


### PR DESCRIPTION
# Description
- Append one or multiple hashtags and/or social media handles if present.
- The hashtags/handles must be configured in the respective build flavor.

# Before and after
Tweet without hashtags/handles / Tweet with automatically added hashtags/handles
  ![Tweet without hashtags/handles](https://user-images.githubusercontent.com/144518/148365995-e44a365e-d6dc-4287-863b-fd3eeb7c4849.png) ![Tweet with automatically added hashtags/handles](https://user-images.githubusercontent.com/144518/148366046-0ee85a8e-f434-44e5-acc8-ca1b3127257c.png)