### PR TITLE
Support configuring custom names for "Engelsystem" and "Engelshifts".

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,8 @@ android {
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "false"
         buildConfigField "boolean", "ENABLE_CHAOSFLIX_EXPORT", "false"
         buildConfigField "boolean", "ENABLE_ENGELSYSTEM_SHIFTS", "false"
+        resValue("string", "engelsystem_alias", "Engelsystem")
+        resValue("string", "engelsystem_shifts_alias", "Engelshifts")
         resValue("string", "preference_hint_engelsystem_json_export_url", '""')
         buildConfigField "boolean", "SHOW_APP_DISCLAIMER", "true"
         buildConfigField "boolean", "ENGAGE_GOOGLE_BETA_TESTING", "true"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -72,7 +72,14 @@ class SessionDetailsFragment : Fragment() {
 
     private lateinit var appRepository: AppRepository
     private lateinit var alarmServices: AlarmServices
-    private val viewModel: SessionDetailsViewModel by viewModels { SessionDetailsViewModelFactory(appRepository, alarmServices) }
+    private val viewModel: SessionDetailsViewModel by viewModels {
+        SessionDetailsViewModelFactory(
+            appRepository = appRepository,
+            alarmServices = alarmServices,
+            defaultEngelsystemRoomName = AppRepository.ENGELSYSTEM_ROOM_NAME,
+            customEngelsystemRoomName = getString(R.string.engelsystem_shifts_alias)
+        )
+    }
     private lateinit var model: SelectedSessionParameter
     private lateinit var markwon: Markwon
     private var sidePane = false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -37,7 +37,9 @@ class SessionDetailsViewModel(
     private val roomForC3NavConverter: RoomForC3NavConverter,
     private val markdownConversion: MarkdownConversion,
     private val formattingDelegate: FormattingDelegate = DateFormattingDelegate(),
-    private val c3NavBaseUrl: String
+    private val c3NavBaseUrl: String,
+    private val defaultEngelsystemRoomName: String,
+    private val customEngelsystemRoomName: String
 
 ) : ViewModel() {
 
@@ -77,6 +79,7 @@ class SessionDetailsViewModel(
 
     val selectedSessionParameter: LiveData<SelectedSessionParameter> = repository.selectedSession
         .map { it.toSelectedSessionParameter() }
+        .map { it.customizeEngelsystemRoomName() }
         .asLiveData(executionContext.database)
 
     val openFeedBack = SingleLiveEvent<Uri>()
@@ -86,6 +89,10 @@ class SessionDetailsViewModel(
     val setAlarm = SingleLiveEvent<Unit>()
     val navigateToRoom = SingleLiveEvent<Uri>()
     val closeDetails = SingleLiveEvent<Unit>()
+
+    private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
+        roomName = if (roomName == defaultEngelsystemRoomName) customEngelsystemRoomName else roomName
+    )
 
     private fun Session.toSelectedSessionParameter(): SelectedSessionParameter {
         val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -16,7 +16,9 @@ import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 class SessionDetailsViewModelFactory(
 
     private val appRepository: AppRepository,
-    private val alarmServices: AlarmServices
+    private val alarmServices: AlarmServices,
+    private val defaultEngelsystemRoomName: String,
+    private val customEngelsystemRoomName: String
 
 ) : ViewModelProvider.Factory {
 
@@ -33,7 +35,9 @@ class SessionDetailsViewModelFactory(
             sessionUrlComposition = SessionUrlComposer(),
             roomForC3NavConverter = RoomForC3NavConverter(),
             markdownConversion = MarkdownConverter,
-            c3NavBaseUrl = BuildConfig.C3NAV_URL
+            c3NavBaseUrl = BuildConfig.C3NAV_URL,
+            defaultEngelsystemRoomName = defaultEngelsystemRoomName,
+            customEngelsystemRoomName = customEngelsystemRoomName
         ) as T
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ErrorMessage.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ErrorMessage.kt
@@ -111,7 +111,7 @@ sealed interface ErrorMessage {
             val message = when (parseResult) {
                 is ParseScheduleResult -> getMessageForScheduleVersion(parseResult.version)
                 is ParseShiftsResult.Error -> getMessageForErrorResult(parseResult)
-                is ParseShiftsResult.Exception -> context.getString(R.string.engelsystem_shifts_parsing_error_generic)
+                is ParseShiftsResult.Exception -> context.getString(R.string.engelsystem_shifts_parsing_error_generic, R.string.engelsystem_alias)
                 else -> ""
             }
             check(message.isNotEmpty()) { "Unknown parsing result: $parseResult" }
@@ -124,9 +124,9 @@ sealed interface ErrorMessage {
         }
 
         private fun getMessageForErrorResult(errorResult: ParseShiftsResult.Error) = when {
-            errorResult.isForbidden() -> context.getString(R.string.engelsystem_shifts_parsing_error_forbidden)
-            errorResult.isNotFound() -> context.getString(R.string.engelsystem_shifts_parsing_error_not_found)
-            else -> context.getString(R.string.engelsystem_shifts_parsing_error_generic)
+            errorResult.isForbidden() -> context.getString(R.string.engelsystem_shifts_parsing_error_forbidden, R.string.engelsystem_alias)
+            errorResult.isNotFound() -> context.getString(R.string.engelsystem_shifts_parsing_error_not_found, R.string.engelsystem_alias)
+            else -> context.getString(R.string.engelsystem_shifts_parsing_error_generic, R.string.engelsystem_alias)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -107,7 +107,15 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val appRepository = AppRepository
         val alarmServices = AlarmServices.newInstance(context, appRepository)
         val menuEntriesGenerator = NavigationMenuEntriesGenerator(dayString = getString(R.string.day), todayString = getString(R.string.today))
-        val viewModelFactory = FahrplanViewModelFactory(appRepository, alarmServices, menuEntriesGenerator)
+        val defaultEngelsystemRoomName = AppRepository.ENGELSYSTEM_ROOM_NAME
+        val customEngelsystemRoomName = getString(R.string.engelsystem_alias)
+        val viewModelFactory = FahrplanViewModelFactory(
+            repository = appRepository,
+            alarmServices = alarmServices,
+            navigationMenuEntriesGenerator = menuEntriesGenerator,
+            defaultEngelsystemRoomName = defaultEngelsystemRoomName,
+            customEngelsystemRoomName = customEngelsystemRoomName
+        )
         viewModel = ViewModelProvider(this, viewModelFactory).get(FahrplanViewModel::class.java)
         onSessionClickListener = if (context is OnSessionClickListener) {
             context

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -32,7 +32,9 @@ internal class FahrplanViewModel(
     private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
-    private val scrollAmountCalculator: ScrollAmountCalculator
+    private val scrollAmountCalculator: ScrollAmountCalculator,
+    private val defaultEngelsystemRoomName: String,
+    private val customEngelsystemRoomName: String
 
 ) : ViewModel() {
 
@@ -70,12 +72,37 @@ internal class FahrplanViewModel(
                         fahrplanEmptyParameter.postValue(FahrplanEmptyParameter(scheduleVersion))
                     } // else: Nothing to do because schedule has not been loaded yet
                 } else {
-                    val fahrplanParameter = scheduleData.toFahrplanParameter()
+                    val fahrplanParameter = scheduleData
+                        .customizeEngelsystemRoomName()
+                        .toFahrplanParameter()
                     mutableFahrplanParameter.postValue(fahrplanParameter)
                 }
             }
         }
     }
+
+    /**
+     * Rewrite properties to which "Engelshifts" has been applied before
+     * in ShiftExtensions -> Shift.toSessionAppModel.
+     */
+    private fun ScheduleData.customizeEngelsystemRoomName() = copy(
+        roomDataList = roomDataList.map { roomData ->
+            val customRoomName = if (roomData.roomName == defaultEngelsystemRoomName) {
+                customEngelsystemRoomName
+            } else {
+                roomData.roomName
+            }
+            val customSessions = roomData.sessions.map { session ->
+                val customTrackName = if (session.track == defaultEngelsystemRoomName) {
+                    customEngelsystemRoomName
+                } else {
+                    session.track
+                }
+                Session(session).apply { track = customTrackName }
+            }
+            roomData.copy(roomName = customRoomName, sessions = customSessions)
+        }
+    )
 
     private fun ScheduleData.toFahrplanParameter(): FahrplanParameter {
         val dayIndex = repository.readDisplayDayIndex()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
@@ -13,7 +13,9 @@ internal class FahrplanViewModelFactory(
 
     private val repository: AppRepository,
     private val alarmServices: AlarmServices,
-    private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator
+    private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
+    private val defaultEngelsystemRoomName: String,
+    private val customEngelsystemRoomName: String
 
 ) : ViewModelProvider.Factory {
 
@@ -28,7 +30,9 @@ internal class FahrplanViewModelFactory(
             navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),
-            scrollAmountCalculator = ScrollAmountCalculator(logging)
+            scrollAmountCalculator = ScrollAmountCalculator(logging),
+            defaultEngelsystemRoomName = defaultEngelsystemRoomName,
+            customEngelsystemRoomName = customEngelsystemRoomName
         ) as T
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -118,7 +118,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
             val urlPreference = requirePreference<EditTextPreference>(getString(R.string.preference_key_engelsystem_json_export_url))
             urlPreference.summaryProvider = SummaryProvider<EditTextPreference> {
                 when (it.text.isNullOrEmpty()) {
-                    true -> getString(R.string.preference_summary_engelsystem_json_export_url).toSpanned()
+                    true -> getString(R.string.preference_summary_engelsystem_json_export_url, getString(R.string.engelsystem_alias))
+                        .toSpanned()
                     false -> "${it.text!!.dropLast(23)}..." // Truncate to keep the key private.
                 }
             }

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -37,7 +37,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[Damit deine Schichten angezeigt werden, gib hier bitte deine <u>persönliche</u> URL ein.<br/><br/>
-        1. Melde dich beim Engelsystem an.<br/>
+        1. Melde dich beim <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> an.<br/>
         2. Kopiere die URL hinter der <u>JSON Export</u>-Schaltfläche auf deiner Profilseite.<br/>
         3. Füge die URL hier ein.<br/><br/>
         Schichten vor und nach den offiziellen Konferenztagen werden <u>nicht</u> dargestellt.]]>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -105,9 +105,9 @@
     <string name="today">heute</string>
     <string name="schedule_parsing_error_generic">Unbekannter Fehler beim Parsen des Fahrplans</string>
     <string name="schedule_parsing_error_with_version">Fehler beim Parsen der Fahrplan-Version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>
-    <string name="engelsystem_shifts_parsing_error_generic">Unbekannter Fehler beim Parsen der Engelsystem-Schichten</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Ungültiger API-Schlüssel für Engelsystem-Schichten</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Falsche URL für Engelsystem-Schichten</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Unbekannter Fehler beim Parsen der <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>-Schichten</string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Ungültiger API-Schlüssel für <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>-Schichten</string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Falsche URL für <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>-Schichten</string>
     <string name="alarms_empty">
 		Aktuell sind keine Alarme gespeichert. Im Fahrplan
 		kannst du über das entsprechende Symbol in der ActionBar

--- a/app/src/main/res/values-es/preferences.xml
+++ b/app/src/main/res/values-es/preferences.xml
@@ -42,7 +42,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[Para ver tus turnos por favor pon tu URL <u>personal</u> aquí.<br/><br/>
-        1. Haz login en tu cuenta Engelsystem.<br/>
+        1. Haz login en tu cuenta <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>.<br/>
         2. Copia la URL detrás del botón de <u>Exportación en JSON</u> en tu página de perfil.<br/>
         3. Pega la URL aquí.<br/><br/>
         Los horarios antes y después de los días principales de la conferencia <u>no</u> serán mostrados.]]>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,9 +116,9 @@
     <string name="today">Hoy</string>
     <string name="schedule_parsing_error_generic">Error desconocido mientras se procesaba el calendario</string>
     <string name="schedule_parsing_error_with_version">Error de procesado para la versión del calendario %s</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Error desconocido mientras se convertían turnos de Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">API key inválida para turnos de Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">URL inválida para turnos de Engelsystem</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Error desconocido mientras se convertían turnos de <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">API key inválida para turnos de <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_not_found">URL inválida para turnos de <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
     <string name="alarms_empty">
       No hay alarmas que mostrar. Tenga en cuenta que puede 
       configurar alarmas individuales para cada elemento del horario. 

--- a/app/src/main/res/values-fr/preferences.xml
+++ b/app/src/main/res/values-fr/preferences.xml
@@ -17,7 +17,7 @@
 
     <!-- Category Engelsystem -->
     <string name="preference_summary_engelsystem_json_export_url"><![CDATA[Afin de voir vos créneaux de service, veuillez entrer votre URL <u>personnel</u>ici.<br /><br />
-         1. Connectez-vous à votre compte Engelsystem.<br />
+         1. Connectez-vous à votre compte <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>.<br />
          2. Copiez l\'URL derrière le bouton <u>JSON Export</u> sur votre page de profil.<br />
          3. Collez l\'URL ici.<br /><br />
          Les créneaux de service avant et après les principaux jours de conférence <u>ne</u> sont <u>pas</u> affichés.]]></string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -134,9 +134,9 @@
     <string name="share_as_text">Partager en tant que texte</string>
     <string name="share_as_json">Partager en tant que JSON (pour Chaosflix)</string>
     <string name="dlg_err_failed_http_cleartext_not_permitted">HTTP n\'est pas autorisé. Veuillez utiliser HTTPS.</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Erreur inconnue pendant la lecture des créneaux Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Clé API invalide pour les créneaux Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Mauvaise URL pour les créneaux Engelsystem</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Erreur inconnue pendant la lecture des créneaux <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Clé API invalide pour les créneaux <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Mauvaise URL pour les créneaux <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
     <string name="session_list_item_duration_text"><xliff:g example="45" id="duration">%d</xliff:g> min.</string>
     <string name="session_list_item_language_content_description">Langue : <xliff:g example="English" id="language">%s</xliff:g></string>
     <string name="session_list_item_language_portuguese_content_description">Portugais</string>

--- a/app/src/main/res/values-ja/preferences.xml
+++ b/app/src/main/res/values-ja/preferences.xml
@@ -18,7 +18,7 @@
     <!-- Category Engelsystem -->
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[シフトを確認するには、ここに<u>個人</ u>のURLを入力してください。<br/><br/>
-        1. あなたのEngelsystemアカウントにログインします。<br/>
+        1. あなたの<xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>アカウントにログインします。<br/>
         2. プロフィールページの<u>JSON出力</u>ボタンの後ろにあるURLをコピーします.<br/>
         3. URLをここに貼ります。<br/><br/>
         メイン会議日の前後のシフトは<u>表示されません</u>。]]>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -95,9 +95,9 @@
     <string name="today">今日</string>
     <string name="schedule_parsing_error_generic">スケジュールの解析中に不明なエラーが発生しました</string>
     <string name="schedule_parsing_error_with_version">スケジュールバージョン％sの解析エラー %s</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Engelsystemシフトの解析中に不明なエラーが発生しました</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Engelsystemシフトの無効なAPIキー</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">EngelsystemシフトのURLが間違っています</string>
+    <string name="engelsystem_shifts_parsing_error_generic"><xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>シフトの解析中に不明なエラーが発生しました</string>
+    <string name="engelsystem_shifts_parsing_error_forbidden"><xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>シフトの無効なAPIキー</string>
+    <string name="engelsystem_shifts_parsing_error_not_found"><xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>シフトのURLが間違っています</string>
     <string name="alarms_empty">
         表示するアラームはありません。 スケジュールの
         項目ごとに個別のアラームを設定できることに注意してください。

--- a/app/src/main/res/values-nl/preferences.xml
+++ b/app/src/main/res/values-nl/preferences.xml
@@ -37,7 +37,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[Om jouw tijden te zien, vul jouw <u>persoonlijke</u> URL hier in.<br/><br/>
-        1. Login op jouw Engelsystem account.<br/>
+        1. Login op jouw <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> account.<br/>
         2. Kopieer de URL achter de <u>JSON Export</u> knop op jouw profielpagina.<br/>
         3. Plak de URL hier.<br/><br/>
         Tijden voor en na de hoofd conferance dagen zijn <u>niet</u> getoond.]]>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -100,9 +100,9 @@
     <string name="today">vandaag</string>
     <string name="schedule_parsing_error_generic">Onbekende fout tijdens verwerken tijdschema</string>
     <string name="schedule_parsing_error_with_version">Verwerkings fout voor tijdschema versie %s</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Onbekende fout gedurende het ontleden Engelsystem tijden</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Invalide API sleutel voor Engelsystem tijden</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Verkeerde URL voor Engelsysteem tijden</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Onbekende fout gedurende het ontleden <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> tijden</string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Invalide API sleutel voor <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> tijden</string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Verkeerde URL voor <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> tijden</string>
     <string name="alarms_empty">
 		Er zijn geen alarmen om weer te geven. Houd er rekening mee
         dat u individuele alarmen kunt instellen voor elk item in

--- a/app/src/main/res/values-pl/preferences.xml
+++ b/app/src/main/res/values-pl/preferences.xml
@@ -37,7 +37,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[Aby widzieć swoje zmiany, podaj tu <u>swój osobisty</u> URL.<br/><br/>
-        1. Zaloguj się na swoje konto w Engelsystem.<br/>
+        1. Zaloguj się na swoje konto w <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>.<br/>
         2. Skopiuj URL pod przyciskiem <u>JSON Export</u> na swojej stronie profilowej.<br/>
         3. Wklej tu skopiowany URL.<br/><br/>
         Zmiany przed oraz po głównych dniach konferencji <u>nie są</u> wyświetlane.]]>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -111,9 +111,9 @@
     <string name="today">dzisiaj</string>
     <string name="schedule_parsing_error_generic">Nieznany błąd w trakcie parsowania grafiku</string>
     <string name="schedule_parsing_error_with_version">Błąd parsowania dla grafiku w wersji <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>
-    <string name="engelsystem_shifts_parsing_error_generic">Nieznany błąd w trakcie parsowania zmian z Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Błędny klucz API dla zmian w Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Błędny URL dla zmian w Engelsystem</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Nieznany błąd w trakcie parsowania zmian z <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Błędny klucz API dla zmian w <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Błędny URL dla zmian w <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
     <string name="alarms_empty">
         Brak przypomnień do wyświetlenia. Pamiętaj, że możesz
         ustawić indywidualne przypomnienia dla każdej pozycji grafiku.

--- a/app/src/main/res/values-pt/preferences.xml
+++ b/app/src/main/res/values-pt/preferences.xml
@@ -17,7 +17,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
     <![CDATA[Para ver seus turnos, insira sua URL <u>pessoal</u> aqui.<br/><br/>
-        1. Faça login em sua conta Engelsystem.<br/>
+        1. Faça login em sua conta <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g>.<br/>
         2. Copie o URL atrás do botão <u>Exportar JSON</u> na página do seu perfil.<br/>
         3. Cole a URL aqui.<br/><br/>
         Os turnos antes e depois dos dias da conferência principal <u>não</u> são exibidos.]]>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -97,9 +97,9 @@
     <string name="today">hoje</string>
     <string name="schedule_parsing_error_generic">Erro desconhecido ao processar cronograma</string>
     <string name="schedule_parsing_error_with_version">Erro ao processar versão do cronograma %s</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Erro desconhecido ao processar turnos no Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Chave de API inválido para turnos no Engelsystem</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">URL incorreta para turnos no Engelsystem</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Erro desconhecido ao processar turnos no <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Chave de API inválido para turnos no <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
+    <string name="engelsystem_shifts_parsing_error_not_found">URL incorreta para turnos no <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g></string>
     <string name="alarms_empty">
         Não há alertas para exibir, você pode configurar alertas
         individuais para cada item no cronograma.

--- a/app/src/main/res/values-sv/preferences.xml
+++ b/app/src/main/res/values-sv/preferences.xml
@@ -17,7 +17,7 @@
 
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[För att se din pass, ange din <u>personliga</u> URL här.<br/><br/>
-        1. Logga in till ditt Engelsystem konto.<br/>
+        1. Logga in till ditt <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> konto.<br/>
         2. Kopiera URLen bakom <u>JSON Exporta</u> knappen på din profil sida.<br/>
         3. Klista in URLen här.<br/><br/>
         Pass före och efter huvudkonferensens dagar syns <u>inte</u>.]]>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -166,9 +166,9 @@
         Anpassade påminnelser för olika evenemang.
     </string>
     <string name="session_details_section_title_session_online">Online-händelse</string>
-    <string name="engelsystem_shifts_parsing_error_generic">Okänt fel vid tolking av Engelsystem pass</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Ogiltlig API nyckel för Engelsystem pass</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Felaktig URL för Engelsystem pass</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Okänt fel vid tolking av <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> pass</string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Ogiltlig API nyckel för <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> pass</string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Felaktig URL för <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> pass</string>
     <string name="validation_error_invalid_url">
         Ogiltlig <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL.
     </string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -128,21 +128,21 @@
     <string name="preference_engelsystem_category_key" translatable="false">
         preference_engelsystem_category_key
     </string>
-    <string name="preference_engelsystem_category_title" translatable="false">Engelsystem</string>
+    <string name="preference_engelsystem_category_title" translatable="false">@string/engelsystem_alias</string>
     <string name="preference_key_engelsystem_json_export_url" translatable="false">
         preference_key_engelsystem_json_export_url
     </string>
     <string name="preference_default_value_engelsystem_json_export_url" translatable="false" />
     <string name="preference_summary_engelsystem_json_export_url">
         <![CDATA[In order to see your shifts please enter your <u>personal</u> URL here.<br/><br/>
-        1. Login to your Engelsystem account.<br/>
+        1. Login to your <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> account.<br/>
         2. Copy the URL behind the <u>JSON Export</u> button at your profile page.<br/>
         3. Paste the URL here.<br/><br/>
         Shifts before and after the main conference days are <u>not</u> displayed.]]>
     </string>
     <string name="preference_title_engelsystem_json_export_url">Configure JSON Export URL</string>
     <string name="preference_url_type_friendly_name_engelsystem_json_export" translatable="false">
-        Engelsystem
+        @string/engelsystem_alias
     </string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,9 +120,9 @@
     <string name="today">today</string>
     <string name="schedule_parsing_error_generic">Unknown error while parsing schedule</string>
     <string name="schedule_parsing_error_with_version">Parsing error for schedule version <xliff:g example="0.99a" id="scheduleVersion">%s</xliff:g></string>
-    <string name="engelsystem_shifts_parsing_error_generic">Unknown error while parsing Engelsystem shifts</string>
-    <string name="engelsystem_shifts_parsing_error_forbidden">Invalid API key for Engelsystem shifts</string>
-    <string name="engelsystem_shifts_parsing_error_not_found">Wrong URL for Engelsystem shifts</string>
+    <string name="engelsystem_shifts_parsing_error_generic">Unknown error while parsing <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> shifts</string>
+    <string name="engelsystem_shifts_parsing_error_forbidden">Invalid API key for <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> shifts</string>
+    <string name="engelsystem_shifts_parsing_error_not_found">Wrong URL for <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> shifts</string>
     <string name="alarms_empty">
 		There are no alarms to display. Please note that you
 		can set up individual alarms for each item in the schedule.

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -381,7 +381,9 @@ class SessionDetailsViewModelTest {
         roomForC3NavConverter = roomForC3NavConverter,
         markdownConversion = markdownConversion,
         formattingDelegate = formattingDelegate,
-        c3NavBaseUrl = c3NavBaseUrl
+        c3NavBaseUrl = c3NavBaseUrl,
+        defaultEngelsystemRoomName = "Engelshifts",
+        customEngelsystemRoomName = "Trollshifts"
     )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -384,7 +384,9 @@ class FahrplanViewModelTest {
         navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
         simpleSessionFormat = simpleSessionFormat,
         jsonSessionFormat = jsonSessionFormat,
-        scrollAmountCalculator = scrollAmountCalculator
+        scrollAmountCalculator = scrollAmountCalculator,
+        defaultEngelsystemRoomName = "Engelshifts",
+        customEngelsystemRoomName = "Trollshifts"
     )
 
 }

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -17,6 +17,8 @@ This list is for your preparation. Step 3 guides you through where to fill in th
 - Email address for bug reports
 - Social media hashtags/handles (can be empty), e.g. `#36c3 @ccc`
 - Schedule feedback URL template (optional), e.g. `https://awesome-event.com/2021/events/%s/feedback/new`
+- Custom name used for the Engelsystem (optional), e.g. `Trollsystem`
+- Custom name used for the Engelsystem shifts (optional), e.g. `Trollshifts`
 - Engelsystem URL (optional), e.g. `https://engelsystem.de/awesome-event/shifts-json-export?key=YOUR_KEY`
 - Name/s of the author/s of the logo(s), website URL/s optionally
 
@@ -80,6 +82,8 @@ The following options can be enabled via a `buildConfigField` and configured in 
 - c3nav integration via `C3NAV_URL`
 - Chaosflix export via `ENABLE_CHAOSFLIX_EXPORT`
 - Engelsystem shifts via `ENABLE_ENGELSYSTEM_SHIFTS`
+  - Customize the name for the Engelsystem via `engelsystem_alias`
+  - Customize the name for the Engelsystem shifts via `engelsystem_shifts_alias`
   - Customize Engelsystem shifts JSON export URL hint via `preference_hint_engelsystem_json_export_url`
 - Feedback system via `SCHEDULE_FEEDBACK_URL`
 


### PR DESCRIPTION
# Description
+ A few events do not stick with the name of the "Engelsystem" software but use a custom name for the volunteer coordination system. The GPN event uses "Trollsystem" for example.
+ The alias can now be configured per build flavor aka. per event.

# Before and after screenshots
![before-settings](https://user-images.githubusercontent.com/144518/187987181-858d09e7-b95d-45c4-b699-2eae6a446c4d.png) ![after-settings](https://user-images.githubusercontent.com/144518/187987200-76fd03f9-9895-4373-8977-49fd0df1a2d9.png)
![before-error](https://user-images.githubusercontent.com/144518/187987215-995074da-2d7e-48bd-8058-8c0274202d34.png) ![after-error](https://user-images.githubusercontent.com/144518/187987226-0c21061a-70be-45cd-ba21-52f4c8ea6ee4.png)
![before-shifts](https://user-images.githubusercontent.com/144518/187987272-74bcdc33-0f7e-43a7-85ed-0630f6b56241.png) ![after-shifts](https://user-images.githubusercontent.com/144518/187987307-b0eddd44-4ebf-41c2-ac4b-5dc615e7cf6f.png)
![before-shift](https://user-images.githubusercontent.com/144518/187987319-21273c0e-6f60-4329-ab1e-32c340870e9c.png) ![after-shift](https://user-images.githubusercontent.com/144518/187987327-02b41c98-ea52-44f1-b69e-6c96951dffa9.png)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 12 (API 31)