### PR TITLE
Prevent crashes when upgrading the app

### DIFF
--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SQLiteDatabaseExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SQLiteDatabaseExtensions.kt
@@ -1,3 +1,5 @@
+@file:JvmName("SQLiteDatabaseExtensions")
+
 package info.metadude.android.eventfahrplan.database.extensions
 
 import android.content.ContentValues
@@ -75,3 +77,27 @@ internal fun SQLiteDatabase.upsert(delete: SQLiteDatabase.() -> Int, insert: SQL
             delete()
             insert()
         }
+
+/**
+ * Returns `true` if the given [column][columnName] is present
+ * in the [table][tableName], otherwise `false`.
+ *
+ * Throws an [IllegalArgumentException] if the schema does not contain
+ * the expected column named `name`.
+ */
+fun SQLiteDatabase.columnExists(tableName: String, columnName: String): Boolean {
+        val cursor = rawQuery("PRAGMA table_info($tableName)", null)
+        while (cursor.moveToNext()) {
+                // "name" is the name of the schema column which contains the table column names.
+                val schemaColumnIndex = cursor.getColumnIndexOrThrow("name")
+                if (schemaColumnIndex != -1) {
+                        val currentColumnName = cursor.getString(schemaColumnIndex)
+                        if (columnName == currentColumnName) {
+                                cursor.close()
+                                return true
+                        }
+                }
+        }
+        cursor.close()
+        return false
+}

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
@@ -62,7 +62,7 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
      * increments the primary key and therefore generates a new notification ID.
      */
     private static final String SESSION_BY_NOTIFICATION_ID_TABLE_CREATE =
-            "CREATE TABLE " + SessionByNotificationIdTable.NAME + " (" +
+            "CREATE TABLE IF NOT EXISTS " + SessionByNotificationIdTable.NAME + " (" +
             BaseColumns._ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
             SessionByNotificationIdTable.Columns.SESSION_ID + " TEXT)";
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
@@ -12,6 +12,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns;
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Defaults;
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Values;
+import info.metadude.android.eventfahrplan.database.extensions.SQLiteDatabaseExtensions;
 
 public class SessionsDBOpenHelper extends SQLiteOpenHelper {
 
@@ -132,7 +133,10 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
             db.execSQL(SESSION_BY_NOTIFICATION_ID_TABLE_CREATE);
         }
         if (oldVersion < 11 && newVersion >= 11) {
-            db.execSQL("ALTER TABLE " + SessionsTable.NAME + " ADD COLUMN " + Columns.TIME_ZONE_OFFSET + " INTEGER DEFAULT NULL");
+            boolean columnExists = SQLiteDatabaseExtensions.columnExists(db, SessionsTable.NAME, Columns.TIME_ZONE_OFFSET);
+            if (!columnExists) {
+                db.execSQL("ALTER TABLE " + SessionsTable.NAME + " ADD COLUMN " + Columns.TIME_ZONE_OFFSET + " INTEGER DEFAULT NULL");
+            }
         }
         if (oldVersion < 12) {
             // Clear database from rC3 12/2020.


### PR DESCRIPTION
# Description
- Prevent duplicate table crash when upgrading the app.
  - Error message: `SQLiteException: table session_by_notification_id already exists`
  - Related commit: 537674db6ea460607975e7b727b7f98d93ff78bc.
- Prevent duplicate column crash when upgrading the app.
  - Error message: `SQLiteException: duplicate column name: time_zone_offset`
  - Related commit: ad2a8a54c74e895727eeceefd1fc9c144e1433cd.

# Before
- CCCamp app crashes when upgrading from 2019 to 2023 instance.

# After
- CCCamp app launches without errors when upgrading from 2019 to 2023 instance.

# Successfully tested on
with `cccamp2019` -> `cccamp2023` flavor, `debug` and `release` builds
- :heavy_check_mark: Google Pixel 6, Android 13 (API 33)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)