### PR TITLE
Engage users to learn about using the app in landscape mode.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ android {
         buildConfigField "boolean", "SHOW_APP_DISCLAIMER", "true"
         buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"
         buildConfigField "boolean", "ENGAGE_GOOGLE_PLAY_RATING", "true"
+        buildConfigField "boolean", "ENGAGE_LANDSCAPE_ORIENTATION", "true"
     }
 
     buildTypes {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/Engagements.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/Engagements.kt
@@ -19,6 +19,9 @@ fun AppCompatActivity.initUserEngagement() {
     if (BuildConfig.ENGAGE_C3NAV_APP_INSTALLATION) {
         snackEngageBuilder.withSnack(C3navSnack(this))
     }
+    if (BuildConfig.ENGAGE_LANDSCAPE_ORIENTATION) {
+        snackEngageBuilder.withSnack(LandscapeOrientationSnack(this))
+    }
     snackEngageBuilder
             .build()
             .engageWhenAppropriate()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/LandscapeOrientationSnack.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/LandscapeOrientationSnack.kt
@@ -1,0 +1,34 @@
+package nerd.tuxmobil.fahrplan.congress.engagements
+
+import android.content.Context
+import nerd.tuxmobil.fahrplan.congress.R
+import org.ligi.snackengage.conditions.AfterNumberOfOpportunities
+import org.ligi.snackengage.conditions.NeverAgainWhenClickedOnce
+import org.ligi.snackengage.snacks.BaseSnack
+
+/**
+ * Snack to engage that the user rotates the device to learn
+ * that in landscape mode there is much more screen estate.
+ */
+class LandscapeOrientationSnack(
+
+    val context: Context
+
+) : BaseSnack() {
+
+    init {
+        withConditions(
+            NeverAgainWhenClickedOnce(),
+            AfterNumberOfOpportunities(2),
+        )
+    }
+
+    override fun getId() = "LANDSCAPE_ORIENTATION"
+
+    override fun getText() =
+        context.getString(R.string.snack_engage_landscape_orientation_title)
+
+    override fun getActionText() =
+        context.getString(R.string.snack_engage_landscape_orientation_action)
+
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -153,6 +153,8 @@
     <string name="snack_engage_google_play_beta_testing_action">Werde Beta-Tester</string>
     <string name="snack_engage_c3nav_title">Indoor-Navigation auf dem <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Mit der c3nav-App</string>
     <string name="snack_engage_c3nav_action">Jetzt installieren!</string>
+    <string name="snack_engage_landscape_orientation_title">Schon Querformat probiert?</string>
+    <string name="snack_engage_landscape_orientation_action">Dreh dein Gerät!</string>
 
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,9 @@
     <string name="snack_engage_c3nav_title">Indoor navigation at <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! With the c3nav app</string>
     <string name="snack_engage_c3nav_action">Get it now!</string>
 
+    <string name="snack_engage_landscape_orientation_title">Tried landscape mode?</string>
+    <string name="snack_engage_landscape_orientation_action">Rotate your device!</string>
+
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">
         Send <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> crash report &#8230;

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -90,3 +90,4 @@ The app prompts the user to engage in the following topics if enabled via a `bui
 - c3nav app installation via `ENGAGE_C3NAV_APP_INSTALLATION`
 - Google Play beta testing via `ENGAGE_GOOGLE_BETA_TESTING`
 - Google Play rating via `ENGAGE_GOOGLE_PLAY_RATING`
+- to learn about the screen estate in landscape mode via `ENGAGE_LANDSCAPE_ORIENTATION`


### PR DESCRIPTION
# Description
+ Repetitive users reported that they discovered the screen estate offered in landscape mode somewhat late.
+ The snackbar message aims to help with that at the early time of usage.

# Screenshot
- New snackbar at the bottom of the screen.

  ![screenshot](https://user-images.githubusercontent.com/144518/186706601-da0278e0-967b-444f-9fbb-9ce28222390e.png)
