### PR TITLE
Only show horizontal progress bar when schedule loading takes longer.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -11,7 +11,6 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.widget.ProgressBar
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
@@ -19,8 +18,8 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
-import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.core.widget.ContentLoadingProgressBar
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.OnBackStackChangedListener
@@ -92,7 +91,7 @@ class MainActivity : BaseActivity(),
 
     private lateinit var keyguardManager: KeyguardManager
     private lateinit var errorMessageFactory: ErrorMessage.Factory
-    private lateinit var progressBar: ProgressBar
+    private lateinit var progressBar: ContentLoadingProgressBar
     private var progressDialog: ProgressDialog? = null
     private val viewModel: MainViewModel by viewModels { MainViewModelFactory(AppRepository) }
 
@@ -169,7 +168,11 @@ class MainActivity : BaseActivity(),
         } else {
             hideProgressDialog()
         }
-        progressBar.isInvisible = uiState !is LoadScheduleUiState.Active
+        if (uiState is LoadScheduleUiState.Active) {
+            progressBar.show()
+        } else {
+            progressBar.hide()
+        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/res/layout-port/main_layout.xml
+++ b/app/src/main/res/layout-port/main_layout.xml
@@ -11,7 +11,7 @@
         style="@style/ToolBar"
         app:contentInsetStart="@dimen/tool_bar_content_inset_start" />
 
-    <ProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress"
         style="@style/ProgressBar"
         android:layout_below="@id/toolbar"

--- a/app/src/main/res/layout/main_layout_land.xml
+++ b/app/src/main/res/layout/main_layout_land.xml
@@ -11,7 +11,7 @@
         style="@style/ToolBar"
         app:contentInsetStart="@dimen/tool_bar_content_inset_start" />
 
-    <ProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress"
         style="@style/ProgressBar"
         android:layout_below="@id/toolbar"

--- a/app/src/main/res/layout/main_layout_land_large.xml
+++ b/app/src/main/res/layout/main_layout_land_large.xml
@@ -11,7 +11,7 @@
         style="@style/ToolBar"
         app:contentInsetStart="@dimen/tool_bar_content_inset_start" />
 
-    <ProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress"
         style="@style/ProgressBar"
         android:layout_below="@id/toolbar"

--- a/app/src/main/res/layout/main_layout_land_large_split.xml
+++ b/app/src/main/res/layout/main_layout_land_large_split.xml
@@ -11,7 +11,7 @@
         style="@style/ToolBar"
         app:contentInsetStart="@dimen/tool_bar_content_inset_start" />
 
-    <ProgressBar
+    <androidx.core.widget.ContentLoadingProgressBar
         android:id="@+id/progress"
         style="@style/ProgressBar"
         android:layout_below="@id/toolbar"


### PR DESCRIPTION
# Description
+ The [ContentLoadingProgressBar](https://developer.android.com/reference/androidx/core/widget/ContentLoadingProgressBar) prevents visual flicker.
+ Affects the progress bar shown when manually refreshing the schedule by tapping the "Refresh" menu item.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)