### PR TITLE
Hide feedback menu item for sessions which are Engelsystem shifts.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
@@ -32,7 +32,7 @@ data class SelectedSessionParameter(
     // Options menu
     val isFlaggedAsFavorite: Boolean,
     val hasAlarm: Boolean,
-    val isFeedbackUrlEmpty: Boolean,
-    val isC3NavRoomNameEmpty: Boolean
+    val supportsFeedback: Boolean,
+    val isC3NavRoomNameEmpty: Boolean,
 
-)
+    )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -373,7 +373,7 @@ class SessionDetailsFragment : Fragment() {
             menu.setMenuItemVisibility(R.id.menu_item_set_alarm, false)
             menu.setMenuItemVisibility(R.id.menu_item_delete_alarm, true)
         }
-        menu.setMenuItemVisibility(R.id.menu_item_feedback, SHOW_FEEDBACK_MENU_ITEM && !model.isFeedbackUrlEmpty)
+        menu.setMenuItemVisibility(R.id.menu_item_feedback, SHOW_FEEDBACK_MENU_ITEM && model.supportsFeedback)
         if (sidePane) {
             menu.setMenuItemVisibility(R.id.menu_item_close_session_details, true)
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -88,7 +88,7 @@ internal class SessionDetailsViewModel(
 
     val selectedSessionParameter: Flow<SelectedSessionParameter> = repository.selectedSession
         .map { it.toSelectedSessionParameter() }
-        .map { it.customizeEngelsystemRoomName() }
+        .map { it.customizeEngelsystemRoomName() } // Do not rename before preparing parameter!
         .flowOn(executionContext.database)
 
     private val mutableOpenFeedBack = Channel<Uri>()
@@ -128,6 +128,8 @@ internal class SessionDetailsViewModel(
         val sessionLink = sessionFormatter.getFormattedUrl(sessionUrl)
         val isFeedbackUrlEmpty = feedbackUrlComposer.getFeedbackUrl(this).isEmpty()
         val isC3NavRoomNameEmpty = roomForC3NavConverter.convert(room).isEmpty()
+        val isEngelshift = room == defaultEngelsystemRoomName
+        val supportsFeedback = !isFeedbackUrlEmpty && !isEngelshift
 
         return SelectedSessionParameter(
             // Details content
@@ -152,8 +154,8 @@ internal class SessionDetailsViewModel(
             // Options menu
             isFlaggedAsFavorite = highlight,
             hasAlarm = hasAlarm,
-            isFeedbackUrlEmpty = isFeedbackUrlEmpty,
-            isC3NavRoomNameEmpty = isC3NavRoomNameEmpty
+            supportsFeedback = supportsFeedback,
+            isC3NavRoomNameEmpty = isC3NavRoomNameEmpty,
         )
     }
 


### PR DESCRIPTION
# Description
+ Feedback can only be submitted for regular sessions.
+ There is no backend to receive feedback for Engelsystem shifts.

# Before
![engelshift-before](https://github.com/EventFahrplan/EventFahrplan/assets/144518/7a9ac6e3-abe6-466c-b974-19a67ee8907e)

# After
![engelshift-after](https://github.com/EventFahrplan/EventFahrplan/assets/144518/2df46b7d-6f83-4ddb-9ad0-a5a3064bb853)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 13 (API 33)