### PR TITLE
Clarify behavior of navigation menu entries generator

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
@@ -47,6 +47,9 @@ internal class NavigationMenuEntriesGenerator @JvmOverloads constructor(
         if (dateInfos == null || dateInfos.isEmpty()) {
             throw IllegalArgumentException("Invalid date info list: $dateInfos")
         }
+        if (numDays < dateInfos.size) {
+            throw IllegalArgumentException("Too small number of days: $numDays, date info list contains ${dateInfos.size} items")
+        }
         logging.d(LOG_TAG, "Today is " + currentDate.toUtcDateTime().toLocalDate())
         val entries = mutableListOf<String>()
         for (dayIndex in 0 until numDays) {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -31,6 +31,22 @@ class NavigationMenuEntriesGeneratorTest {
     }
 
     @Test
+    fun `getDayMenuEntries returns five day entries with today mark`() {
+        val dateInfoList = DateInfos()
+        dateInfoList.add(DateInfo(1, Moment.parseDate("2022-11-18")))
+        dateInfoList.add(DateInfo(2, Moment.parseDate("2022-11-19")))
+        dateInfoList.add(DateInfo(3, Moment.parseDate("2022-11-20")))
+        val entries = getDayMenuEntries(5, dateInfoList, "2022-11-19")
+        assertThat(entries).isNotNull
+        assertThat(entries.size).isEqualTo(5)
+        assertThat(entries[0]).isEqualTo("Day 1")
+        assertThat(entries[1]).isEqualTo("Day 2 - Today")
+        assertThat(entries[2]).isEqualTo("Day 3")
+        assertThat(entries[3]).isEqualTo("Day 4")
+        assertThat(entries[4]).isEqualTo("Day 5")
+    }
+
+    @Test
     fun `getDayMenuEntries fails when date info list is empty`() {
         try {
             getDayMenuEntries(1, DateInfos(), "2018-11-19")

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -100,6 +100,19 @@ class NavigationMenuEntriesGeneratorTest {
         }
     }
 
+    @Test
+    fun `getDayMenuEntries fails when number of days is less than date list items size`() {
+        val dateInfoList = DateInfos()
+        dateInfoList.add(DateInfo(1, Moment.parseDate("2022-11-18")))
+        dateInfoList.add(DateInfo(2, Moment.parseDate("2022-11-19")))
+        try {
+            getDayMenuEntries(1, dateInfoList, "2022-11-18")
+            fail("Expect an IllegalArgumentException to be thrown.")
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("Too small number of days: 1, date info list contains 2 items")
+        }
+    }
+
     private fun getDayMenuEntries(numDays: Int, dateInfos: DateInfos?, currentDate: String) =
         generator.getDayMenuEntries(numDays, dateInfos, Moment.parseDate(currentDate))
 


### PR DESCRIPTION
# Description
- Document that day menu entries are generated for days without sessions.
- Crash if number of days is less than the number items in date info list.

# Successfully tested on
with `foss4g2022` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 12 (API 31)

Relates #435