### PR TITLE
Consistently output session language value

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -54,7 +54,7 @@ class ChangeListAdapter internal constructor(
 
             speakers.textOrHide = session.formattedSpeakers
             speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
-            lang.textOrHide = session.lang
+            lang.textOrHide = session.languageText
             lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.lang)
 
             val dayText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(session.dateUTC, session.timeZoneOffset)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -55,7 +55,7 @@ class ChangeListAdapter internal constructor(
             speakers.textOrHide = session.formattedSpeakers
             speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
             lang.textOrHide = session.languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.lang)
+            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.languageText)
 
             val dayText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(session.dateUTC, session.timeZoneOffset)
             day.textOrHide = dayText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -55,7 +55,7 @@ class StarredListAdapter internal constructor(
 
             speakers.textOrHide = session.formattedSpeakers
             speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
-            lang.textOrHide = session.lang
+            lang.textOrHide = session.languageText
             lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.lang)
 
             day.isVisible = false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -56,7 +56,7 @@ class StarredListAdapter internal constructor(
             speakers.textOrHide = session.formattedSpeakers
             speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
             lang.textOrHide = session.languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.lang)
+            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.languageText)
 
             day.isVisible = false
             val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -300,11 +300,20 @@ public class Session {
         return speakers == null ? "" : TextUtils.join(", ", speakers);
     }
 
+    @NonNull
+    public String getLanguageText() {
+        if (TextUtils.isEmpty(lang)) {
+            return "";
+        } else {
+            return lang.replace("-formal", "");
+        }
+    }
+
     public String getFormattedTrackLanguageText() {
         StringBuilder builder = new StringBuilder();
         builder.append(track);
         if (!TextUtils.isEmpty(lang)) {
-            String language = lang.replace("-formal", "");
+            String language = getLanguageText();
             builder.append(" [").append(language).append("]");
         }
         return builder.toString();

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -53,7 +53,7 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         textView.contentDescription = Session.getSpeakersContentDescription(sessionView.context, session.speakers.size, session.formattedSpeakers)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
         textView.text = session.formattedTrackLanguageText
-        textView.contentDescription = Session.getFormattedTrackContentDescription(sessionView.context, session.track, session.lang)
+        textView.contentDescription = Session.getFormattedTrackContentDescription(sessionView.context, session.track, session.languageText)
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut


### PR DESCRIPTION
# Description
+ Reduce language to its two letter abbreviation (_favorites_ & _changes_ screens). 
  + Pretalx allows to select `de-formal`. This is shorted here to `de`.
  + Related: 615460feb0cea28cb7b90ddd4276f5f4f767d705
+ Improve content description for sessions marked with `de-formal`.
  + Instead `de` will be used which then maps to `German`.

# Before
![before](https://user-images.githubusercontent.com/144518/213927440-f27aeb1b-0c2d-4e5c-a7f8-d79e44f2048e.png)


# After
![after](https://user-images.githubusercontent.com/144518/213927449-e1d92c00-7146-4402-900a-bd1d4224dcf1.png)


# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)