### PR TITLE
Ease customization of colors and background images

### DIFF
--- a/app/src/main/res/drawable/schedule_changes_background.xml
+++ b/app/src/main/res/drawable/schedule_changes_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/schedule_changes_background" />
+        </shape>
+    </item>
+
+</layer-list>

--- a/app/src/main/res/layout/about_dialog.xml
+++ b/app/src/main/res/layout/about_dialog.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_root"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@color/about_window_background">
 
     <LinearLayout
         android:layout_width="fill_parent"

--- a/app/src/main/res/layout/fragment_session_list.xml
+++ b/app/src/main/res/layout/fragment_session_list.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@drawable/favorites_background"
+    android:background="@drawable/schedule_changes_background"
     tools:context=".changes.ChangeListFragment">
 
     <ListView

--- a/app/src/main/res/layout/fragment_session_list_narrow.xml
+++ b/app/src/main/res/layout/fragment_session_list_narrow.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@drawable/favorites_background"
+    android:background="@drawable/schedule_changes_background"
     tools:context=".changes.ChangeListFragment">
 
     <ListView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -29,6 +29,7 @@
     <color name="day_menu_text">@color/text_primary</color>
 
     <!-- About -->
+    <color name="about_window_background">@color/windowBackground</color>
     <color name="about_horizontal_line">#606060</color>
     <color name="about_title">@android:color/primary_text_dark</color>
     <color name="about_subtitle">@android:color/primary_text_dark</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -63,9 +63,9 @@
     <color name="favorites_background">#ffffff</color>
 
     <!-- Session item (favorites + schedule changes) -->
-    <color name="session_list_header_text">@android:color/secondary_text_light</color>
-    <color name="session_list_item_text">#000000</color>
-    <color name="session_list_empty_text">#000000</color>
+    <color name="session_list_header_text">@color/text_primary</color>
+    <color name="session_list_item_text">@color/text_primary</color>
+    <color name="session_list_empty_text">@color/text_primary</color>
 
     <!-- Spinner -->
     <color name="spinner_drop_down_text">#cc0000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -54,6 +54,7 @@
     <color name="schedule_changes_dialog_new_version_text">@color/colorAccent</color>
 
     <!-- Schedule changes -->
+    <color name="schedule_changes_background">@color/windowBackground</color>
     <color name="schedule_change">#F57C00</color>
     <color name="schedule_change_new">#689F38</color>
     <color name="schedule_change_canceled">#D32F2F</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <color name="text_primary">@android:color/primary_text_dark</color>
+    <color name="text_secondary">@android:color/secondary_text_dark</color>
+    <color name="text_tertiary">@android:color/tertiary_text_dark</color>
     <color name="windowBackground">#003339</color>
     <color name="popupBackground">@color/colorPrimaryDark</color>
     <color name="text_link_on_light">@color/colorAccent</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="text_tertiary">@android:color/tertiary_text_dark</color>
     <color name="windowBackground">#003339</color>
     <color name="popupBackground">@color/colorPrimaryDark</color>
+    <color name="foreground">#888</color>
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
     <color name="text_link_pressed_background_on_light">#aafec700</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,7 @@
 
     <!-- Tool bar -->
     <color name="tool_bar_background">@color/colorPrimary</color>
+    <color name="day_menu_text">@color/text_primary</color>
 
     <!-- About -->
     <color name="about_horizontal_line">#606060</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,7 +60,7 @@
 
     <!-- Favorites -->
     <color name="favorites_past_session_text">#808080</color>
-    <color name="favorites_background">#ffffff</color>
+    <color name="favorites_background">@color/windowBackground</color>
 
     <!-- Session item (favorites + schedule changes) -->
     <color name="session_list_header_text">@color/text_primary</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -66,14 +66,8 @@
     <color name="spinner_drop_down_text">#cc0000</color>
 
     <!-- Session details -->
-    <color name="session_details_background">
-        @color/session_background
-    </color>
-    <color name="session_details_text">
-        @android:color/black
-    </color>
-    <color name="session_detailbar_icon">
-        @color/colorAccent
-    </color>
+    <color name="session_details_background">@color/session_background</color>
+    <color name="session_details_text">@android:color/black</color>
+    <color name="session_detailbar_icon">@color/colorAccent</color>
 
 </resources>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -6,6 +6,8 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:textColorPrimary">@color/text_primary</item>
+        <item name="android:textColorSecondary">@color/text_secondary</item>
 
         <!-- The rest of your attributes -->
         <item name="android:textColorHighlight">@color/text_link_pressed_background_on_light</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -32,6 +32,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:colorForeground">@color/foreground</item>
         <item name="android:textColorPrimary">@color/text_primary</item>
         <item name="android:textColorSecondary">@color/text_secondary</item>
         <item name="android:textColorHint">@color/text_secondary</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -94,6 +94,8 @@
     </style>
 
     <style name="AlertDialog" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="android:textColorPrimary">@color/text_primary</item>
+        <item name="android:textColorSecondary">@color/text_secondary</item>
         <item name="colorAccent">@color/alert_dialog_button_text</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
         <item name="android:windowBackground">@color/windowBackground</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -116,6 +116,7 @@
         <item name="android:paddingLeft">16dp</item>
         <item name="android:background">@color/popupBackground</item>
         <item name="android:foreground">?android:attr/selectableItemBackground</item>
+        <item name="android:textColor">@color/day_menu_text</item>
     </style>
 
     <style name="AlarmList.Icon" parent="@android:style/TextAppearance.Medium">

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -17,6 +17,7 @@
         <item name="alertDialogTheme">@style/AlertDialog</item>
         <item name="android:windowBackground">@drawable/window_background</item>
         <item name="android:spinnerItemStyle">@style/SpinnerItemStyle</item>
+        <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItemStyle</item>
 
         <!-- Scrollbar -->
         <item name="android:scrollbarSize">@dimen/scrollbar_size</item>
@@ -38,6 +39,7 @@
         <item name="actionOverflowMenuStyle">@style/PopupMenuOverflowStyle</item>
         <item name="android:contextPopupMenuStyle" tools:targetApi="N">@style/ContextPopupMenuStyle</item>
         <item name="android:spinnerItemStyle">@style/SpinnerItemStyle</item>
+        <item name="android:spinnerDropDownItemStyle">@style/SpinnerDropDownItemStyle</item>
         <item name="actionDropDownStyle">@style/MyActionDropDownStyle</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeBackground">@color/colorPrimary</item>
@@ -55,8 +57,15 @@
     </style>
 
     <style name="SpinnerItemStyle" parent="Widget.AppCompat.DropDownItem.Spinner">
+        <item name="android:textColor">@color/text_primary</item>
         <item name="android:paddingBottom">12dp</item>
         <item name="android:paddingTop">12dp</item>
+        <item name="android:foreground">?android:attr/selectableItemBackground</item>
+    </style>
+
+    <style name="SpinnerDropDownItemStyle" parent="Widget.AppCompat.DropDownItem.Spinner">
+        <item name="android:textColor">@color/text_primary</item>
+        <item name="android:background">@color/windowBackground</item>
         <item name="android:foreground">?android:attr/selectableItemBackground</item>
     </style>
 

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -29,6 +29,9 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:textColorPrimary">@color/text_primary</item>
+        <item name="android:textColorSecondary">@color/text_secondary</item>
+        <item name="android:textColorHint">@color/text_secondary</item>
 
         <!-- The rest of your attributes -->
         <item name="android:textColorHighlight">@color/text_link_pressed_background_on_light</item>

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -99,6 +99,7 @@
         <item name="colorAccent">@color/alert_dialog_button_text</item>
         <item name="android:textAppearance">@style/TextAppearance.AppCompat.Title</item>
         <item name="android:windowBackground">@color/windowBackground</item>
+        <item name="textColorAlertDialogListItem">@color/text_secondary</item>
     </style>
 
     <style name="MyActionDropDownStyle" parent="Widget.AppCompat.Spinner.DropDown.ActionBar">


### PR DESCRIPTION
# Description
- Base definitions for colors are placed in the `main` sourceSet and can be overwritten in each flavor.
- Refer to the individual commit messages for details.

# Successfully tested on
with `ccc36c3`, `camp2019`, `rc3` flavors, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 32)