### PR TITLE
Update project setup (Multidex, Preference 1.2.0, core-ktx 1.7.0, AppCompat 1.4.1, lifecycle-livedata-ktx 2.4.1, Material 1.5.0)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
         minSdk Android.minSdkVersion
         targetSdk Android.targetSdkVersion
         archivesBaseName = "Fahrplan-$versionName"
+        multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 apply plugin: "com.google.devtools.ksp"
 apply plugin: "de.mobilej.unmock"
+apply plugin: "com.getkeepsafe.dexcount"
 apply from: "../gradle/sonarqube.gradle"
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,7 +197,7 @@ dependencies {
     implementation Libs.emailIntentBuilder
     implementation Libs.kotlinCoroutinesAndroid
     implementation Libs.kotlinCoroutinesCore
-    implementation Libs.liveDataKtx
+    implementation Libs.lifecycleLiveData
     implementation Libs.markwonCore
     implementation Libs.markwonLinkify
     implementation Libs.material

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
@@ -1,8 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress
 
-import android.app.Application
 import android.util.Log
 import androidx.annotation.CallSuper
+import androidx.multidex.MultiDexApplication
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
@@ -11,7 +11,7 @@ import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.TimeZone
 
-class MyApp : Application() {
+class MyApp : MultiDexApplication() {
 
     enum class TASKS {
         NONE, FETCH, PARSE

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/AlarmTonePreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/AlarmTonePreference.kt
@@ -31,25 +31,25 @@ class AlarmTonePreference : Preference {
     }
 
     @Suppress("unused")
-    constructor(context: Context?) :
+    constructor(context: Context) :
             super(context) {
         applyDefaultValue()
     }
 
     @Suppress("unused")
-    constructor(context: Context?, attrs: AttributeSet?) :
+    constructor(context: Context, attrs: AttributeSet?) :
             super(context, attrs) {
         applyDefaultValue()
     }
 
     @Suppress("unused")
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) :
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) :
             super(context, attrs, defStyleAttr) {
         applyDefaultValue()
     }
 
     @Suppress("unused")
-    constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) :
             super(context, attrs, defStyleAttr, defStyleRes) {
         applyDefaultValue()
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -97,7 +97,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 true
             }
             alternativeScheduleUrlPreference.summaryProvider = SummaryProvider<EditTextPreference> {
-                when (it.text.isEmpty()) {
+                when (it.text.isNullOrEmpty()) {
                     true -> getString(R.string.preference_summary_alternative_schedule_url)
                     false -> it.text
                 }
@@ -115,9 +115,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
         if (BuildConfig.ENABLE_ENGELSYSTEM_SHIFTS) {
             val urlPreference = requirePreference<EditTextPreference>(getString(R.string.preference_key_engelsystem_json_export_url))
             urlPreference.summaryProvider = SummaryProvider<EditTextPreference> {
-                when (it.text.isEmpty()) {
+                when (it.text.isNullOrEmpty()) {
                     true -> getString(R.string.preference_summary_engelsystem_json_export_url).toSpanned()
-                    false -> "${it.text.dropLast(23)}..." // Truncate to keep the key private.
+                    false -> "${it.text!!.dropLast(23)}..." // Truncate to keep the key private.
                 }
             }
             urlPreference.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, _: Any? ->

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath Plugins.android
         classpath Plugins.androidJunitJacoco
+        classpath Plugins.dexcount
         classpath Plugins.kotlin
         classpath Plugins.ksp
         classpath Plugins.sonarQube

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -53,7 +53,7 @@ object Libs {
         const val espresso = "3.4.0"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.6.0"
-        const val liveDataKtx = "2.3.1" // compileSdk 31 is required as of 2.4.0
+        const val liveDataKtx = "2.4.1"
         const val markwon = "4.6.2"
         const val material = "1.4.0" // compileSdk 31 is required as of 1.5.0
         const val mockito = "4.4.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -59,6 +59,7 @@ object Libs {
         const val mockito = "4.4.0"
         const val mockitoKotlin = "4.0.0"
         const val moshi = "1.13.0"
+        const val multiDex = "2.0.1"
         const val okhttp = "3.12.13"
         const val preference = "1.1.1" // compileSdk 31 is required as of 1.2.0
         const val retrofit = "2.6.4"
@@ -93,6 +94,7 @@ object Libs {
     const val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}"
     const val moshi = "com.squareup.moshi:moshi:${Versions.moshi}"
     const val moshiCodeGen = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.moshi}"
+    const val multiDex = "androidx.multidex:multidex:${Versions.multiDex}"
     const val okhttp = "com.squareup.okhttp3:okhttp:${Versions.okhttp}"
     const val okhttpLoggingInterceptor = "com.squareup.okhttp3:logging-interceptor:${Versions.okhttp}"
     const val okhttpMockWebServer = "com.squareup.okhttp3:mockwebserver:${Versions.okhttp}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -61,7 +61,7 @@ object Libs {
         const val moshi = "1.13.0"
         const val multiDex = "2.0.1"
         const val okhttp = "3.12.13"
-        const val preference = "1.1.1" // compileSdk 31 is required as of 1.2.0
+        const val preference = "1.2.0"
         const val retrofit = "2.6.4"
         const val robolectric = "4.3_r2-robolectric-0"
         const val snackengage = "0.29"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -46,7 +46,7 @@ object Libs {
         const val assertjAndroid = "1.2.0"
         const val betterLinkMovementMethod = "2.2.0"
         const val constraintLayout = "2.1.3"
-        const val coreKtx = "1.6.0" // compileSdk 31 is required as of 1.7.0
+        const val coreKtx = "1.7.0"
         const val coreTesting = "2.1.0"
         const val emailIntentBuilder = "2.0.0"
         const val engelsystem = "6.0.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -22,7 +22,7 @@ object Plugins {
         const val androidJunitJacoco = "0.16.0"
         const val dexcount = "3.1.0"
         const val kotlin = "1.6.10"
-        const val ksp = "1.6.10-1.0.2"
+        const val ksp = "1.6.10-1.0.4"
         const val sonarQube = "3.3"
         const val unMock = "0.7.9"
         const val versions = "0.42.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -20,6 +20,7 @@ object Plugins {
     private object Versions {
         const val android = "7.1.2"
         const val androidJunitJacoco = "0.16.0"
+        const val dexcount = "3.1.0"
         const val kotlin = "1.6.10"
         const val ksp = "1.6.10-1.0.2"
         const val sonarQube = "3.3"
@@ -29,6 +30,7 @@ object Plugins {
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"
     const val androidJunitJacoco = "com.vanniktech:gradle-android-junit-jacoco-plugin:${Versions.androidJunitJacoco}"
+    const val dexcount = "com.getkeepsafe.dexcount:dexcount-gradle-plugin:${Versions.dexcount}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val ksp = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${Versions.ksp}"
     const val sonarQube = "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${Versions.sonarQube}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -55,7 +55,7 @@ object Libs {
         const val kotlinCoroutines = "1.6.0"
         const val lifecycle = "2.4.1"
         const val markwon = "4.6.2"
-        const val material = "1.4.0" // compileSdk 31 is required as of 1.5.0
+        const val material = "1.5.0"
         const val mockito = "4.4.0"
         const val mockitoKotlin = "4.0.0"
         const val moshi = "1.13.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -42,7 +42,7 @@ object Libs {
 
     private object Versions {
         const val annotation = "1.3.0"
-        const val appCompat = "1.3.1" // compileSdk 31 is required as of 1.4.0
+        const val appCompat = "1.4.1"
         const val assertjAndroid = "1.2.0"
         const val betterLinkMovementMethod = "2.2.0"
         const val constraintLayout = "2.1.3"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -53,7 +53,7 @@ object Libs {
         const val espresso = "3.4.0"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.6.0"
-        const val liveDataKtx = "2.4.1"
+        const val lifecycle = "2.4.1"
         const val markwon = "4.6.2"
         const val material = "1.4.0" // compileSdk 31 is required as of 1.5.0
         const val mockito = "4.4.0"
@@ -86,7 +86,7 @@ object Libs {
     const val kotlinCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"
-    const val liveDataKtx = "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.liveDataKtx}"
+    const val lifecycleLiveData = "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.lifecycle}"
     const val markwonCore = "io.noties.markwon:core:${Versions.markwon}"
     const val markwonLinkify = "io.noties.markwon:linkify:${Versions.markwon}"
     const val material = "com.google.android.material:material:${Versions.material}"

--- a/commons-testing/build.gradle
+++ b/commons-testing/build.gradle
@@ -35,7 +35,7 @@ dependencies {
         // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-    implementation Libs.liveDataKtx
+    implementation Libs.lifecycleLiveData
     implementation Libs.truth
     api Libs.mockitoKotlin
 

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-    implementation Libs.liveDataKtx
+    implementation Libs.lifecycleLiveData
     implementation Libs.tracedroid
     api Libs.threeTenBp
 


### PR DESCRIPTION
# Description
+ Use dexcount-gradle-plugin v.3.1.0.
+ Use multidex v.2.1.0. Enable multidex.
+ Use preference v.1.2.0.
+ Use core-ktx v.1.7.0.
+ Use appcompat v.1.4.1.
+ Use lifecycle-livedata-ktx v.2.4.1.
+ Clarify dependency names.
+ Use material v.1.5.0.
+ Use ksp v.1.6.10-1.0.4.

# Successfully tested on
with `ccc36c3`, `rc3` flavors, `release` builds
- :heavy_check_mark: Pixel 2 device, Android 11 (API 30)