### PR TITLE
Use compileSdk & targetSdk 31 (Android 12).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             >
         <activity
                 android:label="@string/app_name"
+                android:exported="true"
                 android:theme="@style/Theme.Congress.NoActionBar"
                 android:launchMode="singleTop"
                 android:resizeableActivity="true"
@@ -49,12 +50,16 @@
 
         <receiver android:name=".alarms.AlarmReceiver">
         </receiver>
-        <receiver android:name="nerd.tuxmobil.fahrplan.congress.system.OnBootReceiver">
+        <receiver
+            android:name="nerd.tuxmobil.fahrplan.congress.system.OnBootReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
-        <receiver android:name="nerd.tuxmobil.fahrplan.congress.system.OnLocaleChangedReceiver">
+        <receiver
+            android:name="nerd.tuxmobil.fahrplan.congress.system.OnLocaleChangedReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.LOCALE_CHANGED" />
             </intent-filter>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.java
@@ -1,5 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.alarms;
 
+import static android.app.PendingIntent.FLAG_ONE_SHOT;
+import static nerd.tuxmobil.fahrplan.congress.utils.PendingIntentCompat.FLAG_IMMUTABLE;
+
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -34,7 +37,6 @@ public final class AlarmReceiver extends BroadcastReceiver {
     private static final String BUNDLE_KEY_NOTIFICATION_ID = "BUNDLE_KEY_NOTIFICATION_ID";
     private static final int INVALID_NOTIFICATION_ID = -1;
     private static final int DEFAULT_REQUEST_CODE = 0;
-    private static final int NO_FLAGS = 0;
 
     private final AppRepository appRepository = AppRepository.INSTANCE;
 
@@ -55,14 +57,14 @@ public final class AlarmReceiver extends BroadcastReceiver {
             int uniqueNotificationId = appRepository.createSessionAlarmNotificationId(sessionId);
             Intent launchIntent = MainActivity.createLaunchIntent(context, sessionId, day, uniqueNotificationId);
             PendingIntent contentIntent = PendingIntent
-                    .getActivity(context, DEFAULT_REQUEST_CODE, launchIntent, PendingIntent.FLAG_ONE_SHOT);
+                    .getActivity(context, DEFAULT_REQUEST_CODE, launchIntent, FLAG_ONE_SHOT | FLAG_IMMUTABLE);
 
             NotificationHelper notificationHelper = new NotificationHelper(context);
             Uri soundUri = appRepository.readAlarmToneUri();
 
             Intent deleteNotificationIntent = createDeleteNotificationIntent(context, uniqueNotificationId);
             PendingIntent deleteBroadcastIntent = PendingIntent
-                    .getBroadcast(context, DEFAULT_REQUEST_CODE, deleteNotificationIntent, NO_FLAGS);
+                    .getBroadcast(context, DEFAULT_REQUEST_CODE, deleteNotificationIntent, FLAG_IMMUTABLE);
 
             NotificationCompat.Builder builder = notificationHelper.getSessionAlarmNotificationBuilder(
                     contentIntent, title, when, soundUri, deleteBroadcastIntent);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -16,6 +16,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.utils.PendingIntentCompat.FLAG_IMMUTABLE
 import org.threeten.bp.ZoneOffset
 
 /**
@@ -72,11 +73,10 @@ class AlarmServices @VisibleForTesting constructor(
     private object PendingIntentProvider : PendingIntentDelegate {
 
         const val DEFAULT_REQUEST_CODE = 0
-        const val NO_FLAGS = 0
 
         @SuppressLint("WrongConstant")
         override fun onPendingIntentBroadcast(context: Context, intent: Intent): PendingIntent {
-            return PendingIntent.getBroadcast(context, DEFAULT_REQUEST_CODE, intent, NO_FLAGS)
+            return PendingIntent.getBroadcast(context, DEFAULT_REQUEST_CODE, intent, FLAG_IMMUTABLE)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -162,6 +162,8 @@ class AlarmServices @VisibleForTesting constructor(
         if (discardExisting) {
             alarmManager.cancel(pendingIntent)
         }
+        // Redesign might be needed as of Android 12 (API level 31)
+        // See https://developer.android.com/training/scheduling/alarms
         alarmManager.set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.java
@@ -1,5 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.autoupdate;
 
+import static android.app.PendingIntent.FLAG_ONE_SHOT;
+import static nerd.tuxmobil.fahrplan.congress.utils.PendingIntentCompat.FLAG_IMMUTABLE;
+
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -59,7 +62,7 @@ public class UpdateService extends SafeJobIntentService {
         notificationIntent.setFlags(
                 Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
         PendingIntent contentIntent = PendingIntent
-                .getActivity(this, 0, notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+                .getActivity(this, 0, notificationIntent, FLAG_ONE_SHOT | FLAG_IMMUTABLE);
 
         String contentText;
         if (TextUtils.isEmpty(version)) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
@@ -54,6 +54,8 @@ object FahrplanMisc {
 
             override fun onScheduleUpdateAlarm(interval: Long, nextFetch: Long) {
                 MyApp.LogDebug(LOG_TAG, "Scheduling update alarm to interval $interval, next in ~${nextFetch - now}")
+                // Redesign might be needed as of Android 12 (API level 31)
+                // See https://developer.android.com/training/scheduling/alarms
                 alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingIntent)
             }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
@@ -12,6 +12,7 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmUpdater
 import nerd.tuxmobil.fahrplan.congress.extensions.getAlarmManager
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import nerd.tuxmobil.fahrplan.congress.utils.PendingIntentCompat.FLAG_IMMUTABLE
 
 
 object FahrplanMisc {
@@ -40,7 +41,7 @@ object FahrplanMisc {
         val alarmManager = context.getAlarmManager()
         val alarmIntent = Intent(context, AlarmReceiver::class.java)
             .apply { action = AlarmReceiver.ALARM_UPDATE }
-        val pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, 0)
+        val pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, FLAG_IMMUTABLE)
 
         MyApp.LogDebug(LOG_TAG, "set update alarm")
         val now = Moment.now().toMilliseconds()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/PendingIntentCompat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/PendingIntentCompat.kt
@@ -1,0 +1,16 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import android.app.PendingIntent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES
+
+object PendingIntentCompat {
+
+    /**
+     * Flag indicating that the created PendingIntent should be immutable.
+     * See [PendingIntent.FLAG_IMMUTABLE].
+     */
+    @JvmField
+    val FLAG_IMMUTABLE = if (SDK_INT >= VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+
+}

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -10,9 +10,9 @@ object Config {
 
 object Android {
     const val buildToolsVersion = "32.0.0"
-    const val compileSdkVersion = 30
+    const val compileSdkVersion = 31
     const val minSdkVersion = 16
-    const val targetSdkVersion = 30
+    const val targetSdkVersion = 31
 }
 
 object Plugins {


### PR DESCRIPTION
# Description
+ Use compileSdk 31.
+ Use targetSdk 31.
+ Declare pending intents mutability.
+ Declare `android:exported` attribute for app components.

# Successfully tested on
with `rc3` flavor, `debug` and `release` builds
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)
- :heavy_check_mark: Pixel 3a device, Android 12 (API 31)

---

Resolves #420