### PR TITLE
Adding custom scrollbar

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.java
@@ -41,7 +41,7 @@ public abstract class SessionsAdapter extends ArrayAdapter<Session> {
 
     protected SessionsAdapter(Context context, @LayoutRes int layout, List<Session> list, int numDays, boolean useDeviceTimeZone) {
         super(context, layout, list);
-        this.context = new ContextThemeWrapper(context, R.style.Theme_AppCompat_Light);
+        this.context = new ContextThemeWrapper(context, R.style.Theme_Congress_NoActionBar);
         this.list = list;
         this.numDays = numDays;
         this.useDeviceTimeZone = useDeviceTimeZone;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -61,7 +61,7 @@ class ChangeListFragment : AbstractListFragment() {
         val arguments = requireArguments()
         val sidePane = arguments.getBoolean(BundleKeys.SIDEPANE)
 
-        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_AppCompat_Light)
+        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress_NoActionBar)
         val localInflater = inflater.cloneInContext(contextThemeWrapper)
         val (fragmentLayout, headerLayout) = when {
             sidePane -> R.layout.fragment_session_list_narrow to R.layout.changes_header

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -95,7 +95,7 @@ class StarredListFragment :
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_AppCompat_Light)
+        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress_NoActionBar)
         val localInflater = inflater.cloneInContext(contextThemeWrapper)
         val view: View
         val header: View

--- a/app/src/main/res/drawable/scrollbar_thumb.xml
+++ b/app/src/main/res/drawable/scrollbar_thumb.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/scrollbar_background" />
+    <corners android:radius="@dimen/scrollbar_corner_radius" />
+</shape>

--- a/app/src/main/res/layout/alarms.xml
+++ b/app/src/main/res/layout/alarms.xml
@@ -12,7 +12,6 @@
             android:id="@android:id/list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbarStyle="outsideOverlay"
             tools:listitem="@layout/alarm_list_item">
     </ListView>
 

--- a/app/src/main/res/layout/fragment_favorites_list.xml
+++ b/app/src/main/res/layout/fragment_favorites_list.xml
@@ -11,7 +11,6 @@
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 
     <TextView

--- a/app/src/main/res/layout/fragment_favorites_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_favorites_list_narrow.xml
@@ -13,7 +13,6 @@
         android:layout_height="match_parent"
         android:paddingLeft="@dimen/list_pane_leftright_padding"
         android:paddingRight="@dimen/list_pane_leftright_padding"
-        android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 
     <TextView

--- a/app/src/main/res/layout/fragment_session_list.xml
+++ b/app/src/main/res/layout/fragment_session_list.xml
@@ -12,7 +12,6 @@
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 
     <TextView

--- a/app/src/main/res/layout/fragment_session_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_session_list_narrow.xml
@@ -14,7 +14,6 @@
         android:layout_height="match_parent"
         android:paddingLeft="@dimen/list_pane_leftright_padding"
         android:paddingRight="@dimen/list_pane_leftright_padding"
-        android:scrollbarStyle="outsideOverlay"
         tools:listitem="@layout/session_list_item" />
 
     <TextView

--- a/app/src/main/res/layout/session_detailbar.xml
+++ b/app/src/main/res/layout/session_detailbar.xml
@@ -5,8 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/session_detailbar_background"
-    android:paddingTop="4dp"
-    android:paddingBottom="4dp">
+    android:paddingVertical="4dp"
+    android:paddingHorizontal="16dp">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/session_detailbar_date_time_view"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,6 +15,9 @@
     <color name="session_detailbar_background">#eee</color>
     <color name="session_detailbar_text">#999</color>
 
+    <!-- Scrollbar -->
+    <color name="scrollbar_background">@color/colorAccent</color>
+
     <!-- MainActivity layout -->
     <color name="main_background">@android:color/transparent</color>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,6 +21,15 @@
     <dimen name="list_pane_leftright_padding">16dp</dimen>
     <dimen name="header_height">0dp</dimen>
 
+    <!-- Scrollbar -->
+    <!--
+    If you use a value greater than 16dp make sure to adjust the padding
+    in session_detailbar.xml and session_list_item.xml
+    -->
+    <dimen name="scrollbar_size">5.0dp</dimen>
+    <!-- Should be half of scrollbar_size at maximum -->
+    <dimen name="scrollbar_corner_radius">0dp</dimen>
+
     <!-- Alarm list -->
     <dimen name="alarm_list_icon_stroke_width">2dp</dimen>
     <dimen name="alarm_list_icon_width">40dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2010 Johan Nilsson <http://markupartist.com>
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2010 Johan Nilsson <http://markupartist.com>
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -14,11 +13,11 @@
      limitations under the License.
 -->
 <resources>
-    <item type="integer" name="box_height">13</item>
-    <item type="integer" name="max_cols">1</item>
+    <item name="box_height" type="integer">13</item>
+    <item name="max_cols" type="integer">1</item>
     <dimen name="time_width">38dp</dimen>
-    <item type="integer" name="min_width_dip">160</item>
-    <item type="integer" name="room_title_size">14</item>
+    <item name="min_width_dip" type="integer">160</item>
+    <item name="room_title_size" type="integer">14</item>
     <dimen name="list_pane_leftright_padding">16dp</dimen>
     <dimen name="header_height">0dp</dimen>
 

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -17,6 +17,11 @@
         <item name="alertDialogTheme">@style/AlertDialog</item>
         <item name="android:windowBackground">@drawable/window_background</item>
         <item name="android:spinnerItemStyle">@style/SpinnerItemStyle</item>
+
+        <!-- Scrollbar -->
+        <item name="android:scrollbarSize">@dimen/scrollbar_size</item>
+        <item name="android:scrollbarThumbVertical">@drawable/scrollbar_thumb</item>
+        <item name="android:scrollbarThumbHorizontal">@drawable/scrollbar_thumb</item>
     </style>
 
     <style name="Theme.Congress.NoActionBar" parent="Theme.AppCompat.NoActionBar">
@@ -35,6 +40,11 @@
         <item name="actionModeBackground">@color/colorPrimary</item>
         <item name="alertDialogTheme">@style/AlertDialog</item>
         <item name="android:windowBackground">@drawable/window_background</item>
+
+        <!-- Scrollbar -->
+        <item name="android:scrollbarSize">@dimen/scrollbar_size</item>
+        <item name="android:scrollbarThumbVertical">@drawable/scrollbar_thumb</item>
+        <item name="android:scrollbarThumbHorizontal">@drawable/scrollbar_thumb</item>
     </style>
 
     <style name="ContextPopupMenuStyle" parent="@style/Widget.AppCompat.Light.PopupMenu.Overflow">
@@ -51,6 +61,11 @@
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
         <item name="android:textColorHighlight">@color/text_link_pressed_background_on_dark</item>
         <item name="android:windowBackground">@drawable/window_background</item>
+
+        <!-- Scrollbar -->
+        <item name="android:scrollbarSize">@dimen/scrollbar_size</item>
+        <item name="android:scrollbarThumbVertical">@drawable/scrollbar_thumb</item>
+        <item name="android:scrollbarThumbHorizontal">@drawable/scrollbar_thumb</item>
     </style>
 
     <style name="ToolBar">

--- a/app/src/rc3/res/values/colors.xml
+++ b/app/src/rc3/res/values/colors.xml
@@ -17,6 +17,7 @@
     <color name="session_detailbar_background">@color/colorPrimaryDark</color>
     <color name="session_detailbar_text">@color/colorAccent</color>
     <color name="session_detailbar_icon">#A358EE</color>
+    <color name="scrollbar_background">#88EE6558</color>
 
     <!-- Schedule screen -->
     <color name="schedule_time_column_background">#30000000</color>


### PR DESCRIPTION
# Description
 - fixing issue #441 by adding a custom drawable for the scrollbar
 - The color of the scrollbar can be customized via the color resources, by default the accent color is used
 - Automatically applied to all screens via themes, so it looks the same anywhere in the app
 - also added horizontal padding to the detail bar 
    - The padding always is the width of the scrollbar to prevent the content from overlapping with the scrollbar

# Before
Just the default scrollbar provided by Android
![sScreenshot 2022-01-19 220954](https://user-images.githubusercontent.com/44641688/150215542-72cbb860-a7cf-48a9-b092-817d78e5c030.png)


# After
Added the custom scrollbar, in this case just using the default color
![a](https://user-images.githubusercontent.com/44641688/150217737-30487dec-ed90-4058-bfe5-8e48fc34d839.png)

# Testing
- Pixel 3a API lvl 31
- Pixel 2, API lvl 31 Emulator
- Pixel 5, API lvl 24 Emulator
- Nexus 9 API lvl 30 Emulator

Resolves #441 
Resolves #440 
