### PR TITLE
Random housekeeping

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/ActionBarListActivity.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/ActionBarListActivity.java
@@ -6,10 +6,7 @@ import android.widget.ListAdapter;
 import android.widget.ListView;
 
 /**
- * + * Taken from http://stackoverflow
- * .com/questions/18403647/actionbaractivity-of-android-support-v7-appcompat-and
- * -listactivity-in-same-act
- * +
+ * Taken from <a href="https://stackoverflow.com/q/18403647/356895">StackOverflow</a>
  */
 public abstract class ActionBarListActivity extends BaseActivity {
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -9,6 +9,7 @@ import android.widget.ImageView
 import android.widget.TextView
 
 import androidx.annotation.LayoutRes
+import androidx.core.widget.TextViewCompat
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 
 import nerd.tuxmobil.fahrplan.congress.R
@@ -122,7 +123,7 @@ abstract class SessionsAdapter protected constructor(
     }
 
     protected open fun resetTextStyle(textView: TextView, style: Int) {
-        textView.setTextAppearance(context, style)
+        TextViewCompat.setTextAppearance(textView, style)
     }
 
     protected abstract fun setItemContent(position: Int, viewHolder: ViewHolder)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -124,7 +124,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             defaultEngelsystemRoomName = defaultEngelsystemRoomName,
             customEngelsystemRoomName = customEngelsystemRoomName
         )
-        viewModel = ViewModelProvider(this, viewModelFactory).get(FahrplanViewModel::class.java)
+        viewModel = ViewModelProvider(this, viewModelFactory)[FahrplanViewModel::class.java]
         onSessionClickListener = if (context is OnSessionClickListener) {
             context
         } else {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -46,11 +46,11 @@ class CalendarSharingTest {
                 intent.extras != null && matchesExtras(intent.extras!!)
 
         private fun matchesExtras(extras: Bundle) =
-            extras.get(CalendarContract.Events.TITLE) == "Title" &&
-                    extras.get(CalendarContract.Events.DESCRIPTION) == "Lorem ipsum dolor" &&
-                    extras.get(CalendarContract.Events.EVENT_LOCATION) == "Room" &&
-                    extras.get(CalendarContract.EXTRA_EVENT_BEGIN_TIME) == 1439478900000L &&
-                    extras.get(CalendarContract.EXTRA_EVENT_END_TIME) == 1439480700000L
+            extras.getString(CalendarContract.Events.TITLE) == "Title" &&
+                    extras.getString(CalendarContract.Events.DESCRIPTION) == "Lorem ipsum dolor" &&
+                    extras.getString(CalendarContract.Events.EVENT_LOCATION) == "Room" &&
+                    extras.getLong(CalendarContract.EXTRA_EVENT_BEGIN_TIME) == 1439478900000L &&
+                    extras.getLong(CalendarContract.EXTRA_EVENT_END_TIME) == 1439480700000L
 
         override fun toString() = "Session intent does not match."
     }


### PR DESCRIPTION
# Description
- Replace deprecated `TextView#setTextAppearance` with `TextViewCompat#setTextAppearance`.
- Use indexing operator.
- Clean up JavaDoc.
- Replace deprecated `Bundle#get` function.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)