### PR TITLE
Fix crash when attempting to send stacktrace.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/reporting/TraceDroidEmailSender.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/reporting/TraceDroidEmailSender.java
@@ -11,6 +11,8 @@ import androidx.appcompat.app.AlertDialog;
 import org.ligi.tracedroid.TraceDroid;
 import org.ligi.tracedroid.collecting.TraceDroidMetaInfo;
 
+import java.io.File;
+
 import de.cketti.mailto.EmailIntentBuilder;
 import nerd.tuxmobil.fahrplan.congress.BuildConfig;
 import nerd.tuxmobil.fahrplan.congress.R;
@@ -21,7 +23,8 @@ import nerd.tuxmobil.fahrplan.congress.R;
 public abstract class TraceDroidEmailSender {
 
     public static void sendStackTraces(@NonNull final Activity context) {
-        if (TraceDroid.getStackTraceFiles().length < 1) {
+        File[] stackTraceFiles = TraceDroid.getStackTraceFiles();
+        if (stackTraceFiles == null || stackTraceFiles.length < 1) {
             return;
         }
 


### PR DESCRIPTION
+ Error: `NullPointerException: Attempt to get length of null array`
+ Reported on: Redmi/Lineage 18.1
+ Stacktrace:

  ``` kotlin
  java.lang.NullPointerException: Attempt to get length of null array
    at nerd.tuxmobil.fahrplan.congress.reporting.TraceDroidEmailSender.sendStackTraces(TraceDroidEmailSender.java:24)
    at nerd.tuxmobil.fahrplan.congress.schedule.MainActivity.onCreate(MainActivity.kt:131)
  ```