### PR TITLE
Update project setup (compose 1.4.8, 2023.06.01, kotlin 1.8.22, coroutines 1.7.2, moshi 1.15.0)

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -18,8 +18,8 @@ object Android {
 object Compose {
 
     object Versions {
-        internal const val bom = "2023.05.01"
-        const val compiler = "1.4.7"
+        internal const val bom = "2023.06.01"
+        const val compiler = "1.4.8"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"
@@ -35,8 +35,8 @@ object Plugins {
         const val android = "7.4.2"
         const val androidJunitJacoco = "0.16.0"
         const val dexcount = "4.0.0"
-        const val kotlin = "1.8.21"
-        const val ksp = "1.8.21-1.0.11"
+        const val kotlin = "1.8.22"
+        const val ksp = "1.8.22-1.0.11"
         const val sonarQube = "4.0.0.2929"
         const val unMock = "0.7.9"
         const val versions = "0.47.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -37,7 +37,7 @@ object Plugins {
         const val dexcount = "4.0.0"
         const val kotlin = "1.8.22"
         const val ksp = "1.8.22-1.0.11"
-        const val sonarQube = "4.0.0.2929"
+        const val sonarQube = "4.2.1.3168"
         const val unMock = "0.7.9"
         const val versions = "0.47.0"
     }

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -72,7 +72,7 @@ object Libs {
         const val material = "1.9.0"
         const val mockito = "5.3.0"
         const val mockitoKotlin = "5.0.0"
-        const val moshi = "1.14.0"
+        const val moshi = "1.15.0"
         const val multiDex = "2.0.1"
         const val okhttp = "4.11.0"
         const val preference = "1.2.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -70,7 +70,7 @@ object Libs {
         const val lifecycle = "2.6.1"
         const val markwon = "4.6.2"
         const val material = "1.9.0"
-        const val mockito = "5.3.0"
+        const val mockito = "5.4.0"
         const val mockitoKotlin = "5.0.0"
         const val moshi = "1.15.0"
         const val multiDex = "2.0.1"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -71,7 +71,7 @@ object Libs {
         const val markwon = "4.6.2"
         const val material = "1.9.0"
         const val mockito = "5.3.0"
-        const val mockitoKotlin = "4.1.0"
+        const val mockitoKotlin = "5.0.0"
         const val moshi = "1.14.0"
         const val multiDex = "2.0.1"
         const val okhttp = "4.11.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -39,7 +39,7 @@ object Plugins {
         const val ksp = "1.8.21-1.0.11"
         const val sonarQube = "4.0.0.2929"
         const val unMock = "0.7.9"
-        const val versions = "0.46.0"
+        const val versions = "0.47.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -66,7 +66,7 @@ object Libs {
         const val engelsystem = "7.2.0"
         const val espresso = "3.5.1"
         const val junit = "4.13.2"
-        const val kotlinCoroutines = "1.7.1"
+        const val kotlinCoroutines = "1.7.2"
         const val lifecycle = "2.6.1"
         const val markwon = "4.6.2"
         const val material = "1.9.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -82,7 +82,7 @@ object Libs {
         const val testExtJunit = "1.1.5"
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
-        const val truth = "1.1.3"
+        const val truth = "1.1.5"
         const val turbine = "0.12.3"
     }
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -83,7 +83,7 @@ object Libs {
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
         const val truth = "1.1.5"
-        const val turbine = "0.12.3"
+        const val turbine = "1.0.0"
     }
 
     const val annotation = "androidx.annotation:annotation:${Versions.annotation}"


### PR DESCRIPTION
# Description
+ Use gradle-versions-plugin v.0.47.0.
+ Use mockito-kotlin v.5.0.0.
+ Use truth v.1.1.5.
+ Use moshi 1.15.0.
+ Use turbine v.1.0.0.
+ Use mockito v.5.4.0.
+ Use coroutines v.1.7.2.
+ Use Jetpack Compose UI (1.4.8, 2023.06.01) & kotlin v.1.8.22 & ksp v.1.8.22-1.0.11.
+ Use sonarqube-gradle-plugin 4.2.1.3168.

# Successfully tested on
with `hackover2023` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 13 (API 33)