### PR TITLE
Fix crash when opening schedule changes screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
@@ -15,7 +15,7 @@ fun Context.getAlarmManager() = getSystemService<AlarmManager>()!!
 
 fun Context.getLayoutInflater() = getSystemService<LayoutInflater>()!!
 
-fun Context.getNotificationManager() = getSystemService<NotificationManagerCompat>()!!
+fun Context.getNotificationManager() = NotificationManagerCompat.from(this)
 
 fun Context.startActivity(intent: Intent, onActivityNotFound: () -> Unit) {
     try {


### PR DESCRIPTION
# Description
+ Fix invalid service API usage.
+ Broken since: 490decaef7ad162958a0d195c76c0c8bb6e2a21f, #523.

# Stacktrace

``` java
java.lang.NullPointerException
    at nerd.tuxmobil.fahrplan.congress.extensions.Contexts.getNotificationManager(Contexts.kt:32)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper$notificationManager$2.invoke(NotificationHelper.kt:18)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper$notificationManager$2.invoke(NotificationHelper.kt:17)
    at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper.getNotificationManager(NotificationHelper.kt:17)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper.createNotificationChannel(NotificationHelper.kt:79)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper.createChannels(NotificationHelper.kt:26)
    at nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper.<init>(NotificationHelper.kt:22)
    at nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment$observeViewModel$2.invoke(ChangeListFragment.kt:90)
    at nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment$observeViewModel$2.invoke(ChangeListFragment.kt:89)
    at nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment.observeViewModel$lambda$1(ChangeListFragment.kt:89)
    at nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment.$r8$lambda$Rge6oC2T5Y_uOCd8coeZ3068k6Q(Unknown Source:0)
    at nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment$$ExternalSyntheticLambda1.onChanged(Unknown Source:2)
    at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent$observe$1.invoke(SingleLiveEvent.kt:35)
    at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent$observe$1.invoke(SingleLiveEvent.kt:33)
    at info.metadude.android.eventfahrplan.commons.livedata.SingleLiveEvent.observe$lambda$0(SingleLiveEvent.kt:33)
```