### PR TITLE
Support configuring the postal address of the event

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ android {
         buildConfigField "String", "SOURCE_CODE_URL", '"https://github.com/EventFahrplan/EventFahrplan"'
         buildConfigField "String", "ISSUES_URL", '"https://github.com/EventFahrplan/EventFahrplan/issues"'
         buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", '"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md"'
+        buildConfigField "String", "EVENT_POSTAL_ADDRESS", '""'
         buildConfigField "boolean", "ENGAGE_C3NAV_APP_INSTALLATION", "false"
         buildConfigField "String", "C3NAV_URL", '""'
         buildConfigField "boolean", "ENABLE_ALTERNATIVE_SCHEDULE_URL", "false"
@@ -84,6 +85,7 @@ android {
             buildConfigField "String", "SCHEDULE_URL", '"https://data.c3voc.de/camp2019/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"http://events.ccc.de/camp/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"http://events.ccc.de/camp/2019/"'
+            buildConfigField "String", "EVENT_POSTAL_ADDRESS", '"Ziegeleipark Mildenberg, 16792 Zehdenick"'
             buildConfigField "String", "SERVER_BACKEND_TYPE", '"frab"'
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_YEAR", "2019"
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_MONTH", "8"
@@ -105,6 +107,7 @@ android {
             buildConfigField "String", "SCHEDULE_URL", '"https://raw.githubusercontent.com/voc/36C3_schedule/master/everything.schedule.xml"'
             buildConfigField "String", "EVENT_URL", '"https://events.ccc.de/congress/2019/Fahrplan/events/%1$s.html"'
             buildConfigField "String", "EVENT_WEBSITE_URL", '"https://events.ccc.de/congress/2019/wiki"'
+            buildConfigField "String", "EVENT_POSTAL_ADDRESS", '"Congress Center Leipzig, Messe-Allee 1, 04356 Leipzig"'
             buildConfigField "String", "SERVER_BACKEND_TYPE", '"frab"'
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_YEAR", "2019"
             buildConfigField "int", "SCHEDULE_FIRST_DAY_START_MONTH", "12"

--- a/app/src/ccc36c3/res/values-de/strings.xml
+++ b/app/src/ccc36c3/res/values-de/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Fahrplan</string>
-    <string name="app_hardcoded_subtitle">27.-30. Dezember 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27.-30. Dezember 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design von <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-es/strings.xml
+++ b/app/src/ccc36c3/res/values-es/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Calendario</string>
-    <string name="app_hardcoded_subtitle">27 - 30 de diciembre de 2019. Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27 - 30 de diciembre de 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Diseño por <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-fr/strings.xml
+++ b/app/src/ccc36c3/res/values-fr/strings.xml
@@ -3,5 +3,5 @@
     <string name="app_name">Programme du 36C3</string>
     <string name="copyright_logo"><![CDATA[36C3: Exhaustion de ressource. Conçu par <a href="http://bleeptrack.de">bleeptrack</a>]]></string>
     <string name="about_logo_content_description">36C3: logo d\'exhaustion de ressource</string>
-    <string name="app_hardcoded_subtitle">27–30 décembre 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27–30 décembre 2019</string>
 </resources>

--- a/app/src/ccc36c3/res/values-ja/strings.xml
+++ b/app/src/ccc36c3/res/values-ja/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Schedule</string>
-    <string name="app_hardcoded_subtitle">2019年12月27日〜30日, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">2019年12月27日〜30日</string>
     <string name="copyright_logo"><![CDATA[36C3: Resource exhaustion.  <a href="http://bleeptrack.de">bleeptrack</a>]]>によるデザイン</string>
     <string name="about_logo_content_description">36C3: Resource exhaustionのロゴ</string>
 </resources>

--- a/app/src/ccc36c3/res/values-nl/strings.xml
+++ b/app/src/ccc36c3/res/values-nl/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Schedule</string>
-    <string name="app_hardcoded_subtitle">27–30 december 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27–30 december 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Ontwerp door <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-pl/strings.xml
+++ b/app/src/ccc36c3/res/values-pl/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Grafik 36C3</string>
-    <string name="app_hardcoded_subtitle">27–30 grudnia 2019, Lipsk, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27–30 grudnia 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Projekt <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-pt/strings.xml
+++ b/app/src/ccc36c3/res/values-pt/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Cronograma 36C3</string>
-    <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27.-30 de dezembro de 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design por <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-ru/strings.xml
+++ b/app/src/ccc36c3/res/values-ru/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Pасписание 36C3</string>
-    <string name="app_hardcoded_subtitle">27.-30-го декабря 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27.-30-го декабря 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion дизайн от <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values-sv/strings.xml
+++ b/app/src/ccc36c3/res/values-sv/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Schedule</string>
-    <string name="app_hardcoded_subtitle">27–30 december 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">27–30 december 2019</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design av <a href="http://bleeptrack.de">bleeptrack</a>]]>
     </string>

--- a/app/src/ccc36c3/res/values/strings.xml
+++ b/app/src/ccc36c3/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">36C3 Schedule</string>
-    <string name="app_hardcoded_subtitle">December 27.-30. 2019, Leipzig, Leipziger Messe</string>
+    <string name="app_hardcoded_subtitle">December 27.-30. 2019</string>
     <string name="conference_name" translatable="false">36C3</string>
     <string name="copyright_logo">
         <![CDATA[36C3: Resource exhaustion. Design by <a href="http://bleeptrack.de">bleeptrack</a>]]>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.kt
@@ -1,17 +1,23 @@
 package nerd.tuxmobil.fahrplan.congress.about
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import android.widget.Toast
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.setLinkText
+import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
@@ -93,6 +99,17 @@ class AboutDialog : DialogFragment() {
         logoCopyright.setLinkTextColor(linkTextColor)
         logoCopyright.movementMethod = movementMethod
 
+        // Event location
+        val locationView = view.requireViewByIdCompat<TextView>(R.id.about_conference_location_view)
+        val locationText = BuildConfig.EVENT_POSTAL_ADDRESS
+        if (locationText.isEmpty()) {
+            locationView.isVisible = false
+        } else {
+            locationView.isVisible = true
+            locationView.setLinkText(locationText, null, movementMethod, linkTextColor)
+            locationView.setOnClickListener { openMap(view.context, locationText) }
+        }
+
         // Event website URL
         val conferenceUrl = view.requireViewByIdCompat<TextView>(R.id.about_conference_url_view)
         val websiteUrl = BuildConfig.EVENT_WEBSITE_URL
@@ -167,6 +184,14 @@ class AboutDialog : DialogFragment() {
         val buildHashValue = getString(R.string.git_sha)
         val buildHashText = getString(R.string.build_info_hash, buildHashValue)
         buildHashTextView.text = buildHashText
+    }
+
+    private fun openMap(context: Context, @Suppress("SameParameterValue") locationText: String) {
+        val encodedLocationText = Uri.encode(locationText)
+        val uri = "geo:0,0?q=$encodedLocationText".toUri()
+        context.startActivity(Intent(Intent.ACTION_VIEW).apply { data = uri }) {
+            Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
+        }
     }
 
 }

--- a/app/src/main/res/layout/about_dialog.xml
+++ b/app/src/main/res/layout/about_dialog.xml
@@ -47,6 +47,18 @@
             tools:text="Works for me" />
 
         <TextView
+            android:id="@+id/about_conference_location_view"
+            style="@style/TextViewLinks"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:linksClickable="true"
+            android:paddingBottom="10dp"
+            android:singleLine="false"
+            tools:text="CCH, Congressplatz 1, 20355 Hamburg" />
+
+        <TextView
             android:id="@+id/about_conference_url_view"
             style="@style/TextViewLinks"
             android:layout_width="wrap_content"

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -13,6 +13,7 @@ This list is for your preparation. Step 3 guides you through where to fill in th
 - Google Play URL, e.g. `https://play.google.com/store/apps/details?id=com.awesome.event.schedule`
 - F-Droid URL, e.g. `https://f-droid.org/packages/com.awesome.event.schedule`
 - Event URL, e.g. `https://awesome-event.com/2021`
+- Event postal address (optional), e.g. `CCH, Congressplatz 1, 20355 Hamburg`
 - Start and end date of the event
 - Email address for bug reports
 - Social media hashtags/handles (can be empty), e.g. `#36c3 @ccc`
@@ -77,6 +78,7 @@ In some of the steps it is the easiest to copy and adapt configuration settings,
 
 The following options can be enabled via a `buildConfigField` and configured in *app/build.gradle* if needed.
 
+- Event postal address for easy map navigation via `EVENT_POSTAL_ADDRESS`
 - Social media hashtags/handles for the event via `SOCIAL_MEDIA_HASHTAGS_HANDLES`
 - Alternative schedule URL via `ENABLE_ALTERNATIVE_SCHEDULE_URL`
 - c3nav integration via `C3NAV_URL`


### PR DESCRIPTION
# Description
+ Tapping the address link in the info screen triggers a request to open a map app to navigate to the given address.
+ The build config field can be empty. In this case the associated view is hidden.
+ The postal address can now be configured per build flavor aka. per event.

# Before and after screenshots
![before](https://user-images.githubusercontent.com/144518/189502497-163914ef-d057-4c02-86da-18a1c6117718.png) ![after](https://user-images.githubusercontent.com/144518/189502502-8cced9af-aa27-403d-a0f3-c4c40133c5e5.png)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 12 (API 31)