### PR TITLE
Add parser for the duration value in the Fahrplan XML

### DIFF
--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -21,6 +21,7 @@ import info.metadude.android.eventfahrplan.network.models.Meta;
 import info.metadude.android.eventfahrplan.network.models.Session;
 import info.metadude.android.eventfahrplan.network.serialization.exceptions.MissingXmlAttributeException;
 import info.metadude.android.eventfahrplan.network.temporal.DateParser;
+import info.metadude.android.eventfahrplan.network.temporal.DurationParser;
 import info.metadude.android.eventfahrplan.network.validation.DateFieldValidation;
 
 public class FahrplanParser {
@@ -268,7 +269,8 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                             }
                                         } else if (name.equals("duration")) {
                                             parser.next();
-                                            session.setDuration(DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser)));
+                                            int minutes = DurationParser.getMinutes(XmlPullParsers.getSanitizedText(parser));
+                                            session.setDuration(minutes);
                                         } else if (name.equals("date")) {
                                             parser.next();
                                             String sanitizedText = XmlPullParsers.getSanitizedText(parser);

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DurationParser.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DurationParser.kt
@@ -1,0 +1,46 @@
+package info.metadude.android.eventfahrplan.network.temporal
+
+import org.threeten.bp.Duration
+
+/**
+ * Parser for the duration string used in the schedule.
+ */
+object DurationParser {
+    @JvmStatic
+    fun getMinutes(durationString: String): Int {
+        val parts = durationString.split(':')
+        return when (parts.size) {
+            1 -> extractMinutesOnly(minutesString = parts[0])
+            2 -> extractHoursAndMinutes(hoursString = parts[0], minutesString = parts[1])
+            3 -> extractDaysAndHoursAndMinutes(
+                daysString = parts[0],
+                hoursString = parts[1],
+                minutesString = parts[2]
+            )
+
+            else -> error("Unknown duration format: $durationString")
+        }
+    }
+
+    private fun extractMinutesOnly(minutesString: String): Int {
+        return minutesString.toInt()
+    }
+
+    private fun extractHoursAndMinutes(hoursString: String, minutesString: String): Int {
+        return Duration
+            .ofHours(hoursString.toLong())
+            .plusMinutes(extractMinutesOnly(minutesString).toLong())
+            .toMinutes()
+            .toInt()
+    }
+
+    // This format was introduced for the CCCamp 2023 schedule. Hopefully support for it can be removed soon.
+    // See https://github.com/EventFahrplan/EventFahrplan/pull/561
+    private fun extractDaysAndHoursAndMinutes(daysString: String, hoursString: String, minutesString: String): Int {
+        return Duration
+            .ofDays(daysString.toLong())
+            .plusMinutes(extractHoursAndMinutes(hoursString, minutesString).toLong())
+            .toMinutes()
+            .toInt()
+    }
+}

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DurationParserTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DurationParserTest.kt
@@ -1,0 +1,59 @@
+package info.metadude.android.eventfahrplan.network.temporal
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DurationParserTest {
+    @Test
+    fun `duration in minutes`() {
+        assertThat(DurationParser.getMinutes("5")).isEqualTo(5)
+        assertThat(DurationParser.getMinutes("10")).isEqualTo(10)
+        assertThat(DurationParser.getMinutes("15")).isEqualTo(15)
+        assertThat(DurationParser.getMinutes("30")).isEqualTo(30)
+        assertThat(DurationParser.getMinutes("45")).isEqualTo(45)
+        assertThat(DurationParser.getMinutes("60")).isEqualTo(60)
+        assertThat(DurationParser.getMinutes("90")).isEqualTo(90)
+        assertThat(DurationParser.getMinutes("120")).isEqualTo(120)
+        assertThat(DurationParser.getMinutes("1680")).isEqualTo(1680)
+        assertThat(DurationParser.getMinutes("2910")).isEqualTo(2910)
+        assertThat(DurationParser.getMinutes("7230")).isEqualTo(7230)
+    }
+
+    @Test
+    fun `duration in hours and minutes`() {
+        assertThat(DurationParser.getMinutes("0:05")).isEqualTo(5)
+        assertThat(DurationParser.getMinutes("00:05")).isEqualTo(5)
+        assertThat(DurationParser.getMinutes("0:10")).isEqualTo(10)
+        assertThat(DurationParser.getMinutes("00:10")).isEqualTo(10)
+        assertThat(DurationParser.getMinutes("0:15")).isEqualTo(15)
+        assertThat(DurationParser.getMinutes("00:15")).isEqualTo(15)
+        assertThat(DurationParser.getMinutes("0:30")).isEqualTo(30)
+        assertThat(DurationParser.getMinutes("00:30")).isEqualTo(30)
+        assertThat(DurationParser.getMinutes("0:45")).isEqualTo(45)
+        assertThat(DurationParser.getMinutes("00:45")).isEqualTo(45)
+        assertThat(DurationParser.getMinutes("1:00")).isEqualTo(60)
+        assertThat(DurationParser.getMinutes("01:00")).isEqualTo(60)
+        assertThat(DurationParser.getMinutes("1:30")).isEqualTo(90)
+        assertThat(DurationParser.getMinutes("01:30")).isEqualTo(90)
+        assertThat(DurationParser.getMinutes("2:00")).isEqualTo(120)
+        assertThat(DurationParser.getMinutes("02:00")).isEqualTo(120)
+        assertThat(DurationParser.getMinutes("28:00")).isEqualTo(1680)
+        assertThat(DurationParser.getMinutes("48:30")).isEqualTo(2910)
+        assertThat(DurationParser.getMinutes("120:30")).isEqualTo(7230)
+    }
+
+    @Test
+    fun `duration in days and hours and minutes`() {
+        assertThat(DurationParser.getMinutes("0:00:05")).isEqualTo(5)
+        assertThat(DurationParser.getMinutes("0:00:10")).isEqualTo(10)
+        assertThat(DurationParser.getMinutes("0:00:15")).isEqualTo(15)
+        assertThat(DurationParser.getMinutes("0:00:30")).isEqualTo(30)
+        assertThat(DurationParser.getMinutes("0:00:45")).isEqualTo(45)
+        assertThat(DurationParser.getMinutes("0:01:00")).isEqualTo(60)
+        assertThat(DurationParser.getMinutes("0:01:30")).isEqualTo(90)
+        assertThat(DurationParser.getMinutes("0:02:00")).isEqualTo(120)
+        assertThat(DurationParser.getMinutes("1:04:00")).isEqualTo(1680)
+        assertThat(DurationParser.getMinutes("2:00:30")).isEqualTo(2910)
+        assertThat(DurationParser.getMinutes("5:00:30")).isEqualTo(7230)
+    }
+}


### PR DESCRIPTION
# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [x] I have read the recent version of the [contribution guide](
  https://github.com/EventFahrplan/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [x] I have checked a few other pull requests to see how they are written.
* [x] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [x] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [x] I can help myself to get this feature implemented or know someone who wants to do it.

# Description
Adds a workaround for the current issues with the CCCamp 2023 schedule file.

# Before
Schedule isn't updated due to parsing errors.

# After
Schedule can be parsed without errors.

Resolves #559
