### PR TITLE
Random housekeeping + changes dialog translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/EventFahrplan/EventFahrplan.svg?branch=master)](https://travis-ci.com/EventFahrplan/EventFahrplan) [![Apache License](http://img.shields.io/badge/license-Apache%20License%202.0-lightgrey.svg)](http://choosealicense.com/licenses/apache-2.0/)
+[![Build Status](https://app.travis-ci.com/EventFahrplan/EventFahrplan.svg?branch=master)](https://app.travis-ci.com/EventFahrplan/EventFahrplan) [![Apache License](http://img.shields.io/badge/license-Apache%20License%202.0-lightgrey.svg)](http://choosealicense.com/licenses/apache-2.0/)
 
 # EventFahrplan
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,12 +28,12 @@ android {
         resValue("string", "git_sha", "\"${gitSha()}\"")
 
         // Build configuration / feature flags
-        buildConfigField "String", "F_DROID_URL", "\"\""
-        buildConfigField "String", "SOURCE_CODE_URL", "\"https://github.com/EventFahrplan/EventFahrplan\""
-        buildConfigField "String", "ISSUES_URL", "\"https://github.com/EventFahrplan/EventFahrplan/issues\""
-        buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", "\"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md\""
-        resValue("string", "preference_hint_engelsystem_json_export_url", "\"\"")
-        buildConfigField "String", "C3NAV_URL", "\"\""
+        buildConfigField "String", "F_DROID_URL", '""'
+        buildConfigField "String", "SOURCE_CODE_URL", '"https://github.com/EventFahrplan/EventFahrplan"'
+        buildConfigField "String", "ISSUES_URL", '"https://github.com/EventFahrplan/EventFahrplan/issues"'
+        buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", '"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md"'
+        resValue("string", "preference_hint_engelsystem_json_export_url", '""')
+        buildConfigField "String", "C3NAV_URL", '""'
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "true"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "true"
         buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "false"
@@ -49,10 +49,10 @@ android {
         release {
             zipAlignEnabled true
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'),
-                    'proguard-rules/proguard-project.txt',
-                    'proguard-rules/okhttp3.pro',
-                    'proguard-rules/okio.pro'
+            proguardFiles getDefaultProguardFile("proguard-android.txt"),
+                    "proguard-rules/proguard-project.txt",
+                    "proguard-rules/okhttp3.pro",
+                    "proguard-rules/okio.pro"
         }
     }
 
@@ -71,7 +71,7 @@ android {
             applicationId "info.metadude.android.cccamp.schedule"
             versionName "${defaultConfig.versionName}-CCCamp-Edition"
             buildConfigField "String", "GOOGLE_PLAY_URL", '"https://play.google.com/store/apps/details?id=info.metadude.android.cccamp.schedule"'
-            buildConfigField "String", "F_DROID_URL", "\"\""
+            buildConfigField "String", "F_DROID_URL", '""'
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/camp2019/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"http://events.ccc.de/camp/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"http://events.ccc.de/camp/2019/"'
@@ -94,7 +94,7 @@ android {
             dimension defaultDimension
             applicationId "info.metadude.android.congress.schedule"
             buildConfigField "String", "GOOGLE_PLAY_URL", '"https://play.google.com/store/apps/details?id=info.metadude.android.congress.schedule"'
-            buildConfigField "String", "F_DROID_URL", "\"https://f-droid.org/packages/info.metadude.android.congress.schedule\""
+            buildConfigField "String", "F_DROID_URL", '"https://f-droid.org/packages/info.metadude.android.congress.schedule"'
             buildConfigField "String", "SCHEDULE_URL", '"https://raw.githubusercontent.com/voc/36C3_schedule/master/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://events.ccc.de/congress/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"https://events.ccc.de/congress/2019/wiki"'
@@ -107,11 +107,11 @@ android {
             buildConfigField "int", "SCHEDULE_LAST_DAY_END_DAY", "31"
             buildConfigField "boolean", "SHOW_APP_DISCLAIMER", "false"
             buildConfigField "boolean", "ENGAGE_C3NAV_APP_INSTALLATION", "true"
-            buildConfigField "String", "C3NAV_URL", "\"https://36c3.c3nav.de/l/\""
+            buildConfigField "String", "C3NAV_URL", '"https://36c3.c3nav.de/l/"'
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
-            resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.de/36c3/shifts-json-export?key=YOUR_KEY\"")
+            resValue("string", "preference_hint_engelsystem_json_export_url", '"https://engelsystem.de/36c3/shifts-json-export?key=YOUR_KEY"')
             buildConfigField "String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", '"#36c3 #fahrplan"'
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+36c3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/36C3/public/events/%s/feedback/new"'
@@ -137,7 +137,7 @@ android {
             buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
             buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
             buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "true"
-            resValue("string", "preference_hint_engelsystem_json_export_url", "\"https://engelsystem.rc3.world/shifts-json-export?key=YOUR_KEY\"")
+            resValue("string", "preference_hint_engelsystem_json_export_url", '"https://engelsystem.rc3.world/shifts-json-export?key=YOUR_KEY"')
             buildConfigField "String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", '"#rC3 #fahrplan #nowhere"'
             buildConfigField "String", "TRACE_DROID_EMAIL_ADDRESS", '"tobias.preuss+rc3@googlemail.com"'
             buildConfigField "String", "SCHEDULE_FEEDBACK_URL", '"https://frab.cccv.de/en/rc3/public/events/%s/feedback/new"'
@@ -225,8 +225,8 @@ dependencies {
 }
 
 def gitSha() {
-    def res = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
-    def diff = 'git diff'.execute([], project.rootDir).text.trim()
+    def res = "git rev-parse --short HEAD".execute([], project.rootDir).text.trim()
+    def diff = "git diff".execute([], project.rootDir).text.trim()
     if (diff != null && diff.length() > 0) {
         res += "-dirty"
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangesDialog.java
@@ -86,7 +86,10 @@ public class ChangesDialog extends DialogFragment {
         span.append(getString(R.string.schedule_changes_dialog_changed_new_cancelled_text,
                 resources.getQuantityString(R.plurals.schedule_changes_dialog_number_of_sessions, changed, changed),
                 resources.getQuantityString(R.plurals.schedule_changes_dialog_being, added, added),
-                resources.getQuantityString(R.plurals.schedule_changes_dialog_being, cancelled, cancelled)));
+                resources.getQuantityString(R.plurals.schedule_changes_dialog_phrase_new, added),
+                resources.getQuantityString(R.plurals.schedule_changes_dialog_being, cancelled, cancelled),
+                resources.getQuantityString(R.plurals.schedule_changes_dialog_phrase_cancelled, cancelled)
+        ));
         changes1.setText(span);
 
         TextView changes2 = requireViewByIdCompat(msgView, R.id.schedule_changes_dialog_changes_text_view);

--- a/app/src/main/res/layout/fragment_favorites_list.xml
+++ b/app/src/main/res/layout/fragment_favorites_list.xml
@@ -11,8 +11,6 @@
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingLeft="@dimen/activity_padding"
-        android:paddingRight="@dimen/activity_padding"
         android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 

--- a/app/src/main/res/layout/fragment_session_list.xml
+++ b/app/src/main/res/layout/fragment_session_list.xml
@@ -12,8 +12,6 @@
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingLeft="@dimen/activity_padding"
-        android:paddingRight="@dimen/activity_padding"
         android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -56,8 +56,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Fahrplanaktualisierung</string>
     <string name="schedule_changes_dialog_updated_to_text">Der Fahrplan wurde auf Version\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">\u0020aktualisiert. Es gibt Änderungen in <xliff:g example="3 Vorträgen" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 sind" id="num_new">%2$s</xliff:g> neu, <xliff:g example="1 ist" id="num_canceled">%3$s</xliff:g> gestrichen.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">\u0020aktualisiert. Es gibt Änderungen in <xliff:g example="3 Vorträgen" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 sind" id="num_new">%2$s</xliff:g> <xliff:g example="neu" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 ist" id="num_canceled">%4$s</xliff:g> <xliff:g example="gestrichen" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">Die Änderungen betreffen <xliff:g example="2" id="num_marked">%1$d</xliff:g> der favorisierten Vorträge.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">neu</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">gestrichen</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> Vortrag</item>
         <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> Vorträgen</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -58,9 +58,15 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Actulización de calendario</string>
     <string name="schedule_changes_dialog_updated_to_text">El calendario ha sido actualizado a\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Hay cambios en <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> nuevas, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancelada</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Hay cambios en <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="nuevas" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="cancelada" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">Los cambios afectan <xliff:g example="2" id="num_marked">%1$d</xliff:g> de tus clases favoritas</string>
-        <plurals name="schedule_changes_dialog_number_of_sessions">
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">nuevas</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">cancelada</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> clase</item>
         <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> clases</item>
     </plurals>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -23,7 +23,13 @@
         <item quantity="other">%d conférences</item>
     </plurals>
     <string name="schedule_changes_dialog_affected_text">Les modifications affectent <xliff:g example="2" id="num_marked">%1$d</xliff:g> de vos conférences favorites.</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Il y a eu des changements dans <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> nouvelle(s), <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> annulée(s).</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Il y a eu des changements dans <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="nouvelle(s)" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="annulée(s)" id="phrase_cancelled">%5$s</xliff:g>.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">nouvelle(s)</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">annulée(s)</item>
+    </plurals>
     <string name="dlg_err_failed_ssl_failure">Échec SSL</string>
     <string name="dlg_err_failed_wrong_http_credentials">Authentification HTTP non valide</string>
     <string name="dlg_err_failed_unknown_host">Adresse inconnue :

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -83,7 +83,13 @@
     <string name="schedule_changes">Cambiamenti di programma</string>
     <string name="schedule_changes_dialog_affected_text">I cambiamenti riguardano <xliff:g example="2" id="num_marked">%1$d</xliff:g> delle tue conferenze preferite.</string>
     <string name="schedule_changes_dialog_browse">Sfogliare</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Ci sono delle modiche per <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> nuove, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancellate.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Ci sono delle modiche per <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="nuove" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="cancellate" id="phrase_cancelled">%5$s</xliff:g>.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">nuove</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">cancellate</item>
+    </plurals>
     <string name="schedule_changes_dialog_later">Dopo</string>
     <string name="schedule_changes_dialog_title">Aggiornamento del programma</string>
     <string name="schedule_changes_dialog_updated_to_text">Il programma è stato aggiornato a </string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -92,7 +92,7 @@
     </plurals>
     <string name="schedule_changes_dialog_later">Dopo</string>
     <string name="schedule_changes_dialog_title">Aggiornamento del programma</string>
-    <string name="schedule_changes_dialog_updated_to_text">Il programma è stato aggiornato a </string>
+    <string name="schedule_changes_dialog_updated_to_text">Il programma è stato aggiornato a\u0020</string>
     <string name="schedule_updated">Il programma è stato aggiornato.</string>
     <string name="schedule_updated_to">Aggiornato a <xliff:g example="Mildenberg 2018-01-16 16:50" id="version">%s</xliff:g></string>
     <string name="settings">Preferenze</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,8 +48,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">スケジュールを更新</string>
     <string name="schedule_changes_dialog_updated_to_text">スケジュールが更新されました。</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text"><xliff:g example="3個の講義" id="num_changes">%1$s</xliff:g>に変更があります。 <xliff:g example="2 " id="num_new">%2$s</xliff:g> 新しく, <xliff:g example="1 が" id="num_canceled">%3$s</xliff:g> キャンセルされました。</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text"><xliff:g example="3個の講義" id="num_changes">%1$s</xliff:g>に変更があります。 <xliff:g example="2 " id="num_new">%2$s</xliff:g> <xliff:g example="新しく" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 が" id="num_canceled">%4$s</xliff:g> <xliff:g example="キャンセルされました" id="phrase_cancelled">%5$s</xliff:g>。</string>
     <string name="schedule_changes_dialog_affected_text">変更は、お気に入りの講義の<xliff:g example="2" id="num_marked">%1$d</xliff:g>個に影響します。</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">新しく</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">キャンセルされました</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="other">%d 個の講義</item>
     </plurals>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -48,7 +48,7 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">スケジュールを更新</string>
     <string name="schedule_changes_dialog_updated_to_text">スケジュールが更新されました。</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text"><xliff:g example="3個の講義" id="num_changes">%1$s</xliff:g>に変更があります。 <xliff:g example="2 " id="num_new">%2$s</xliff:g> <xliff:g example="新しく" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 が" id="num_canceled">%4$s</xliff:g> <xliff:g example="キャンセルされました" id="phrase_cancelled">%5$s</xliff:g>。</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">\u0020<xliff:g example="3個の講義" id="num_changes">%1$s</xliff:g>に変更があります。 <xliff:g example="2 " id="num_new">%2$s</xliff:g> <xliff:g example="新しく" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 が" id="num_canceled">%4$s</xliff:g> <xliff:g example="キャンセルされました" id="phrase_cancelled">%5$s</xliff:g>。</string>
     <string name="schedule_changes_dialog_affected_text">変更は、お気に入りの講義の<xliff:g example="2" id="num_marked">%1$d</xliff:g>個に影響します。</string>
     <plurals name="schedule_changes_dialog_phrase_new">
         <item quantity="other">新しく</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -51,8 +51,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Tijdschema update</string>
     <string name="schedule_changes_dialog_updated_to_text">Tijdschema is geupdate naar versie\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Er zijn updates voor <xliff:g example="3 evenementen" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 zijn" id="num_new">%2$s</xliff:g> nieuw, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> geannuleerd.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Er zijn updates voor <xliff:g example="3 evenementen" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 zijn" id="num_new">%2$s</xliff:g> <xliff:g example="nieuw" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="geannuleerd" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">De update betreft <xliff:g example="2" id="num_marked">%1$d</xliff:g> van uw favorieten evenementen.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">nieuw</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">geannuleerd</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one">%d evenement</item>
         <item quantity="other">%d evenementen</item>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -56,8 +56,18 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Aktualizacja grafiku</string>
     <string name="schedule_changes_dialog_updated_to_text">Zaktualizowano grafik do wersji\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Są zmiany w <xliff:g example="3 wykładach" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 są" id="num_new">%2$s</xliff:g> nowe, <xliff:g example="1 jest" id="num_canceled">%3$s</xliff:g> anulowany.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Są zmiany w <xliff:g example="3 wykładach" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 są" id="num_new">%2$s</xliff:g> <xliff:g example="nowe" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 jest" id="num_canceled">%4$s</xliff:g> <xliff:g example="anulowany" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">Zmiany dotyczą <xliff:g example="2" id="num_marked">%1$d</xliff:g> twoich ulubionych wykładów.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="one">nowy</item>
+        <item quantity="few">nowe</item>
+        <item quantity="many">nowych</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="one">anulowany</item>
+        <item quantity="few">anulowane</item>
+        <item quantity="many">anulowanych</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> wykładzie</item>
         <item quantity="few"><xliff:g example="3" id="count">%d</xliff:g> wykładach</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -48,8 +48,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Atualização de cronograma</string>
     <string name="schedule_changes_dialog_updated_to_text">O cronograma foi atualizado para\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Há alterações em <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> novos, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancelados.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Há alterações em <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="novos" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="cancelados" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">As alterações afetam <xliff:g example="2" id="num_marked">%1$d</xliff:g> das suas palestras favoritas.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">novos</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">cancelados</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one">%d palestra</item>
         <item quantity="other">%d palestras</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -44,8 +44,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Обновление расписания</string>
     <string name="schedule_changes_dialog_updated_to_text">Расписание обновлено до\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Нет изменений в <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> новые, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> отменены.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Нет изменений в <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="новые" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="отменены" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">Изменения затронули <xliff:g example="2" id="num_marked">%1$d</xliff:g> из вашего списка избранных.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">новые</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">отменены</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one">%d лекция</item>
         <item quantity="few">%d лекции</item>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -86,8 +86,14 @@
     <string name="dlg_err_failed_wrong_http_credentials">Ogiltlig HTTP-autentisering</string>
     <string name="menu_item_title_share_session">Dela händelse</string>
     <string name="menu_item_title_share_favorites">Deka favoriter</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Det är ändringar i <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> new, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancelled.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. Det är ändringar i <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="new" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="cancelled" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">Dessa ändringar påverkar <xliff:g example="2" id="num_marked">%1$d</xliff:g> av dina favoriserade föreläsningar.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">new</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">cancelled</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one">%d föreläsning</item>
         <item quantity="other">%d föreläsningar</item>

--- a/app/src/main/res/values-sw600dp-port/dimens.xml
+++ b/app/src/main/res/values-sw600dp-port/dimens.xml
@@ -17,7 +17,6 @@
     <item type="integer" name="box_height">18</item>
     <item type="integer" name="max_cols">4</item>
     <dimen name="time_width">38dp</dimen>
-    <dimen name="activity_padding">48dp</dimen>
     <dimen name="list_pane_leftright_padding">64dp</dimen>
     <dimen name="header_height">16dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -20,7 +20,6 @@
     <item type="integer" name="min_width_dip">160</item>
     <item type="integer" name="room_title_size">16</item>
     <dimen name="list_pane_leftright_padding">32dp</dimen>
-    <dimen name="activity_padding">80dp</dimen>
     <dimen name="header_height">16dp</dimen>
 
     <!-- Session details text sizes -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -20,7 +20,6 @@
     <item type="integer" name="min_width_dip">160</item>
     <item type="integer" name="room_title_size">14</item>
     <dimen name="list_pane_leftright_padding">16dp</dimen>
-    <dimen name="activity_padding">16dp</dimen>
     <dimen name="header_height">0dp</dimen>
 
     <!-- Alarm list -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,8 +58,14 @@
     <!-- Schedule changes dialog -->
     <string name="schedule_changes_dialog_title">Schedule update</string>
     <string name="schedule_changes_dialog_updated_to_text">The schedule has been updated to\u0020</string>
-    <string name="schedule_changes_dialog_changed_new_cancelled_text">. There are changes in <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> new, <xliff:g example="1 is" id="num_canceled">%3$s</xliff:g> cancelled.</string>
+    <string name="schedule_changes_dialog_changed_new_cancelled_text">. There are changes in <xliff:g example="3 lectures" id="num_changes">%1$s</xliff:g>, <xliff:g example="2 are" id="num_new">%2$s</xliff:g> <xliff:g example="new" id="phrase_new">%3$s</xliff:g>, <xliff:g example="1 is" id="num_canceled">%4$s</xliff:g> <xliff:g example="cancelled" id="phrase_cancelled">%5$s</xliff:g>.</string>
     <string name="schedule_changes_dialog_affected_text">The changes affect <xliff:g example="2" id="num_marked">%1$d</xliff:g> of your favored lectures.</string>
+    <plurals name="schedule_changes_dialog_phrase_new">
+        <item quantity="other">new</item>
+    </plurals>
+    <plurals name="schedule_changes_dialog_phrase_cancelled">
+        <item quantity="other">cancelled</item>
+    </plurals>
     <plurals name="schedule_changes_dialog_number_of_sessions">
         <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> lecture</item>
         <item quantity="other"><xliff:g example="9" id="count">%d</xliff:g> lectures</item>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
+        gradlePluginPortal()
     }
     dependencies {
         classpath Plugins.android

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -11,6 +11,7 @@ This list is for your preparation. Step 3 guides you through where to fill in th
 - Session URL template, e.g. `https://awesome-event.com/2021/events/%1$s.html`
 - Server backend type, one of: `pentabarf`, `frab`, `pretalx`
 - Google Play URL, e.g. `https://play.google.com/store/apps/details?id=com.awesome.event.schedule`
+- F-Droid URL, e.g. `https://f-droid.org/packages/com.awesome.event.schedule`
 - Event URL, e.g. `https://awesome-event.com/2021`
 - Start and end date of the event
 - Email address for bug reports


### PR DESCRIPTION
# Description
- Fix Travis CI badge URLs.
- Mention F-Droid URL in customization guide.
- Use built-in repository function.
- Improve maintainability of build script.
- Fix session item layout in favorites and schedule changes screens.

## Improve translation of changes dialog text
+ Allow to decline "new" and "cancelled".
+ Add missing dot in Spanish sentence.
+ Improve Polish translation. See https://github.com/EventFahrplan/EventFahrplan/pull/426#issuecomment-993809900.
- TODOs:
  + French and Swedish translations are incomplete.
  + The "new" and "cancelled" phrases might have to be declined in other languages.

# Polish: before and after
![36c3-pl1](https://user-images.githubusercontent.com/144518/148644870-b36eccf9-246f-4542-8156-f5062a1dff5c.png) ![36c3-pl2](https://user-images.githubusercontent.com/144518/148846411-25c6c0f9-f326-48d9-b89b-c46a331f78d4.png)

# Other languages: after
![36c3-de2](https://user-images.githubusercontent.com/144518/148646502-6bc71e75-9f51-4120-847e-a305d556bfde.png)
![36c3-es2](https://user-images.githubusercontent.com/144518/148646503-c6e1a489-74b7-4645-8c1e-861d94121255.png)
![36c3-fr2](https://user-images.githubusercontent.com/144518/148646505-4aa7a1bb-e833-4edb-8372-95f43dd12ade.png)
![36c3-it2](https://user-images.githubusercontent.com/144518/148646506-8afc6418-2002-4a1b-98fa-275e840dac80.png)
![36c3-ja2](https://user-images.githubusercontent.com/144518/148646507-de781ef2-a009-4232-aafc-9000bfac619f.png)
![36c3-nl2](https://user-images.githubusercontent.com/144518/148646509-21f3880c-31d4-4d01-bf56-6e0ce58e4205.png)
![36c3-pt2](https://user-images.githubusercontent.com/144518/148646510-ba2dfcd0-8b58-4488-a056-d139333794b9.png)
![36c3-ru2](https://user-images.githubusercontent.com/144518/148646511-4345eb75-e18c-4220-8456-0251dc243926.png)
![36c3-sv2](https://user-images.githubusercontent.com/144518/148646512-801b8db2-3093-4f98-bd20-8910f1087275.png)
