### PR TITLE
Update project setup (okhttp 4.11.0, retrofit 2.9.0)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 21
-          script: ./gradlew connectedCheck
+          script: ./gradlew connectedJev2022DebugAndroidTest
 
       - name: Publish unit-test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -62,7 +62,7 @@ object Libs {
         const val multiDex = "2.0.1"
         const val okhttp = "4.11.0"
         const val preference = "1.2.0"
-        const val retrofit = "2.6.4"
+        const val retrofit = "2.9.0"
         const val robolectric = "4.3_r2-robolectric-0"
         const val snackengage = "0.30"
         const val testExtJunit = "1.1.5"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -60,7 +60,7 @@ object Libs {
         const val mockitoKotlin = "4.1.0"
         const val moshi = "1.14.0"
         const val multiDex = "2.0.1"
-        const val okhttp = "3.12.13"
+        const val okhttp = "4.11.0"
         const val preference = "1.2.0"
         const val retrofit = "2.6.4"
         const val robolectric = "4.3_r2-robolectric-0"

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
@@ -134,7 +134,7 @@ internal class FetchFahrplanTask(
             e.printStackTrace()
             return HttpStatus.HTTP_COULD_NOT_CONNECT
         }
-        val statusCode = response.code()
+        val statusCode = response.code
 
         if (statusCode == 304) {
             return HttpStatus.HTTP_NOT_MODIFIED
@@ -160,13 +160,13 @@ internal class FetchFahrplanTask(
         }
 
         responseStr = try {
-            response.body()!!.string()
+            response.body!!.string()
         } catch (e: NullPointerException) {
             return HttpStatus.HTTP_CANNOT_PARSE_CONTENT
         } catch (e: IOException) {
             return HttpStatus.HTTP_CANNOT_PARSE_CONTENT
         } finally {
-            response.body()?.close()
+            response.body?.close()
         }
         return HttpStatus.HTTP_OK
     }


### PR DESCRIPTION
# Description
- Speed up CI build by limiting instrumentation tests to one build flavor.
- Now that minSdk 21 is used the following dependencies can finally be updated:
  - Use okhttp 4.11.0.
  - Use retrofit 2.9.0.

# Successfully tested on
with `gpn2023` flavor, `release` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

---

Relates to #547