### PR TITLE
Add initial GitHub workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+name: Build
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+            
+      - name: Build the app
+        run: ./gradlew assemble
+
+      - name: Unit Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 16
+          script: ./gradlew testRc3DebugUnitTest assembleRc3Debug lintAnalyzeRc3Debug
+
+      - name: Publish unit-test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: |
+            build/test-results/**/*.xml
+            */build/test-results/**/*.xml
+
+  android_tests:
+    # see https://github.com/reactivecircus/android-emulator-runner,
+    # needs to run on macos as only there virtualization is available!
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+
+      - name: Instrumentation Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 16
+          script: ./gradlew connectedCheck
+
+      - name: Publish unit-test results
+        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        if: always()
+        with:
+          files: |
+            build/test-results/**/*.xml
+            */build/test-results/**/*.xml
+            */build/outputs/androidTest-results/connected/*.xml

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -215,7 +215,10 @@ dependencies {
     }
     testImplementation Libs.coreTesting
     testImplementation Libs.junit
-    testImplementation Libs.kotlinCoroutinesTest
+    testImplementation (Libs.kotlinCoroutinesTest) {
+        // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
     testImplementation Libs.mockitoCore
     testImplementation Libs.threeTenBp
     testImplementation Libs.truth

--- a/commons-testing/build.gradle
+++ b/commons-testing/build.gradle
@@ -31,7 +31,10 @@ android {
 dependencies {
 
     implementation Libs.junit
-    implementation Libs.kotlinCoroutinesTest
+    implementation (Libs.kotlinCoroutinesTest) {
+        // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
     implementation Libs.liveDataKtx
     implementation Libs.truth
     api Libs.mockitoKotlin


### PR DESCRIPTION
# Description

This adds an initial Github workflow to build and test EventFahrplan.

It adds a single workflow which adds two builds, one for normal building and testing and a 2nd for running tests with an Android Emulator. At the end, failing test-results are published so that you can analyze failures in more detail.

It uses debug-build for now similar to the Travis-CI build, switching to release-build is discussed in #85 and is kept as 2nd step.

More build-targets can be added easily by adding them to the `./gradlew`-command.

I had to add a workaround for a build-error `2 files found with path win32-x86/attach_hotspot_windows.dll'.`. Without it building failed both locally and in the Github Workflow. See https://github.com/Kotlin/kotlinx.coroutines/issues/2023 for details about the workaround.

You can see successful executions in the forked repository at https://github.com/centic9/EventFahrplan/actions
