### PR TITLE
Replace displayed session language with language code to save screen space.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -311,7 +311,17 @@ public class Session {
         if (TextUtils.isEmpty(lang)) {
             return "";
         } else {
-            return lang.replace("-formal", "");
+            return lang
+                    .replace("-formal", "")
+                    .replace("German", "de")
+                    .replace("german", "de")
+                    .replace("Deutsch", "de")
+                    .replace("deutsch", "de")
+                    .replace("English", "en")
+                    .replace("english", "en")
+                    .replace("Englisch", "en")
+                    .replace("englisch", "en")
+                    ;
         }
     }
 


### PR DESCRIPTION
# Description
+ Add cases when languages are spelled out.

# Before
![before2](https://github.com/EventFahrplan/EventFahrplan/assets/144518/1e365fde-72b8-44bf-aafb-fb19924f83ff)
![before1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/d3a76271-6a00-45fa-badc-833e624a6826)

# Successfully tested on
with `cccamp2023` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)