### PR TITLE
Add loading spinner while starred lectures are loading

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -19,6 +19,7 @@ import android.widget.Toast
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.MainThread
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
@@ -74,6 +75,8 @@ class StarredListFragment :
      */
     private lateinit var currentListView: ListView
 
+    private lateinit var loadingSpinnerView: View
+
     private val starredListAdapter: StarredListAdapter
         get() {
             val headerViewListAdapter = currentListView.adapter as HeaderViewListAdapter
@@ -113,6 +116,9 @@ class StarredListFragment :
         currentListView.choiceMode = AbsListView.CHOICE_MODE_MULTIPLE_MODAL
         currentListView.setMultiChoiceModeListener(this)
         currentListView.setOnScrollListener(this)
+
+        loadingSpinnerView = view.requireViewByIdCompat(R.id.loading_spinner_view)
+
         return view
     }
 
@@ -128,6 +134,8 @@ class StarredListFragment :
             val adapter = StarredListAdapter(activity, sessions, numDays, useDeviceTimeZone)
             currentListView.adapter = adapter
             activity.invalidateOptionsMenu()
+
+            loadingSpinnerView.isVisible = false
         }
         viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
             SessionSharer.shareSimple(requireContext(), formattedSession)

--- a/app/src/main/res/layout/fragment_favorites_list.xml
+++ b/app/src/main/res/layout/fragment_favorites_list.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/favorites_background"
     android:orientation="vertical"
     tools:context=".changes.ChangeListFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loading_spinner_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:visibility="gone">
+
+        <ProgressBar
+            android:layout_width="@dimen/progress_spinner_size"
+            android:layout_height="@dimen/progress_spinner_size"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ListView
         android:id="@android:id/list"

--- a/app/src/main/res/layout/fragment_favorites_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_favorites_list_narrow.xml
@@ -1,11 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/favorites_background"
     android:orientation="vertical"
     tools:context=".changes.ChangeListFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loading_spinner_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:visibility="gone">
+
+        <ProgressBar
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ListView
         android:id="@android:id/list"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -21,6 +21,9 @@
     <dimen name="list_pane_leftright_padding">16dp</dimen>
     <dimen name="header_height">0dp</dimen>
 
+    <!-- Loading Spinner -->
+    <dimen name="progress_spinner_size">80dp</dimen>
+
     <!-- Scrollbar -->
     <!--
     If you use a value greater than 16dp make sure to adjust the padding


### PR DESCRIPTION
# Description
Loading the starred talks from the local db can take quite some time,
during this time the view will show "No favourite lectures".
Adding a loading overlay until the first data is received from the
database mitigates this problem

- Tested on Android 10 and Android 4.1 (Sidenote, i was unable to load data on android 4.1 since i got a timeout exception. But the loading state itself seems to be working)

Tested by adding a delay into the StarredListViewModel:
```kotlin
val starredListParameter: LiveData<StarredListParameter> = repository.starredSessions
        .map { it.toStarredListParameter() }
        .onEach { delay(1000) }
        .asLiveData(executionContext.database)
```

# Before
While the data was loading from the local database the screen would show the "no starred lectures" screen, even when lectures are starred. This would quickly switch to the actual list when the data is loaded

# After
Until the first data is loaded a loading spinner is shown
![image](https://user-images.githubusercontent.com/4669075/169982082-e4d16777-a0b7-4622-b6b1-4a79ed9a627f.png)

Resolves #412 
