### PR TITLE
Update project setup (Engelsystem 7.2.0, SnackEngage 0.30).

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -64,7 +64,7 @@ object Libs {
         const val preference = "1.2.0"
         const val retrofit = "2.6.4"
         const val robolectric = "4.3_r2-robolectric-0"
-        const val snackengage = "0.29"
+        const val snackengage = "0.30"
         const val testExtJunit = "1.1.4"
         const val threeTenBp = "1.6.5"
         const val tracedroid = "3.1"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -49,7 +49,7 @@ object Libs {
         const val coreKtx = "1.8.0" // compileSdk 33 is required as of 1.9.0
         const val coreTesting = "2.1.0"
         const val emailIntentBuilder = "2.0.0"
-        const val engelsystem = "7.1.0"
+        const val engelsystem = "7.2.0"
         const val espresso = "3.5.0"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.6.4"


### PR DESCRIPTION
# Description
- Use engelsystem v.7.2.0.
- Use snackengage-playrate v.0.30.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 32)