### PR TITLE
Changed "Thomaeum Kempen" to "isi_ko404"

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,12 @@ Copyright 2011-2015 Daniel Dorau
 Contributions from 0x5ubt13, Adriano Pereira Junior, Akarsh Seggemu,
 Andrea Marziali, Andy Scherzinger, Andreas Schildbach, Animesh Verma,
 bashtian, bjoernb, Björn Olsson Jarl, ButterflyOfFire, cacarrara,
-Caio Volpato, cketti, codingcatgirl, entropynil, ideadapt, Jasper van der Graaf,
-Joergi, koelnkalkverbot, Larissa Yasin, ligi, Luis Azcuaga, Mateus Baptista,
-Matthias Geisler, Matthias Hunstock, MichaelRocks, Nghiem Xuan Hien, NiciDieNase,
-Noemis, Omicron, Poschi, rotrot, Sjors van Mierlo, Stefan Medack, SubOptimal,
-Teeranai.P, Thomaeum Kempen, Torsten Grote, Victor Herasme, Vladimir Alabov, Yanicka
+Caio Volpato, cketti, codingcatgirl, entropynil, ideadapt, isi_ko404, 
+Jasper van der Graaf, Joergi, koelnkalkverbot, Larissa Yasin, ligi, 
+Luis Azcuaga, Mateus Baptista, Matthias Geisler, Matthias Hunstock,
+MichaelRocks, Nghiem Xuan Hien, NiciDieNase, Noemis, Omicron, Poschi,
+rotrot, Sjors van Mierlo, Stefan Medack, SubOptimal, Teeranai.P,
+Torsten Grote, Victor Herasme, Vladimir Alabov, Yanicka
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="copyright_notes" translatable="false">
         Copyright 2013-2022 johnjohndoe.
         \nCopyright 2011-2015 Daniel Dorau.
-        \nContributions from 0x5ubt13, Adriano Pereira Junior, Akarsh Seggemu, Andrea Marziali, Andy Scherzinger, Andreas Schildbach, Animesh Verma, bashtian, bjoernb, Björn Olsson Jarl, ButterflyOfFire, cacarrara, Caio Volpato, cketti, codingcatgirl, entropynil, ideadapt, Jasper van der Graaf, Joergi, koelnkalkverbot, Larissa Yasin, ligi, Luis Azcuaga, Mateus Baptista, Matthias Geisler, Matthias Hunstock, MichaelRocks, Nghiem Xuan Hien, NiciDieNase, Noemis, Omicron, Poschi, rotrot, Sjors van Mierlo, Stefan Medack, SubOptimal, Teeranai.P, Thomaeum Kempen, Torsten Grote, Victor Herasme, Vladimir Alabov, Yanicka.
+        \nContributions from 0x5ubt13, Adriano Pereira Junior, Akarsh Seggemu, Andrea Marziali, Andy Scherzinger, Andreas Schildbach, Animesh Verma, bashtian, bjoernb, Björn Olsson Jarl, ButterflyOfFire, cacarrara, Caio Volpato, cketti, codingcatgirl, entropynil, ideadapt, isi_ko404, Jasper van der Graaf, Joergi, koelnkalkverbot, Larissa Yasin, ligi, Luis Azcuaga, Mateus Baptista, Matthias Geisler, Matthias Hunstock, MichaelRocks, Nghiem Xuan Hien, NiciDieNase, Noemis, Omicron, Poschi, rotrot, Sjors van Mierlo, Stefan Medack, SubOptimal, Teeranai.P, Torsten Grote, Victor Herasme, Vladimir Alabov, Yanicka.
         \nPortions Copyright 2008-2011 The K-9 Dog Walkers and 2006-2013 the Android Open Source Project.
     </string>
     <string name="today">today</string>


### PR DESCRIPTION
# Description
Changed the mention of "Thomaeum Kempen" as a contributor to "isi_ko404", as Thomaeum is just my school.

(see: 84cb16892ff37d1b2940f512c327e9dd5c4585c7)