### PR TITLE
Show "track" in session details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
@@ -22,6 +22,7 @@ data class SelectedSessionParameter(
     val description: String,
     val formattedDescription: String,
     val roomName: String,
+    val track: String,
 
     val hasLinks: Boolean,
     val formattedLinks: String,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -268,6 +268,22 @@ class SessionDetailsFragment : Fragment() {
             textView.isVisible = false
         }
 
+        // Track
+        val trackSectionView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_track_name_section_view)
+        typeface = typefaceFactory.getTypeface(viewModel.trackSectionFont)
+        trackSectionView.typeface = typeface
+        val trackView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_track_name_view)
+        val trackText = model.track
+        if (trackText.isEmpty()) {
+            trackSectionView.isVisible = false
+            trackView.isVisible = false
+        } else {
+            trackSectionView.isVisible = true
+            trackView.isVisible = true
+            typeface = typefaceFactory.getTypeface(viewModel.trackFont)
+            trackView.applyText(typeface, trackText)
+        }
+
         // Session online
         val sessionOnlineSectionView = view.requireViewByIdCompat<TextView>(R.id.session_details_content_session_online_section_view)
         typeface = typefaceFactory.getTypeface(viewModel.sessionOnlineSectionFont)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -71,6 +71,8 @@ class SessionDetailsViewModel(
     val descriptionFont = Font.Roboto.Regular
     val linksFont = Font.Roboto.Regular
     val linksSectionFont = Font.Roboto.Bold
+    val trackFont = Font.Roboto.Regular
+    val trackSectionFont = Font.Roboto.Black
     val sessionOnlineFont = Font.Roboto.Regular
     val sessionOnlineSectionFont = Font.Roboto.Black
     val speakersFont = Font.Roboto.Black
@@ -122,6 +124,7 @@ class SessionDetailsViewModel(
             description = description.orEmpty(),
             formattedDescription = formattedDescription,
             roomName = room.orEmpty(),
+            track = track.orEmpty(),
             hasLinks = getLinks().isNotEmpty(),
             formattedLinks = formattedLinks,
             hasWikiLinks = getLinks().containsWikiLink(),

--- a/app/src/main/res/layout/session_details_content.xml
+++ b/app/src/main/res/layout/session_details_content.xml
@@ -40,6 +40,16 @@
         tools:text="@string/placeholder_session_links"/>
 
     <TextView
+        android:id="@+id/session_details_content_track_name_section_view"
+        style="@style/SessionDetailsSection.Header"
+        android:text="@string/session_details_section_title_track"/>
+
+    <TextView
+        android:id="@+id/session_details_content_track_name_view"
+        style="@style/SessionDetailsSection"
+        tools:text="@string/placeholder_session_track"/>
+
+    <TextView
         android:id="@+id/session_details_content_session_online_section_view"
         style="@style/SessionDetailsSection.Header"
         android:text="@string/session_details_section_title_session_online"/>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,6 +89,7 @@
         Der Fahrplan wurde aktualisiert.
     </string>
     <string name="settings">Einstellungen</string>
+    <string name="session_details_section_title_track">Themenfeld</string>
     <string name="session_details_section_title_session_online">Event online</string>
     <string name="session_details_section_title_links">Links</string>
     <string name="choose_alarm_time">Wähle die Alarmzeit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="session_details_session_id" translatable="false">
         ID: <xliff:g example="5001a" id="id">%s</xliff:g>
     </string>
+    <string name="session_details_section_title_track">Subject area</string>
     <string name="session_details_section_title_session_online">Event online</string>
     <string name="session_details_section_title_links">Links</string>
     <string name="choose_alarm_time">Choose alarm time</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -90,6 +90,7 @@ class SessionDetailsViewModelTest {
             room = "Main hall"
             abstractt = "Session abstract"
             description = "Session description"
+            track = "Session track"
             links = "[VOC projects](https://www.voc.com/projects/),[POC](https://poc.com/QXut1XBymAk)"
             highlight = true
         }
@@ -137,6 +138,7 @@ class SessionDetailsViewModelTest {
             abstract = "Session abstract",
             formattedDescription = "Markdown",
             description = "Session description",
+            track = "Session track",
             hasLinks = true,
             formattedLinks = "Markdown",
             hasWikiLinks = false,
@@ -161,6 +163,7 @@ class SessionDetailsViewModelTest {
             room = ""
             abstractt = ""
             description = ""
+            track = ""
             links = ""
             highlight = false
         }
@@ -208,6 +211,7 @@ class SessionDetailsViewModelTest {
             abstract = "",
             formattedDescription = "",
             description = "",
+            track = "",
             hasLinks = false,
             formattedLinks = "",
             hasWikiLinks = false,


### PR DESCRIPTION
# Description
+ Until now the "track" is only visible in the schedule screen. Due to the limited space there the word(s) are often truncated.
+ Now the "track" can be read in the details screen.
+ The internal term "track" is displayed as "subject area" in English.

# Before and after screenshot
![before](https://user-images.githubusercontent.com/144518/188233946-ae8a1059-444d-41a5-a7fa-2c44c7d87b43.png) ![after](https://user-images.githubusercontent.com/144518/188233956-a3173874-93ea-4f95-9695-945b5085261e.png)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 12 (API 31)