### PR TITLE
Support removal of Engelsystem shifts

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -338,7 +338,7 @@ object AppRepository {
         val url = readEngelsystemShiftsUrl()
         if (url.isEmpty()) {
             logging.d(LOG_TAG, "Engelsystem shifts URL is empty.")
-            // TODO Cancel or remove shifts from database?
+            deleteAllEngelsystemShiftsForAllDays()
             return
         }
         val requestIdentifier = "loadShifts"
@@ -476,6 +476,14 @@ object AppRepository {
      */
     private fun loadEngelsystemShiftsForAllDays() =
         readEngelsystemShiftsOrderedByDateUtc()
+
+    /**
+     * Deletes all Engelsystem shifts for all days from the database.
+     */
+    private fun deleteAllEngelsystemShiftsForAllDays() {
+        val toBeDeletedSessions = readEngelsystemShiftsOrderedByDateUtc()
+        updateSessions(emptyList(), toBeDeletedSessions)
+    }
 
     /**
      * Loads all sessions from the database which take place on all days.


### PR DESCRIPTION
# Description
+ Delete Engelsystem shifts in the database which disappeared in the backend. 
    + Scenarios: Angels might unassign themselves or shifts are canceled.
+ Delete all Engelsystem shifts from the database when the URL is empty. 
    + Before, Engelsystem shifts could only be removed from the UI by resetting the app. Since the reset also deletes favorites and alarms this should be more convenient.

# Successfully tested on
with `fossgis2023` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)
