### PR TITLE
Let Crowdin only list files which contain translatable strings.

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,5 @@
 files:
-  - source: /app/src/main/res/values/
-    translation: /app/src/main/res/values-%two_letters_code%/%original_file_name%
-    translatable_elements:
+  - source:
       - /app/src/main/res/values/strings.xml
       - /app/src/main/res/values/preferences.xml
+    translation: /app/src/main/res/values-%two_letters_code%/%original_file_name%


### PR DESCRIPTION
# Description
+ Currently, also `styles_congress.xml` and `placeholder.xml` are listed.
+ Fix initial configuration: 16dd1fef1c8c61dbc2087bc2f1f63ad0ce1969d8.
