### PR TITLE
Housekeeping for session item text colors

### DIFF
--- a/app/src/ccc36c3/res/values/colors_congress.xml
+++ b/app/src/ccc36c3/res/values/colors_congress.xml
@@ -35,7 +35,4 @@
     <color name="track_background_highlight_security">#de697e</color>
     <color name="track_background_highlight_self_organized_sessions">#4174ff</color>
 
-    <!-- Track color -->
-    <color name="track_name">#beffffff</color>
-
 </resources>

--- a/app/src/ccc36c3/res/values/colors_congress.xml
+++ b/app/src/ccc36c3/res/values/colors_congress.xml
@@ -38,8 +38,4 @@
     <!-- Track color -->
     <color name="track_name">#beffffff</color>
 
-    <!-- Title color -->
-    <color name="session_title_on_default_background">#a0ffffff</color>
-    <color name="session_title_on_highlight_background">#fff</color>
-
 </resources>

--- a/app/src/cccamp2019/res/values/colors_congress.xml
+++ b/app/src/cccamp2019/res/values/colors_congress.xml
@@ -34,8 +34,4 @@
     <!-- Track color -->
     <color name="track_name">#c8ffffff</color>
 
-    <!--Title color-->
-    <color name="session_title_on_default_background">#a0ffffff</color>
-    <color name="session_title_on_highlight_background">#fff</color>
-
 </resources>

--- a/app/src/cccamp2019/res/values/colors_congress.xml
+++ b/app/src/cccamp2019/res/values/colors_congress.xml
@@ -31,7 +31,4 @@
     <color name="track_background_highlight_talk">#B3714B</color>
     <color name="track_background_highlight_workshop">#A8B34B</color>
 
-    <!-- Track color -->
-    <color name="track_name">#c8ffffff</color>
-
 </resources>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -109,6 +109,7 @@ internal class SessionViewDrawer @JvmOverloads constructor(
             val title = view.requireViewByIdCompat<TextView>(R.id.session_title_view)
             val subtitle = view.requireViewByIdCompat<TextView>(R.id.session_subtitle_view)
             val speakers = view.requireViewByIdCompat<TextView>(R.id.session_speakers_view)
+            val track = view.requireViewByIdCompat<TextView>(R.id.session_track_view)
             val colorResId = if (session.highlight)
                 R.color.session_item_text_on_highlight_background
             else
@@ -117,6 +118,7 @@ internal class SessionViewDrawer @JvmOverloads constructor(
             title.setTextColor(textColor)
             subtitle.setTextColor(textColor)
             speakers.setTextColor(textColor)
+            track.setTextColor(textColor)
         }
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -110,9 +110,9 @@ internal class SessionViewDrawer @JvmOverloads constructor(
             val subtitle = view.requireViewByIdCompat<TextView>(R.id.session_subtitle_view)
             val speakers = view.requireViewByIdCompat<TextView>(R.id.session_speakers_view)
             val colorResId = if (session.highlight)
-                R.color.session_title_on_highlight_background
+                R.color.session_item_text_on_highlight_background
             else
-                R.color.session_title_on_default_background
+                R.color.session_item_text_on_default_background
             val textColor = ContextCompat.getColor(view.context, colorResId)
             title.setTextColor(textColor)
             subtitle.setTextColor(textColor)

--- a/app/src/main/res/layout-port/session_layout.xml
+++ b/app/src/main/res/layout-port/session_layout.xml
@@ -1,92 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              android:padding="10dp">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="10dp">
 
     <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
-                android:id="@+id/session_title_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:textColor="@color/session_title_on_default_background"
-                android:textSize="16sp"
-                android:layout_weight="1"
-                android:textStyle="bold"
-                tools:text="@string/placeholder_session_title">
-        </TextView>
+            android:id="@+id/session_title_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/session_title_on_default_background"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            tools:text="@string/placeholder_session_title" />
 
         <ImageView
-                android:id="@+id/session_no_video_view"
-                android:layout_width="wrap_content"
-                android:layout_height="13sp"
-                android:layout_marginLeft="3dp"
-                android:adjustViewBounds="true"
-                android:baseline="12sp"
-                android:scaleType="fitEnd"
-                android:src="@drawable/ic_novideo">
-
-        </ImageView>
+            android:id="@+id/session_no_video_view"
+            android:layout_width="wrap_content"
+            android:layout_height="13sp"
+            android:layout_marginLeft="3dp"
+            android:adjustViewBounds="true"
+            android:baseline="12sp"
+            android:scaleType="fitEnd"
+            android:src="@drawable/ic_novideo" />
 
         <ImageView
-                android:id="@+id/session_bell_view"
-                android:layout_width="wrap_content"
-                android:layout_height="13sp"
-                android:layout_marginLeft="3dp"
-                android:adjustViewBounds="true"
-                android:baseline="12sp"
-                android:scaleType="fitEnd"
-                android:src="@drawable/bell">
+            android:id="@+id/session_bell_view"
+            android:layout_width="wrap_content"
+            android:layout_height="13sp"
+            android:layout_marginLeft="3dp"
+            android:adjustViewBounds="true"
+            android:baseline="12sp"
+            android:scaleType="fitEnd"
+            android:src="@drawable/bell" />
 
-        </ImageView>
     </LinearLayout>
 
     <TextView
-            android:id="@+id/session_subtitle_view"
-            android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
-            android:layout_weight="1"
-            android:fontFamily="sans-serif-light"
-            android:textColor="@color/session_title_on_default_background"
-            android:textSize="12sp"
-            tools:text="@string/placeholder_session_subtitle"/>
+        android:id="@+id/session_subtitle_view"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-light"
+        android:textColor="@color/session_title_on_default_background"
+        android:textSize="12sp"
+        tools:text="@string/placeholder_session_subtitle" />
 
     <LinearLayout
-            android:layout_width="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom">
+
+        <TextView
+            android:id="@+id/session_speakers_view"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="bottom">
+            android:layout_weight="0.6"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:paddingRight="10dp"
+            android:singleLine="true"
+            android:textColor="@color/session_title_on_default_background"
+            android:textSize="11sp"
+            tools:text="@string/placeholder_session_speakers" />
 
         <TextView
-                android:id="@+id/session_speakers_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.6"
-                android:ellipsize="end"
-                android:fontFamily="sans-serif-condensed"
-                android:paddingRight="10dp"
-                android:singleLine="true"
-                android:textColor="@color/session_title_on_default_background"
-                android:textSize="11sp"
-                tools:text="@string/placeholder_session_speakers"/>
-
-        <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.4"
-                android:ellipsize="start"
-                android:fontFamily="sans-serif-condensed"
-                android:gravity="end"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:textSize="11sp"
-                tools:text="@string/placeholder_session_track"/>
+            android:id="@+id/session_track_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.4"
+            android:ellipsize="start"
+            android:fontFamily="sans-serif-condensed"
+            android:gravity="end"
+            android:singleLine="true"
+            android:textColor="@color/track_name"
+            android:textSize="11sp"
+            tools:text="@string/placeholder_session_track" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout-port/session_layout.xml
+++ b/app/src/main/res/layout-port/session_layout.xml
@@ -80,7 +80,7 @@
             android:fontFamily="sans-serif-condensed"
             android:gravity="end"
             android:singleLine="true"
-            android:textColor="@color/track_name"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="11sp"
             tools:text="@string/placeholder_session_track" />
 

--- a/app/src/main/res/layout-port/session_layout.xml
+++ b/app/src/main/res/layout-port/session_layout.xml
@@ -16,7 +16,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="@color/session_title_on_default_background"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="16sp"
             android:textStyle="bold"
             tools:text="@string/placeholder_session_title" />
@@ -49,7 +49,7 @@
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:fontFamily="sans-serif-light"
-        android:textColor="@color/session_title_on_default_background"
+        android:textColor="@color/session_item_text_on_default_background"
         android:textSize="12sp"
         tools:text="@string/placeholder_session_subtitle" />
 
@@ -67,7 +67,7 @@
             android:fontFamily="sans-serif-condensed"
             android:paddingRight="10dp"
             android:singleLine="true"
-            android:textColor="@color/session_title_on_default_background"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="11sp"
             tools:text="@string/placeholder_session_speakers" />
 

--- a/app/src/main/res/layout/session_layout_land.xml
+++ b/app/src/main/res/layout/session_layout_land.xml
@@ -80,7 +80,7 @@
             android:fontFamily="sans-serif-condensed"
             android:gravity="end"
             android:singleLine="true"
-            android:textColor="@color/track_name"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="8sp"
             tools:text="@string/placeholder_session_track" />
 

--- a/app/src/main/res/layout/session_layout_land.xml
+++ b/app/src/main/res/layout/session_layout_land.xml
@@ -16,7 +16,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="#000000"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="12sp"
             android:textStyle="bold"
             tools:text="@string/placeholder_session_title" />
@@ -49,7 +49,7 @@
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:fontFamily="sans-serif-light"
-        android:textColor="#000000"
+        android:textColor="@color/session_item_text_on_default_background"
         android:textSize="9sp"
         tools:text="@string/placeholder_session_subtitle" />
 
@@ -67,7 +67,7 @@
             android:fontFamily="sans-serif-condensed"
             android:paddingRight="10dp"
             android:singleLine="true"
-            android:textColor="#000000"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="8sp"
             tools:text="@string/placeholder_session_speakers" />
 

--- a/app/src/main/res/layout/session_layout_land.xml
+++ b/app/src/main/res/layout/session_layout_land.xml
@@ -1,92 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              android:padding="10dp">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="10dp">
 
     <LinearLayout
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:orientation="horizontal">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
-                android:id="@+id/session_title_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:textStyle="bold"
-                android:textColor="#000000"
-                android:layout_weight="1"
-                android:textSize="12sp"
-                tools:text="@string/placeholder_session_title"
-                />
+            android:id="@+id/session_title_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="#000000"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            tools:text="@string/placeholder_session_title" />
 
         <ImageView
-                android:id="@+id/session_no_video_view"
-                android:layout_width="wrap_content"
-                android:layout_height="9sp"
-                android:layout_marginLeft="3dp"
-                android:adjustViewBounds="true"
-                android:scaleType="fitEnd"
-                android:baseline="8sp"
-                android:src="@drawable/ic_novideo">
-
-        </ImageView>
+            android:id="@+id/session_no_video_view"
+            android:layout_width="wrap_content"
+            android:layout_height="9sp"
+            android:layout_marginLeft="3dp"
+            android:adjustViewBounds="true"
+            android:baseline="8sp"
+            android:scaleType="fitEnd"
+            android:src="@drawable/ic_novideo" />
 
         <ImageView
-                android:id="@+id/session_bell_view"
-                android:layout_width="wrap_content"
-                android:layout_height="9sp"
-                android:layout_marginLeft="3dp"
-                android:adjustViewBounds="true"
-                android:scaleType="fitEnd"
-                android:baseline="8sp"
-                android:src="@drawable/bell">
+            android:id="@+id/session_bell_view"
+            android:layout_width="wrap_content"
+            android:layout_height="9sp"
+            android:layout_marginLeft="3dp"
+            android:adjustViewBounds="true"
+            android:baseline="8sp"
+            android:scaleType="fitEnd"
+            android:src="@drawable/bell" />
 
-        </ImageView>
     </LinearLayout>
 
     <TextView
-            android:id="@+id/session_subtitle_view"
-            android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
-            android:layout_weight="1"
-            android:textColor="#000000"
-            android:fontFamily="sans-serif-light"
-            android:textSize="9sp"
-            tools:text="@string/placeholder_session_subtitle"/>
+        android:id="@+id/session_subtitle_view"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-light"
+        android:textColor="#000000"
+        android:textSize="9sp"
+        tools:text="@string/placeholder_session_subtitle" />
 
     <LinearLayout
-            android:layout_width="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom">
+
+        <TextView
+            android:id="@+id/session_speakers_view"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="bottom">
+            android:layout_weight="0.6"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:paddingRight="10dp"
+            android:singleLine="true"
+            android:textColor="#000000"
+            android:textSize="8sp"
+            tools:text="@string/placeholder_session_speakers" />
 
         <TextView
-                android:id="@+id/session_speakers_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.6"
-                android:ellipsize="end"
-                android:fontFamily="sans-serif-condensed"
-                android:paddingRight="10dp"
-                android:singleLine="true"
-                android:textColor="#000000"
-                android:textSize="8sp"
-                tools:text="@string/placeholder_session_speakers" />
-
-        <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.4"
-                android:ellipsize="start"
-                android:fontFamily="sans-serif-condensed"
-                android:gravity="end"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:textSize="8sp"
-                tools:text="@string/placeholder_session_track"/>
+            android:id="@+id/session_track_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.4"
+            android:ellipsize="start"
+            android:fontFamily="sans-serif-condensed"
+            android:gravity="end"
+            android:singleLine="true"
+            android:textColor="@color/track_name"
+            android:textSize="8sp"
+            tools:text="@string/placeholder_session_track" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/session_layout_land_large.xml
+++ b/app/src/main/res/layout/session_layout_land_large.xml
@@ -1,91 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:layout_width="200dp"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              android:padding="10dp">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="200dp"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="10dp">
 
     <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
-                android:id="@+id/session_title_view"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:layout_height="wrap_content"
-                android:textColor="#000000"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                tools:text="@string/placeholder_session_title">
-        </TextView>
+            android:id="@+id/session_title_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="#000000"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            tools:text="@string/placeholder_session_title" />
 
         <ImageView
-                android:id="@+id/session_no_video_view"
-                android:layout_width="wrap_content"
-                android:layout_height="16sp"
-                android:layout_marginLeft="5dp"
-                android:adjustViewBounds="true"
-                android:baseline="15sp"
-                android:src="@drawable/ic_novideo">
-
-        </ImageView>
+            android:id="@+id/session_no_video_view"
+            android:layout_width="wrap_content"
+            android:layout_height="16sp"
+            android:layout_marginLeft="5dp"
+            android:adjustViewBounds="true"
+            android:baseline="15sp"
+            android:src="@drawable/ic_novideo" />
 
         <ImageView
-                android:id="@+id/session_bell_view"
-                android:layout_width="wrap_content"
-                android:layout_height="16sp"
-                android:layout_marginLeft="5dp"
-                android:adjustViewBounds="true"
-                android:baseline="14sp"
-                android:src="@drawable/bell">
+            android:id="@+id/session_bell_view"
+            android:layout_width="wrap_content"
+            android:layout_height="16sp"
+            android:layout_marginLeft="5dp"
+            android:adjustViewBounds="true"
+            android:baseline="14sp"
+            android:src="@drawable/bell" />
 
-        </ImageView>
     </LinearLayout>
 
     <TextView
-            android:id="@+id/session_subtitle_view"
-            android:layout_width="wrap_content"
-            android:layout_height="fill_parent"
-            android:layout_weight="1"
-            android:textColor="#000000"
-            android:textSize="15sp"
-            android:fontFamily="sans-serif-light"
-            tools:text="@string/placeholder_session_subtitle"
-            />
+        android:id="@+id/session_subtitle_view"
+        android:layout_width="wrap_content"
+        android:layout_height="fill_parent"
+        android:layout_weight="1"
+        android:fontFamily="sans-serif-light"
+        android:textColor="#000000"
+        android:textSize="15sp"
+        tools:text="@string/placeholder_session_subtitle" />
 
     <LinearLayout
-            android:layout_width="match_parent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom">
+
+        <TextView
+            android:id="@+id/session_speakers_view"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:gravity="bottom">
+            android:layout_weight="0.6"
+            android:ellipsize="end"
+            android:fontFamily="sans-serif-condensed"
+            android:paddingRight="10dp"
+            android:singleLine="true"
+            android:textColor="#000000"
+            android:textSize="13sp"
+            tools:text="@string/placeholder_session_speakers" />
 
         <TextView
-                android:id="@+id/session_speakers_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.6"
-                android:ellipsize="end"
-                android:fontFamily="sans-serif-condensed"
-                android:paddingRight="10dp"
-                android:singleLine="true"
-                android:textColor="#000000"
-                android:textSize="13sp"
-                tools:text="@string/placeholder_session_speakers" />
-
-        <TextView
-                android:id="@+id/session_track_view"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="0.4"
-                android:ellipsize="start"
-                android:fontFamily="sans-serif-condensed"
-                android:gravity="end"
-                android:singleLine="true"
-                android:textColor="@color/track_name"
-                android:textSize="13sp"
-                tools:text="@string/placeholder_session_track" />
+            android:id="@+id/session_track_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.4"
+            android:ellipsize="start"
+            android:fontFamily="sans-serif-condensed"
+            android:gravity="end"
+            android:singleLine="true"
+            android:textColor="@color/track_name"
+            android:textSize="13sp"
+            tools:text="@string/placeholder_session_track" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/session_layout_land_large.xml
+++ b/app/src/main/res/layout/session_layout_land_large.xml
@@ -16,7 +16,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textColor="#000000"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="20sp"
             android:textStyle="bold"
             tools:text="@string/placeholder_session_title" />
@@ -47,7 +47,7 @@
         android:layout_height="fill_parent"
         android:layout_weight="1"
         android:fontFamily="sans-serif-light"
-        android:textColor="#000000"
+        android:textColor="@color/session_item_text_on_default_background"
         android:textSize="15sp"
         tools:text="@string/placeholder_session_subtitle" />
 
@@ -65,7 +65,7 @@
             android:fontFamily="sans-serif-condensed"
             android:paddingRight="10dp"
             android:singleLine="true"
-            android:textColor="#000000"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="13sp"
             tools:text="@string/placeholder_session_speakers" />
 

--- a/app/src/main/res/layout/session_layout_land_large.xml
+++ b/app/src/main/res/layout/session_layout_land_large.xml
@@ -78,7 +78,7 @@
             android:fontFamily="sans-serif-condensed"
             android:gravity="end"
             android:singleLine="true"
-            android:textColor="@color/track_name"
+            android:textColor="@color/session_item_text_on_default_background"
             android:textSize="13sp"
             tools:text="@string/placeholder_session_track" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -35,6 +35,8 @@
     <color name="schedule_time_column_item_text_emphasized">#000</color>
     <color name="schedule_room_name_header_background">#000</color>
     <color name="schedule_room_name_header_text">#fff</color>
+    <color name="session_title_on_default_background">#a0ffffff</color>
+    <color name="session_title_on_highlight_background">#fff</color>
 
     <!-- Schedule changes dialog -->
     <color name="schedule_changes_dialog_new_version_text">@color/colorAccent</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -35,8 +35,8 @@
     <color name="schedule_time_column_item_text_emphasized">#000</color>
     <color name="schedule_room_name_header_background">#000</color>
     <color name="schedule_room_name_header_text">#fff</color>
-    <color name="session_title_on_default_background">#a0ffffff</color>
-    <color name="session_title_on_highlight_background">#fff</color>
+    <color name="session_item_text_on_default_background">#a0ffffff</color>
+    <color name="session_item_text_on_highlight_background">#fff</color>
 
     <!-- Schedule changes dialog -->
     <color name="schedule_changes_dialog_new_version_text">@color/colorAccent</color>

--- a/app/src/rc3/res/values/colors_congress.xml
+++ b/app/src/rc3/res/values/colors_congress.xml
@@ -93,7 +93,4 @@
     <color name="track_background_highlight_workshop">#33691E</color>
     <color name="track_background_highlight_zuerich_bitwaescherei">#B7ACF1</color>
 
-    <!-- Track color -->
-    <color name="track_name">#beffffff</color>
-
 </resources>

--- a/app/src/rc3/res/values/colors_congress.xml
+++ b/app/src/rc3/res/values/colors_congress.xml
@@ -96,8 +96,4 @@
     <!-- Track color -->
     <color name="track_name">#beffffff</color>
 
-    <!-- Title color -->
-    <color name="session_title_on_default_background">#a0ffffff</color>
-    <color name="session_title_on_highlight_background">#fff</color>
-
 </resources>


### PR DESCRIPTION
# Description
- Define session item text colors in `main` build flavor. These colors are seldom customized so default values make sense.
- Improve misleading color resource names.
- Use same text color for "track" as for other session item texts.
- Also use session item text color for landscape layouts.

# Before and after screenshots
![before](https://user-images.githubusercontent.com/144518/149679018-10d6205f-da99-4986-a0d4-1ee251300ca4.png) ![after](https://user-images.githubusercontent.com/144518/149679022-b08cb282-804c-4809-8422-592059387d6b.png)


# Successfully tested on
with `ccc36c3`, `cccamp2019`, `rc3` and `fosdem2022` flavors, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)