### PR TITLE
Indicate a possible reason for the certificate error on Android 7.0.

### DIFF
--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.java
@@ -2,6 +2,7 @@ package info.metadude.android.eventfahrplan.network.fetching;
 
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -13,6 +14,7 @@ import java.net.UnknownHostException;
 import java.net.UnknownServiceException;
 
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLHandshakeException;
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging;
 import okhttp3.Call;
@@ -160,6 +162,7 @@ class FetchFahrplanTask extends AsyncTask<String, Void, HttpStatus> {
             response = call.execute();
         } catch (SSLException e) {
             setExceptionMessage(e);
+            customizeExceptionMessage(e);
             e.printStackTrace();
             return HttpStatus.HTTP_LOGIN_FAIL_UNTRUSTED_CERTIFICATE;
         } catch (SocketTimeoutException e) {
@@ -230,5 +233,13 @@ class FetchFahrplanTask extends AsyncTask<String, Void, HttpStatus> {
         }
     }
 
+    private void customizeExceptionMessage(@NonNull SSLException exception) {
+        if (exception instanceof SSLHandshakeException && Build.VERSION.SDK_INT == Build.VERSION_CODES.N) {
+            // See https://github.com/EventFahrplan/EventFahrplan/issues/431
+            exceptionMessage += "\n\nPlease note that server certificates using elliptic curves " +
+                    "with a length > 256 bits are not supported on Android 7.0. This might cause " +
+                    "this error.";
+        }
+    }
 
 }


### PR DESCRIPTION
# Description
- Adds additional information for the #431 issue.
- Additional to the exception message a hint is shown on devices running Android 7.0.

  ![error-message](https://user-images.githubusercontent.com/144518/162327531-4fcb74e1-6c86-4071-ae47-3b20d35e0e77.png)


# Successfully tested on
with `rc3` flavor, `debug` build
- :heavy_check_mark: Emulator, Android 7.0 (API 24)
- :heavy_check_mark: Pixel 6, Android 12 (API 31)

Resolves #431