### PR TITLE
 Use compileSdk & targetSdk 33 (Android 13).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
             android:label="@string/app_name"
             android:name="nerd.tuxmobil.fahrplan.congress.MyApp"
             android:theme="@style/Theme.Congress"
+            android:localeConfig="@xml/locales_config"
             >
         <activity
                 android:label="@string/app_name"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -1,5 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.details
 
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -14,6 +16,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
@@ -38,6 +42,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
@@ -69,13 +74,15 @@ class SessionDetailsFragment : Fragment() {
         }
 
     }
-
+    private lateinit var permissionRequestLauncher: ActivityResultLauncher<String>
     private lateinit var appRepository: AppRepository
     private lateinit var alarmServices: AlarmServices
+    private lateinit var notificationHelper: NotificationHelper
     private val viewModel: SessionDetailsViewModel by viewModels {
         SessionDetailsViewModelFactory(
             appRepository = appRepository,
             alarmServices = alarmServices,
+            notificationHelper = notificationHelper,
             defaultEngelsystemRoomName = AppRepository.ENGELSYSTEM_ROOM_NAME,
             customEngelsystemRoomName = getString(R.string.engelsystem_shifts_alias)
         )
@@ -105,6 +112,7 @@ class SessionDetailsFragment : Fragment() {
         super.onAttach(context)
         appRepository = AppRepository
         alarmServices = AlarmServices.newInstance(context, appRepository)
+        notificationHelper = NotificationHelper(context)
         markwon = Markwon.builder(requireContext())
             .usePlugin(LinkifyPlugin.create())
             .build()
@@ -114,6 +122,15 @@ class SessionDetailsFragment : Fragment() {
     @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        permissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
+            if (isGranted) {
+                viewModel.setAlarm()
+            } else {
+                showMissingPostNotificationsPermissionError()
+            }
+        }
+
         setHasOptionsMenu(true)
     }
 
@@ -142,6 +159,7 @@ class SessionDetailsFragment : Fragment() {
         activity.setResult(Activity.RESULT_CANCELED)
     }
 
+    @SuppressLint("InlinedApi")
     private fun observeViewModel() {
         viewModel.selectedSessionParameter.observe(viewLifecycleOwner) { model ->
             this.model = model
@@ -183,6 +201,12 @@ class SessionDetailsFragment : Fragment() {
             if (activity is OnSidePaneCloseListener) {
                 (activity as OnSidePaneCloseListener).onSidePaneClose(FRAGMENT_TAG)
             }
+        }
+        viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
+            permissionRequestLauncher.launch(POST_NOTIFICATIONS)
+        }
+        viewModel.missingPostNotificationsPermission.observe(viewLifecycleOwner) {
+            showMissingPostNotificationsPermissionError()
         }
     }
 
@@ -324,6 +348,10 @@ class SessionDetailsFragment : Fragment() {
         this.setLinkTextColor(ContextCompat.getColor(context, R.color.text_link_on_light))
         this.movementMethod = LinkMovementMethodCompat.getInstance()
         this.isVisible = true
+    }
+
+    private fun showMissingPostNotificationsPermissionError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
     }
 
     private fun updateOptionsMenu() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.navigation.RoomForC3NavConverter
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
@@ -13,10 +14,11 @@ import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 
-class SessionDetailsViewModelFactory(
+internal class SessionDetailsViewModelFactory(
 
     private val appRepository: AppRepository,
     private val alarmServices: AlarmServices,
+    private val notificationHelper: NotificationHelper,
     private val defaultEngelsystemRoomName: String,
     private val customEngelsystemRoomName: String
 
@@ -28,6 +30,7 @@ class SessionDetailsViewModelFactory(
             repository = appRepository,
             executionContext = AppExecutionContext,
             alarmServices = alarmServices,
+            notificationHelper = notificationHelper,
             sessionFormatter = SessionFormatter(),
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/IntentExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/IntentExtensions.kt
@@ -1,10 +1,21 @@
 package nerd.tuxmobil.fahrplan.congress.extensions
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
+import android.os.Parcelable
 import androidx.core.os.bundleOf
 
 /**
  * Puts the given [pairs] as a [Bundle] into this [Intent].
  */
 fun Intent.withExtras(vararg pairs: Pair<String, Any?>): Intent = putExtras(bundleOf(*pairs))
+
+/**
+ * Retrieves extended data of type [T] from the intent. See [Intent.getParcelableExtra].
+ * To be removed once the androidx.core library offers such a compat wrapper.
+ */
+inline fun <reified T : Parcelable> Intent.getParcelableExtraCompat(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getParcelableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -18,6 +18,8 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
         getNotificationManager()
     }
 
+    val notificationsEnabled = notificationManager.areNotificationsEnabled()
+
     init {
         createChannels()
     }
@@ -125,5 +127,4 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
         private const val SCHEDULE_UPDATE_CHANNEL_ID = "SCHEDULE_UPDATE_CHANNEL"
         const val SCHEDULE_UPDATE_ID = 2
     }
-
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/AlarmTonePreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/AlarmTonePreference.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import android.content.Intent
 import android.media.RingtoneManager
 import android.net.Uri
+import android.os.Build
 import android.provider.Settings
 import android.util.AttributeSet
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
+import nerd.tuxmobil.fahrplan.congress.extensions.getParcelableExtraCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 
@@ -76,7 +78,7 @@ class AlarmTonePreference : Preference {
     }
 
     fun onAlarmTonePicked(intent: Intent) {
-        val alarmToneUri = intent.getParcelableExtra<Uri?>(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
+        val alarmToneUri = intent.getParcelableExtraCompat<Uri>(RingtoneManager.EXTRA_RINGTONE_PICKED_URI)
         persistString(AlarmToneConversion.getPersistableString(alarmToneUri))
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -1,5 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Typeface
 import android.os.Build
@@ -22,6 +24,8 @@ import android.widget.LinearLayout.LayoutParams.MATCH_PARENT
 import android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.appcompat.app.ActionBar.NAVIGATION_MODE_LIST
 import androidx.appcompat.app.ActionBar.OnNavigationListener
 import androidx.appcompat.app.AppCompatActivity
@@ -44,6 +48,7 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
 import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
@@ -52,6 +57,7 @@ import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.net.ConnectivityObserver
 import nerd.tuxmobil.fahrplan.congress.net.ErrorMessage
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
@@ -89,6 +95,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     }
 
+    private lateinit var permissionRequestLauncher: ActivityResultLauncher<String>
     private lateinit var inflater: LayoutInflater
     private lateinit var sessionViewDrawer: SessionViewDrawer
     private lateinit var errorMessageFactory: ErrorMessage.Factory
@@ -104,6 +111,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
+        val notificationHelper = NotificationHelper(context)
         val appRepository = AppRepository
         val alarmServices = AlarmServices.newInstance(context, appRepository)
         val menuEntriesGenerator = NavigationMenuEntriesGenerator(dayString = getString(R.string.day), todayString = getString(R.string.today))
@@ -112,6 +120,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val viewModelFactory = FahrplanViewModelFactory(
             repository = appRepository,
             alarmServices = alarmServices,
+            notificationHelper = notificationHelper,
             navigationMenuEntriesGenerator = menuEntriesGenerator,
             defaultEngelsystemRoomName = defaultEngelsystemRoomName,
             customEngelsystemRoomName = customEngelsystemRoomName
@@ -131,6 +140,15 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        permissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
+            if (isGranted) {
+                showAlarmTimePicker()
+            } else {
+                showMissingPostNotificationsPermissionError()
+            }
+        }
+
         setHasOptionsMenu(true)
         val context = requireContext()
         roomTitleTypeFace = TypefaceFactory.getNewInstance(context).getTypeface(Font.Roboto.Light)
@@ -165,6 +183,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         inflater = view.context.getLayoutInflater()
     }
 
+    @SuppressLint("InlinedApi")
     private fun observeViewModel() {
         viewModel.fahrplanParameter.observe(viewLifecycleOwner) { (scheduleData, numDays, dayIndex, menuEntries) ->
             menuEntries?.let { buildNavigationMenu(it, numDays) }
@@ -193,6 +212,15 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         }
         viewModel.scrollToSessionParameter.observe(viewLifecycleOwner) { (sessionId, verticalPosition, roomIndex) ->
             scrollTo(sessionId, verticalPosition, roomIndex)
+        }
+        viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
+            permissionRequestLauncher.launch(POST_NOTIFICATIONS)
+        }
+        viewModel.missingPostNotificationsPermission.observe(viewLifecycleOwner) {
+            showMissingPostNotificationsPermissionError()
+        }
+        viewModel.showAlarmTimePicker.observe(viewLifecycleOwner) {
+            showAlarmTimePicker()
         }
     }
 
@@ -455,7 +483,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 updateMenuItems()
             }
             CONTEXT_MENU_ITEM_ID_SET_ALARM -> {
-                showAlarmTimePicker()
+                viewModel.showAlarmTimePickerWithChecks()
             }
             CONTEXT_MENU_ITEM_ID_DELETE_ALARM -> {
                 viewModel.deleteAlarm(session)
@@ -522,6 +550,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         } else {
             menu.add(0, CONTEXT_MENU_ITEM_ID_SHARE, 4, getString(R.string.menu_item_title_share_session))
         }
+    }
+
+    private fun showMissingPostNotificationsPermissionError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
     }
 
     private inner class OnDaySelectedListener(private val numDays: Int) : OnNavigationListener {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
@@ -15,7 +16,8 @@ internal class FahrplanViewModelFactory(
     private val alarmServices: AlarmServices,
     private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
     private val defaultEngelsystemRoomName: String,
-    private val customEngelsystemRoomName: String
+    private val customEngelsystemRoomName: String,
+    private val notificationHelper: NotificationHelper
 
 ) : ViewModelProvider.Factory {
 
@@ -27,6 +29,7 @@ internal class FahrplanViewModelFactory(
             executionContext = AppExecutionContext,
             logging = logging,
             alarmServices = alarmServices,
+            notificationHelper = notificationHelper,
             navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
@@ -43,6 +44,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.net.CertificateErrorFragment
 import nerd.tuxmobil.fahrplan.congress.net.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.reporting.TraceDroidEmailSender
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.OnSessionClickListener
@@ -89,11 +91,14 @@ class MainActivity : BaseActivity(),
             )
     }
 
+    private lateinit var notificationHelper: NotificationHelper
     private lateinit var keyguardManager: KeyguardManager
     private lateinit var errorMessageFactory: ErrorMessage.Factory
     private lateinit var progressBar: ContentLoadingProgressBar
     private var progressDialog: ProgressDialog? = null
-    private val viewModel: MainViewModel by viewModels { MainViewModelFactory(AppRepository) }
+    private val viewModel: MainViewModel by viewModels {
+        MainViewModelFactory(AppRepository, notificationHelper)
+    }
 
     private var isScreenLocked = false
     private var isFavoritesInSidePane = false
@@ -108,6 +113,8 @@ class MainActivity : BaseActivity(),
         super.onCreate(savedInstanceState)
         instance = this
         setContentView(R.layout.main_layout)
+
+        notificationHelper = NotificationHelper(this)
 
         keyguardManager = getSystemService()!!
         errorMessageFactory = ErrorMessage.Factory(this)
@@ -134,6 +141,7 @@ class MainActivity : BaseActivity(),
         initUserEngagement()
         observeViewModel()
         onSessionAlarmNotificationTapped(intent)
+        viewModel.checkPostNotificationsPermission()
     }
 
     private fun observeViewModel() {
@@ -159,6 +167,9 @@ class MainActivity : BaseActivity(),
         }
         viewModel.openSessionDetails.observe(this) {
             openSessionDetails()
+        }
+        viewModel.missingPostNotificationsPermission.observe(this) {
+            Toast.makeText(this, R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
         }
     }
 
@@ -387,5 +398,4 @@ class MainActivity : BaseActivity(),
         }
         shouldScrollToCurrent = true
     }
-
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.changes.ChangeStatistic
 import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.net.ParseResult
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
@@ -23,9 +24,10 @@ import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.LoadScheduleUiState
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScheduleChangesParameter
 
-class MainViewModel(
+internal class MainViewModel(
 
     private val repository: AppRepository,
+    private val notificationHelper: NotificationHelper,
     private val executionContext: ExecutionContext,
     private val logging: Logging
 
@@ -38,6 +40,7 @@ class MainViewModel(
 
     val showAbout = SingleLiveEvent<Meta>()
     val openSessionDetails = SingleLiveEvent<Unit>()
+    val missingPostNotificationsPermission = SingleLiveEvent<Unit>()
 
     init {
         observeLoadScheduleState()
@@ -132,6 +135,12 @@ class MainViewModel(
         launch {
             val meta = repository.readMeta()
             showAbout.postValue(meta)
+        }
+    }
+
+    fun checkPostNotificationsPermission() {
+        if (repository.readAlarms().isNotEmpty() && !notificationHelper.notificationsEnabled) {
+            missingPostNotificationsPermission.postValue(Unit)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelFactory.kt
@@ -3,12 +3,14 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
-class MainViewModelFactory(
+internal class MainViewModelFactory(
 
-    private val repository: AppRepository
+    private val repository: AppRepository,
+    private val notificationHelper: NotificationHelper
 
 ) : ViewModelProvider.Factory {
 
@@ -17,6 +19,7 @@ class MainViewModelFactory(
         val logging = Logging.get()
         return MainViewModel(
             repository = repository,
+            notificationHelper = notificationHelper,
             executionContext = AppExecutionContext,
             logging = logging
         ) as T

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,6 +206,8 @@
     <string name="alarm_time_title_45_minutes_before">45 Minuten vorher</string>
     <string name="alarm_time_title_60_minutes_before">60 Minuten vorher</string>
 
+    <string name="alarms_disabled_notifications_permission_missing">Alarme sind deaktiviert. Bitte erteile die \"Benachrichtigungen\" Berechtigung.</string>
+
     <!-- Session list item -->
     <string name="session_list_item_alarm_time_zero_minutes_content_description">Alarm: zur Startzeit</string>
     <string name="session_list_item_alarm_time_minutes_content_description">Alarm: <xliff:g example="5" id="minutes">%d</xliff:g> Minuten vorher</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,8 @@
     <string name="alarm_time_title_45_minutes_before">45 minutes before</string>
     <string name="alarm_time_title_60_minutes_before">60 minutes before</string>
 
+    <string name="alarms_disabled_notifications_permission_missing">Alarms are disabled. Please grant the \"Notifications\" permission.</string>
+
     <!-- Session list item -->
     <string name="session_list_item_alarm_time_zero_minutes_content_description">Alarm: at start time</string>
     <string name="session_list_item_alarm_time_minutes_content_description">Alarm: <xliff:g example="5" id="minutes">%d</xliff:g> minutes before</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+   <locale android:name="en"/>
+   <locale android:name="de"/>
+   <locale android:name="es"/>
+   <locale android:name="fr"/>
+   <locale android:name="it"/>
+   <locale android:name="ja"/>
+   <locale android:name="nl"/>
+   <locale android:name="pl"/>
+   <locale android:name="pt"/>
+   <locale android:name="ru"/>
+   <locale android:name="sv"/>
+</locale-config>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -20,6 +20,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanEmptyParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanParameter
@@ -201,6 +202,47 @@ class FahrplanViewModelTest {
     }
 
     @Test
+    fun `showAlarmTimePickerWithChecks() posts to showAlarmTimePicker`() {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn true
+        }
+        val repository = createRepository()
+        val viewModel = createViewModel(repository, notificationHelper = notificationHelper)
+        viewModel.showAlarmTimePickerWithChecks()
+        assertLiveData(viewModel.showAlarmTimePicker).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `showAlarmTimePickerWithChecks() posts to requestPostNotificationsPermission`() {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn false
+        }
+        val repository = createRepository()
+        val viewModel = createViewModel(
+            repository = repository,
+            notificationHelper = notificationHelper,
+            runsAtLeastOnAndroidTiramisu = true
+        )
+        viewModel.showAlarmTimePickerWithChecks()
+        assertLiveData(viewModel.requestPostNotificationsPermission).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `showAlarmTimePickerWithChecks() posts to missingPostNotificationsPermission`() {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn false
+        }
+        val repository = createRepository()
+        val viewModel = createViewModel(
+            repository = repository,
+            notificationHelper = notificationHelper,
+            runsAtLeastOnAndroidTiramisu = false
+        )
+        viewModel.showAlarmTimePickerWithChecks()
+        assertLiveData(viewModel.missingPostNotificationsPermission).isEqualTo(Unit)
+    }
+
+    @Test
     fun `addAlarm invokes alarmService function`() {
         val repository = createRepository()
         val alarmServices = mock<AlarmServices>()
@@ -375,20 +417,24 @@ class FahrplanViewModelTest {
     private fun createViewModel(
         repository: AppRepository,
         alarmServices: AlarmServices = mock(),
+        notificationHelper: NotificationHelper = mock(),
         navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator = mock(),
         simpleSessionFormat: SimpleSessionFormat = this.simpleSessionFormat,
-        jsonSessionFormat: JsonSessionFormat = this.jsonSessionFormat
+        jsonSessionFormat: JsonSessionFormat = this.jsonSessionFormat,
+        runsAtLeastOnAndroidTiramisu: Boolean = false
     ) = FahrplanViewModel(
         repository = repository,
         executionContext = TestExecutionContext,
         logging = NoLogging,
         alarmServices = alarmServices,
+        notificationHelper = notificationHelper,
         navigationMenuEntriesGenerator = navigationMenuEntriesGenerator,
         simpleSessionFormat = simpleSessionFormat,
         jsonSessionFormat = jsonSessionFormat,
         scrollAmountCalculator = scrollAmountCalculator,
         defaultEngelsystemRoomName = "Engelshifts",
-        customEngelsystemRoomName = "Trollshifts"
+        customEngelsystemRoomName = "Trollshifts",
+        runsAtLeastOnAndroidTiramisu = runsAtLeastOnAndroidTiramisu
     )
 
 }

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -10,9 +10,9 @@ object Config {
 
 object Android {
     const val buildToolsVersion = "33.0.0"
-    const val compileSdkVersion = 31
+    const val compileSdkVersion = 33
     const val minSdkVersion = 16
-    const val targetSdkVersion = 31
+    const val targetSdkVersion = 33
 }
 
 object Plugins {
@@ -42,7 +42,7 @@ object Libs {
 
     private object Versions {
         const val annotation = "1.5.0"
-        const val appCompat = "1.4.2" // compileSdk 32 is required as of 1.5.0
+        const val appCompat = "1.4.2" // compileSdk 32 is required as of 1.5.0, potential lifecycle-viewmodel-ktx conflict, see: https://issuetracker.google.com/issues/238425626
         const val assertjAndroid = "1.2.0"
         const val betterLinkMovementMethod = "2.2.0"
         const val constraintLayout = "2.1.4"


### PR DESCRIPTION
# Description
* Use `compileSdk` 33.
* Use `targetSdk` 33.
* Add per-app translations
* Implement new notifications permission

# Tested on (with all build flavors):
- Phone (Pixel 2), API lvl 24 Emulator
- Phone (Pixel 2), API lvl 33 Emulator

Resolves #513
