### PR TITLE
Fix favorites to scroll over past sessions.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -136,6 +136,7 @@ class StarredListFragment :
             activity.invalidateOptionsMenu()
 
             loadingSpinnerView.isVisible = false
+            jumpOverPastSessions()
         }
         viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
             SessionSharer.shareSimple(requireContext(), formattedSession)


### PR DESCRIPTION
# Description
- At a running event some sessions have passed and some are still upcoming.
- When visiting the favorites screen it should scroll to the next upcoming session.

# Before the fix
- No scrolling happens - the first past session is shown at the top of the screen.
- Broken since: 4bcd78bf957e798acaa3c9fe3da79fcafda079cf.

# After the fix
- Favorites are scrolled to the first upcoming session.

# Successfully tested on
with `fosdem2023` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)
- :heavy_check_mark: Pixel 6, Android 13 (API 33)