### PR TITLE
Fix broken automatic redraw when settings are changed.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -291,7 +291,7 @@ class MainActivity : BaseActivity(),
                         BundleKeys.USE_DEVICE_TIME_ZONE_UPDATED, false)
 
                     if (isAlternativeHighlightingUpdated || isUseDeviceTimeZoneUpdated) {
-                        if (findViewById<View>(R.id.schedule) != null && findFragment(FahrplanFragment.FRAGMENT_TAG) == null) {
+                        if (findViewById<View>(R.id.schedule) != null && findFragment(FahrplanFragment.FRAGMENT_TAG) != null) {
                             replaceFragment(R.id.schedule, FahrplanFragment(), FahrplanFragment.FRAGMENT_TAG)
                         }
                     }


### PR DESCRIPTION
# Description
+ Affected settings: _alternative highlighting_, _use device time zone_.
+ Broken since cc9817e4710a50ab526c7f92f94ae7aa9d9c389e because this check **never** evaluated as `true`. Instead the redraw was triggered by a central render update mechanism which was still in place before the referenced commit.
  + See: 48e18e4f2d8c5172707f7da8a8b84e26af6c90b2 -> `FahrplanFragment#onResume#228` -> `viewDay()`

# Successfully tested on
with `hope2022` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 12 (API 31)