### PR TITLE
Replace deprecated target fragment API with FragmentResultListener API.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -52,7 +52,7 @@ class SessionDetailsFragment : Fragment() {
 
         private const val LOG_TAG = "SessionDetailsFragment"
         const val FRAGMENT_TAG = "detail"
-        const val SESSION_DETAILS_FRAGMENT_REQUEST_CODE = 546
+        private const val SESSION_DETAILS_FRAGMENT_REQUEST_KEY = "SESSION_DETAILS_FRAGMENT_REQUEST_KEY"
         private const val SCHEDULE_FEEDBACK_URL = BuildConfig.SCHEDULE_FEEDBACK_URL
         private val SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL)
 
@@ -161,7 +161,14 @@ class SessionDetailsFragment : Fragment() {
             CalendarSharing(requireContext()).addToCalendar(session)
         }
         viewModel.setAlarm.observe(viewLifecycleOwner) {
-            AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_CODE)
+            AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_KEY) { requestKey, result ->
+                if (requestKey == SESSION_DETAILS_FRAGMENT_REQUEST_KEY &&
+                    result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                ) {
+                    val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                    viewModel.addAlarm(alarmTimesIndex)
+                }
+            }
         }
         viewModel.navigateToRoom.observe(viewLifecycleOwner) { uri ->
             startActivity(Intent(Intent.ACTION_VIEW, uri))
@@ -330,17 +337,6 @@ class SessionDetailsFragment : Fragment() {
             menu.findItem(R.id.menu_item_share_session)
         }
         item?.let { it.isVisible = true }
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == SESSION_DETAILS_FRAGMENT_REQUEST_CODE &&
-                resultCode == AlarmTimePickerFragment.ALERT_TIME_PICKED_RESULT_CODE &&
-                data != null
-        ) {
-            val alarmTimesIndex = data.getIntExtra(AlarmTimePickerFragment.ALARM_PICKED_INTENT_KEY, 0)
-            viewModel.addAlarm(alarmTimesIndex)
-        }
-        super.onActivityResult(requestCode, resultCode, data)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -447,7 +447,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     override fun onContextItemSelected(item: MenuItem): Boolean {
         val menuItemIndex = item.itemId
         val session = contextMenuView.tag as Session
-        lastSelectedSession = session
+        lastSelectedSession = session // FIXME NPE on rotation while alarm time picker is opened
         MyApp.LogDebug(LOG_TAG, "clicked on ${(contextMenuView.tag as Session).sessionId}")
         val context = requireContext()
         when (menuItemIndex) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
 import android.content.Context
-import android.content.Intent
 import android.graphics.Typeface
 import android.os.Build
 import android.os.Bundle
@@ -77,7 +76,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
         private const val LOG_TAG = "FahrplanFragment"
         const val FRAGMENT_TAG = "schedule"
-        const val FAHRPLAN_FRAGMENT_REQUEST_CODE = 6166
+        private const val FAHRPLAN_FRAGMENT_REQUEST_KEY = "FAHRPLAN_FRAGMENT_REQUEST_KEY"
 
         private const val CONTEXT_MENU_ITEM_ID_FAVORITES = 0
         private const val CONTEXT_MENU_ITEM_ID_SET_ALARM = 1
@@ -421,16 +420,15 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         actionBar.setListNavigationCallbacks(arrayAdapter, OnDaySelectedListener(numDays))
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if (requestCode == FAHRPLAN_FRAGMENT_REQUEST_CODE && resultCode == AlarmTimePickerFragment.ALERT_TIME_PICKED_RESULT_CODE && data != null) {
-            val alarmTimesIndex = data.getIntExtra(AlarmTimePickerFragment.ALARM_PICKED_INTENT_KEY, 0)
-            onAlarmTimesIndexPicked(alarmTimesIndex)
-        }
-        super.onActivityResult(requestCode, resultCode, data)
-    }
-
     private fun showAlarmTimePicker() {
-        AlarmTimePickerFragment.show(this, FAHRPLAN_FRAGMENT_REQUEST_CODE)
+        AlarmTimePickerFragment.show(this, FAHRPLAN_FRAGMENT_REQUEST_KEY) { requestKey, result ->
+            if (requestKey == FAHRPLAN_FRAGMENT_REQUEST_KEY &&
+                result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+            ) {
+                val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                onAlarmTimesIndexPicked(alarmTimesIndex)
+            }
+        }
     }
 
     private fun onAlarmTimesIndexPicked(alarmTimesIndex: Int) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -70,9 +70,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             if (isAutoUpdateEnabled) {
                 FahrplanMisc.setUpdateAlarm(requireContext(), true)
             } else {
-                with(requireActivity()) {
-                    AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm()
-                }
+                AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm()
             }
             true
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConfirmationDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConfirmationDialog.kt
@@ -1,10 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
-import android.app.Dialog
 import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
-
 import androidx.annotation.CallSuper
 import androidx.annotation.MainThread
 import androidx.annotation.StringRes

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.schedule.observables
 
 import androidx.annotation.LayoutRes
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R


### PR DESCRIPTION
# Description
- Replace deprecated target fragment API with `FragmentResultListener` API.
- Add note to fix `NullPointerException`.
- Random housekeeping.

## Deprecation warnings

``` java
app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java:45: 
  warning: [deprecation] setTargetFragment(Fragment,int) in Fragment has been deprecated
        dialogFragment.setTargetFragment(invokingFragment, requestCode);
                      ^
app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java:87: 
  warning: [deprecation] getTargetFragment() in Fragment has been deprecated
        Fragment fragment = getTargetFragment();
                            ^
app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java:91: 
  warning: [deprecation] getTargetRequestCode() in Fragment has been deprecated
        fragment.onActivityResult(getTargetRequestCode(), ALERT_TIME_PICKED_RESULT_CODE, intent);
                                  ^
app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.java:91: 
  warning: [deprecation] onActivityResult(int,int,Intent) in Fragment has been deprecated
        fragment.onActivityResult(getTargetRequestCode(), ALERT_TIME_PICKED_RESULT_CODE, intent);
                ^
```

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Nexus 9 emulator (tablet), Android 5.1.1 (API 22)
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)