### PR TITLE
Allow to colorize the alarm bell icon on a session separately from the toolbar bell icons.

### DIFF
--- a/app/src/main/res/drawable/ic_bell_on_session.xml
+++ b/app/src/main/res/drawable/ic_bell_on_session.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/session_item_alarm_icon"
+        android:pathData="M4,19v-2h2v-7q0,-2.075 1.25,-3.688Q8.5,4.7 10.5,4.2v-0.7q0,-0.625 0.438,-1.062Q11.375,2 12,2t1.062,0.438q0.438,0.437 0.438,1.062v0.7q2,0.5 3.25,2.112Q18,7.925 18,10v7h2v2ZM12,22q-0.825,0 -1.412,-0.587Q10,20.825 10,20h4q0,0.825 -0.587,1.413Q12.825,22 12,22Z" />
+</vector>

--- a/app/src/main/res/layout-port/session_layout.xml
+++ b/app/src/main/res/layout-port/session_layout.xml
@@ -36,7 +36,7 @@
             android:adjustViewBounds="true"
             android:padding="3dp"
             android:scaleType="fitStart"
-            android:src="@drawable/ic_bell_filled" />
+            android:src="@drawable/ic_bell_on_session" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/session_layout_land.xml
+++ b/app/src/main/res/layout/session_layout_land.xml
@@ -36,7 +36,7 @@
             android:adjustViewBounds="true"
             android:padding="2dp"
             android:scaleType="fitStart"
-            android:src="@drawable/ic_bell_filled" />
+            android:src="@drawable/ic_bell_on_session" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/session_layout_land_large.xml
+++ b/app/src/main/res/layout/session_layout_land_large.xml
@@ -36,7 +36,7 @@
             android:adjustViewBounds="true"
             android:padding="4dp"
             android:scaleType="fitStart"
-            android:src="@drawable/ic_bell_filled" />
+            android:src="@drawable/ic_bell_on_session" />
 
     </LinearLayout>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -49,6 +49,7 @@
     <color name="schedule_time_column_item_text_emphasized">#000</color>
     <color name="schedule_room_name_header_background">#000</color>
     <color name="schedule_room_name_header_text">#fff</color>
+    <color name="session_item_alarm_icon">#fff</color>
     <color name="session_item_text_on_default_background">#a0ffffff</color>
     <color name="session_item_text_on_highlight_background">#fff</color>
     <color name="session_item_video_without_recording_took_place">#656565</color>

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -42,8 +42,7 @@ This list is for your preparation. The specific folders and files are mentioned 
 
 - Text and background colors (HEX)
 - Tracks background colors (HEX)
-- Icons in the toolbar as well as the session alarm icon (bell) and the icon for a favored session
-  (star) can be customized via the `tool_bar_icon` color resource.
+- Icons in the toolbar as well as the session alarm icon (bell) can be customized via the `tool_bar_icon` color resource.
 - The video recording icons must be customized manually because they contain more than one color.
 
 ## 3. Your custom app step by step

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -43,6 +43,7 @@ This list is for your preparation. The specific folders and files are mentioned 
 - Text and background colors (HEX)
 - Tracks background colors (HEX)
 - Icons in the toolbar as well as the session alarm icon (bell) can be customized via the `tool_bar_icon` color resource.
+- The alarm icon (bell) which is shown on a session can be customized via the `session_item_alarm_icon` color resource.
 - The video recording icons must be customized manually because they contain more than one color.
 
 ## 3. Your custom app step by step


### PR DESCRIPTION
# Description
- SVG icons can be colorized since #518.
- Currently, the toolbar icons and the **bell** icon on a session are wired to the **same** color resource.
- With this change they can be colorized **separately**.

# Before
- Both the toolbar icons and the bell icons on sessions are colorized yellow.
![before](https://user-images.githubusercontent.com/144518/219211072-c983ca6c-2087-4dd3-abe2-6c493873da37.png)

# After
- The toolbar icons are colorized yellow and the bell icons on sessions are colorized blue.
![after](https://user-images.githubusercontent.com/144518/219211133-a44800a6-4314-49ca-8374-20a8f25330fe.png)

# Successfully tested on
with `clt2023` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)
