### PR TITLE
Ease sharing text from error message alert dialog.

### DIFF
--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -94,6 +94,7 @@
         <item name="colorAccent">@color/alert_dialog_button_text</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
         <item name="android:windowBackground">@color/windowBackground</item>
+        <item name="android:textIsSelectable">true</item>
     </style>
 
     <style name="MyActionDropDownStyle" parent="Widget.AppCompat.Spinner.DropDown.ActionBar">


### PR DESCRIPTION
# Description
+ Text displayed in the dialog can now be selected and then shared.
+ Inspired by #431 

  ![screenshot](https://user-images.githubusercontent.com/144518/161099895-5a2d76ca-91f0-4f42-ae05-d56052eff138.png)

# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Emulator, Android 7.0 (API 24)