### PR TITLE
Improve TalkBack experience when navigating main schedule screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -14,6 +14,7 @@ import org.threeten.bp.ZoneOffset;
 
 import java.util.List;
 
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
 import info.metadude.android.eventfahrplan.network.temporal.DateParser;
@@ -291,6 +292,11 @@ public class Session {
     }
 
     @NonNull
+    public static String getTitleContentDescription(@NonNull Context context, @NonNull String title) {
+        return TextUtils.isEmpty(title) ? "" : context.getString(R.string.session_list_item_title_content_description, title);
+    }
+
+    @NonNull
     public static String getSubtitleContentDescription(@NonNull Context context, @NonNull String subtitle) {
         return TextUtils.isEmpty(subtitle) ? "" : context.getString(R.string.session_list_item_subtitle_content_description, subtitle);
     }
@@ -370,6 +376,15 @@ public class Session {
     public static String getHighlightContentDescription(@NonNull Context context, boolean isHighlighted) {
         int stringResource = isHighlighted ? R.string.session_list_item_favored_content_description : R.string.session_list_item_not_favored_content_description;
         return context.getString(stringResource);
+    }
+
+    @NonNull
+    public static String getStateContentDescription(@NonNull Context context, @NonNull Session session, Boolean useDeviceTimeZone) {
+        String roomNameContentDescription = getRoomNameContentDescription(context, session.room);
+        String startsAtText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset);
+        String startsAtContentDescription = getStartTimeContentDescription(context, startsAtText);
+        String isHighlightContentDescription = getHighlightContentDescription(context, session.highlight);
+        return isHighlightContentDescription + ", " + startsAtContentDescription + ", " + roomNameContentDescription;
     }
 
     public void shiftRoomIndexBy(int amount) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -15,6 +15,7 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.HorizontalScrollView
@@ -254,6 +255,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         horizontalScroller.setRoomsCount(roomCount)
 
         val roomScroller = layoutRoot.requireViewByIdCompat<HorizontalScrollView>(R.id.roomScroller)
+        roomScroller.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
         val roomTitlesRowLayout = roomScroller.getChildAt(0) as LinearLayout
         val columnWidth = horizontalScroller.columnWidth
         addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.roomNames)
@@ -395,6 +397,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     private fun fillTimes(parameters: List<TimeTextViewParameter>) {
         val timeTextColumn = requireView().requireViewByIdCompat<LinearLayout>(R.id.times_layout)
+        timeTextColumn.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
         timeTextColumn.removeAllViews()
         var timeTextView: View
         for ((layout, height, titleText) in parameters) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -185,10 +185,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     @SuppressLint("InlinedApi")
     private fun observeViewModel() {
         viewModel.fahrplanParameter
-            .observe(this) { (scheduleData, numDays, dayIndex, menuEntries) ->
+            .observe(this) { (scheduleData, useDeviceTimeZone, numDays, dayIndex, menuEntries) ->
                 menuEntries?.let { buildNavigationMenu(it, numDays) }
                 viewModel.fillTimes(Moment.now(), getNormalizedBoxHeight())
-                viewDay(scheduleData, numDays, dayIndex)
+                viewDay(scheduleData, useDeviceTimeZone, numDays, dayIndex)
             }
         viewModel.fahrplanEmptyParameter.observe(viewLifecycleOwner) { (scheduleVersion) ->
             val errorMessage = errorMessageFactory.getMessageForEmptySchedule(scheduleVersion)
@@ -247,7 +247,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     /**
      * Updates the session data in the schedule view.
      */
-    private fun viewDay(scheduleData: ScheduleData, numDays: Int, dayIndex: Int) {
+    private fun viewDay(scheduleData: ScheduleData, useDeviceTimeZone: Boolean, numDays: Int, dayIndex: Int) {
         val layoutRoot = requireView()
         val horizontalScroller = layoutRoot.requireViewByIdCompat<HorizontalSnapScrollView>(R.id.horizScroller)
         horizontalScroller.scrollTo(0, 0)
@@ -259,7 +259,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val roomTitlesRowLayout = roomScroller.getChildAt(0) as LinearLayout
         val columnWidth = horizontalScroller.columnWidth
         addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.roomNames)
-        addRoomColumns(horizontalScroller, columnWidth, scheduleData)
+        addRoomColumns(horizontalScroller, columnWidth, scheduleData, useDeviceTimeZone)
 
         MainActivity.instance.shouldScheduleScrollToCurrentTimeSlot {
             if (!viewModel.preserveVerticalScrollPosition) {
@@ -286,7 +286,8 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     private fun addRoomColumns(
         horizontalScroller: HorizontalSnapScrollView,
         columnWidth: Int,
-        scheduleData: ScheduleData
+        scheduleData: ScheduleData,
+        useDeviceTimeZone: Boolean,
     ) {
         val columnsLayout = horizontalScroller.getChildAt(0) as LinearLayout
         // TODO Optimization: Track room names and check if they can be re-used with the updated scheduleData
@@ -310,6 +311,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             val adapter = SessionViewColumnAdapter(
                 sessions = roomSessions,
                 layoutParamsBySession = layoutParamsBySession,
+                useDeviceTimeZone = useDeviceTimeZone,
                 drawer = sessionViewDrawer,
                 eventsHandler = this
             )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -148,10 +148,12 @@ internal class FahrplanViewModel(
         } else {
             null
         }
+        val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
 
         val scheduleDataWithAlarmFlags = createScheduleDataWithAlarmFlags(scheduleData, alarms)
         return FahrplanParameter(
             scheduleData = scheduleDataWithAlarmFlags,
+            useDeviceTimeZone = useDeviceTimeZone,
             numDays = numDays,
             dayIndex = dayIndex,
             dayMenuEntries = dayMenuEntries

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
@@ -13,6 +13,7 @@ internal interface SessionViewEventsHandler : View.OnCreateContextMenuListener, 
 internal class SessionViewColumnAdapter(
         private val sessions: List<Session>,
         private val layoutParamsBySession: Map<Session, LinearLayout.LayoutParams>,
+        private val useDeviceTimeZone: Boolean,
         private val drawer: SessionViewDrawer,
         private val eventsHandler: SessionViewEventsHandler
 ) : RecyclerView.Adapter<SessionViewColumnAdapter.SessionViewHolder>() {
@@ -21,7 +22,7 @@ internal class SessionViewColumnAdapter(
         val session = sessions[position]
         viewHolder.itemView.tag = session
         viewHolder.itemView.layoutParams = layoutParamsBySession[session]
-        drawer.updateSessionView(viewHolder.itemView, session)
+        drawer.updateSessionView(viewHolder.itemView, session, useDeviceTimeZone)
     }
 
     override fun getItemCount(): Int = sessions.size

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -39,12 +39,13 @@ internal class SessionViewDrawer @JvmOverloads constructor(
     private val trackNameBackgroundColorDefaultPairs = TrackBackgrounds.getTrackNameBackgroundColorDefaultPairs(context)
     private val trackNameBackgroundColorHighlightPairs = TrackBackgrounds.getTrackNameBackgroundColorHighlightPairs(context)
 
-    fun updateSessionView(sessionView: View, session: Session) {
+    fun updateSessionView(sessionView: View, session: Session, useDeviceTimeZone: Boolean) {
         val bell = sessionView.requireViewByIdCompat<ImageView>(R.id.session_bell_view)
         bell.isVisible = session.hasAlarm
         var textView = sessionView.requireViewByIdCompat<TextView>(R.id.session_title_view)
         textView.typeface = boldCondensed
         textView.text = session.title
+        textView.contentDescription = Session.getTitleContentDescription(sessionView.context, session.title)
         textView = sessionView.requireViewByIdCompat(R.id.session_subtitle_view)
         textView.text = session.subtitle
         textView.contentDescription = Session.getSubtitleContentDescription(sessionView.context, session.subtitle)
@@ -58,7 +59,7 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut
         }
-        ViewCompat.setStateDescription(sessionView, Session.getHighlightContentDescription(sessionView.context, session.highlight))
+        ViewCompat.setStateDescription(sessionView, Session.getStateContentDescription(sessionView.context, session, useDeviceTimeZone))
         setSessionBackground(session, sessionView)
         setSessionTextColor(session, sessionView)
         sessionView.tag = session

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
@@ -11,6 +11,7 @@ import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
 data class FahrplanParameter(
 
     val scheduleData: ScheduleData,
+    val useDeviceTimeZone: Boolean,
     val numDays: Int,
     val dayIndex: Int,
     val dayMenuEntries: List<String>?

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -218,6 +218,7 @@
     <string name="session_list_item_not_favored_content_description">nicht favorisiert</string>
     <string name="session_list_item_room_content_description">Raum: <xliff:g example="Main hall" id="room">%s</xliff:g></string>
     <string name="session_list_item_start_time_content_description">Startzeit: <xliff:g example="16:30" id="startTime">%s</xliff:g></string>
+    <string name="session_list_item_title_content_description">Titel: <xliff:g example="Berlin stories" id="title">%s</xliff:g></string>
     <string name="session_list_item_subtitle_content_description">Untertitel: <xliff:g example="News from Berlin" id="subtitle">%s</xliff:g></string>
     <string name="session_list_item_track_content_description">Track: <xliff:g example="Security" id="trackName">%s</xliff:g></string>
     <string name="session_list_item_language_content_description">Sprache: <xliff:g example="English" id="language">%s</xliff:g></string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,6 +248,7 @@
     <string name="session_list_item_not_favored_content_description">not favored</string>
     <string name="session_list_item_room_content_description">Room: <xliff:g example="Main hall" id="room">%s</xliff:g></string>
     <string name="session_list_item_start_time_content_description">Start time: <xliff:g example="16:30" id="startTime">%s</xliff:g></string>
+    <string name="session_list_item_title_content_description">Title: <xliff:g example="Berlin stories" id="title">%s</xliff:g></string>
     <string name="session_list_item_subtitle_content_description">Subtitle: <xliff:g example="News from Berlin" id="subtitle">%s</xliff:g></string>
     <string name="session_list_item_track_content_description">Track: <xliff:g example="Security" id="trackName">%s</xliff:g></string>
     <string name="session_list_item_language_content_description">Language: <xliff:g example="English" id="language">%s</xliff:g></string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -118,6 +118,7 @@ class FahrplanViewModelTest {
         val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
         val expected = FahrplanParameter(
             scheduleData = createScheduleData("session-01"),
+            useDeviceTimeZone = false,
             numDays = 1,
             dayIndex = 2,
             dayMenuEntries = null
@@ -147,6 +148,7 @@ class FahrplanViewModelTest {
         val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
         val expected = FahrplanParameter(
             scheduleData = createScheduleData("session-01", hasAlarm = true),
+            useDeviceTimeZone = false,
             numDays = 1,
             dayIndex = 2,
             dayMenuEntries = null
@@ -180,6 +182,7 @@ class FahrplanViewModelTest {
         val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
         val expected = FahrplanParameter(
             scheduleData = createScheduleData("session-01"),
+            useDeviceTimeZone = false,
             numDays = 2,
             dayIndex = 0,
             dayMenuEntries = listOf("Day 1", "Day 2")


### PR DESCRIPTION
# Description
+ The time column on the left and the room names are skipped now. TalkBack selects the actual session(s) instead.
+ The start time and the room name are not being displayed on a session element but instead visible outside of the session element. For TalkBack users these properties are read out additionally for each session.
+ The session title is prefixed with `title: ` here to make it better comprehensible when reading out the session element state before.

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)