### PR TITLE
Fix Overscroll Behavior in Android 12+

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollState.kt
@@ -54,6 +54,7 @@ data class HorizontalSnapScrollState @JvmOverloads constructor(
     /**
      * Returns the column index calculated based on the given [scrollX] value
      * and the current state of [HorizontalSnapScrollState].
+     * @return Returns the calculated index if it is valid, in any other case -1
      */
     fun calculateOnTouchColumnIndex(scrollX: Int): Int {
         val relativeDistance = scrollX - xStart
@@ -74,8 +75,9 @@ data class HorizontalSnapScrollState @JvmOverloads constructor(
 
         columnIndex -= columnIndexDelta
 
-        columnIndex = max(columnIndex, 0)
-        columnIndex = min(columnIndex, roomsCount - displayColumnCount)
+        if (columnIndex < 0 || maxColumnIndex < columnIndex) {
+            return -1
+        }
 
         return columnIndex
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.kt
@@ -173,9 +173,13 @@ class HorizontalSnapScrollView(context: Context?, attrs: AttributeSet?) : Horizo
                 return false
             } else if (event.action == ACTION_UP || event.action == ACTION_CANCEL) {
                 val scrollX = event.x.toInt()
-                val columnIndex = horizontalSnapScrollState.calculateOnTouchColumnIndex(scrollX)
-                scrollToColumn(columnIndex, fast = false)
-                return true
+
+                val calculatedColumnIndex = horizontalSnapScrollState.calculateOnTouchColumnIndex(scrollX)
+
+                if (calculatedColumnIndex > -1) {
+                    scrollToColumn(calculatedColumnIndex, fast = false)
+                    return true
+                }
             }
             return false
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollStateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollStateTest.kt
@@ -184,7 +184,7 @@ class HorizontalSnapScrollStateTest {
     }
 
     @Test
-    fun `calculateOnTouchColumnIndex returns 0 as the minimum index in portrait mode to prevent scrolling off the screen to the left`() {
+    fun `calculateOnTouchColumnIndex returns -1 if the target index is lower than 0 in portrait mode to prevent scrolling off the screen to the left`() {
         with(
             createState().copy(
                 columnWidth = 993,
@@ -194,12 +194,12 @@ class HorizontalSnapScrollStateTest {
             )
         ) {
             val scrollThresholdWidth = (columnWidth * SCROLL_THRESHOLD_FACTOR).toInt()
-            assertThat(calculateOnTouchColumnIndex(scrollX = scrollThresholdWidth + 1)).isEqualTo(0)
+            assertThat(calculateOnTouchColumnIndex(scrollX = scrollThresholdWidth + 1)).isEqualTo(-1)
         }
     }
 
     @Test
-    fun `calculateOnTouchColumnIndex returns 0 as the minimum index in landscape mode to prevent scrolling off the screen to the left`() {
+    fun `calculateOnTouchColumnIndex returns -1 if the target index is lower than 0 in landscape mode to prevent scrolling off the screen to the left`() {
         with(
             createState().copy(
                 columnWidth = 993,
@@ -208,27 +208,27 @@ class HorizontalSnapScrollStateTest {
                 roomsCount = 5
             )
         ) {
-            assertThat(calculateOnTouchColumnIndex(scrollX = columnWidth * 2)).isEqualTo(0)
+            assertThat(calculateOnTouchColumnIndex(scrollX = columnWidth * 2)).isEqualTo(-1)
         }
     }
 
     @Test
-    fun `calculateOnTouchColumnIndex returns the last possible index as the maximum value in portrait mode to prevent scrolling off the screen to the right`() {
+    fun `calculateOnTouchColumnIndex returns -1 if the target index is higher than the max allowed in portrait mode to prevent scrolling off the screen to the right`() {
         with(
             createState().copy(
                 columnWidth = 993,
                 displayColumnCount = 1,
-                activeColumnIndex = 4,
+                activeColumnIndex = 9,
                 roomsCount = 10
             )
         ) {
             val scrollThresholdWidth = (columnWidth * SCROLL_THRESHOLD_FACTOR).toInt()
-            assertThat(calculateOnTouchColumnIndex(scrollX = -scrollThresholdWidth + 1)).isEqualTo(4)
+            assertThat(calculateOnTouchColumnIndex(scrollX = -scrollThresholdWidth - 1)).isEqualTo(-1)
         }
     }
 
     @Test
-    fun `calculateOnTouchColumnIndex returns the last possible index as the maximum value in landscape mode to prevent scrolling off the screen to the right`() {
+    fun `calculateOnTouchColumnIndex returns -1 if the target index is higher than the max allowed in landscape mode to prevent scrolling off the screen to the right`() {
         with(
             createState().copy(
                 columnWidth = 993,
@@ -237,7 +237,7 @@ class HorizontalSnapScrollStateTest {
                 roomsCount = 10
             )
         ) {
-            assertThat(calculateOnTouchColumnIndex(scrollX = -columnWidth * 2)).isEqualTo(6)
+            assertThat(calculateOnTouchColumnIndex(scrollX = -columnWidth * 2)).isEqualTo(-1)
         }
     }
 


### PR DESCRIPTION
# Description
As stated in #488 the overstretch animation of Android 12+ breaks when applied to the main Horizontal Scroll View. This should be fixed with this Pull request. The error was caused by the OnTouchListener catching OnTouch Events even though the target columnIndex was outside the allowed range.

# Before
When trying to scroll outside of the allowed horizontal range of the stretch Animation would not reset after releasing, making horizontal scrolling impossable.

# After
Horizontal scrolling functioning as with the old animation

<!--
Contributing guidelines
Make sure to read the contributing guidelines
https://github.com/EventFahrplan/EventFahrplan/blob/master/CONTRIBUTING.md
before creating this pull request.
-->

<!-- Remove it this pull request does not resolve an issue -->
Resolves #488 
