### PR TITLE
Fix JVM target related build error.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 21
-          script: ./gradlew testCccamp2023DebugUnitTest assembleCccamp2023Debug lintAnalyzeCccamp2023Debug
+          script: ./gradlew testDebug :engelsystem:test testCccamp2023DebugUnitTest assembleCccamp2023Debug lintAnalyzeCccamp2023Debug
 
       - name: Publish unit-test results
         uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,4 +89,4 @@ before_script:
   - echo "org.gradle.caching=true" >> $HOME/.gradle/gradle.properties
 
 script:
-  - ./gradlew testCccamp2023DebugUnitTest assembleCccamp2023Debug
+  - ./gradlew testDebug :engelsystem:test testCccamp2023DebugUnitTest assembleCccamp2023Debug

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -258,7 +258,6 @@ dependencies {
         // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
     }
-    testImplementation Libs.mockitoCore
     testImplementation Libs.threeTenBp
     testImplementation Libs.truth
     testImplementation Libs.turbine

--- a/engelsystem/build.gradle
+++ b/engelsystem/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation Libs.junit
     testImplementation Libs.kotlinCoroutinesTest
-    testImplementation Libs.mockitoKotlin
+    testImplementation Libs.mockitoCore
     testImplementation Libs.okhttpMockWebServer
     testImplementation Libs.retrofitConverterMoshi
     testImplementation Libs.truth

--- a/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
+++ b/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
@@ -15,7 +15,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.mock
+import org.mockito.Mockito.mock
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 import retrofit2.Retrofit


### PR DESCRIPTION
# Description
+ Broken since: f9d038506d6f2ba7797e1a5b04e84f01559d3eaa
+ Error: `Cannot inline bytecode built with JVM target 11 into bytecode that is being built with JVM target 1.8. Please specify proper '-jvm-target' option`
+ Related: https://github.com/mockito/mockito/releases/tag/v5.0.0 (Update the minimum supported Java version to 11)
+ Clean up Mockito dependencies.
+ CI: Fix running unit tests in library modules.

# Successfully tested on
with `cccamp2023` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 13 (API 33)