### PR TITLE
Use new Engelsystem shift type API

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -69,6 +69,12 @@ val Shift.descriptionText: String
             }
             text += "<a href=\"$locationUrl\">$locationUrl</a>"
         }
+        if (typeDescription.isNotEmpty()) {
+            if (text.isNotEmpty()) {
+                text += "\n\n"
+            }
+            text += typeDescription
+        }
         if (locationDescription.isNotEmpty()) {
             if (text.isNotEmpty()) {
                 text += "\n\n"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -31,7 +31,7 @@ fun Shift.toSessionAppModel(
     room = virtualRoomName
     speakers = emptyList()
     startTime = minuteOfDay  // minutes since day start
-    title = name
+    title = typeName
     subtitle = talkTitle
     // Shift.timeZoneName is not mapped here. Using Meta.timeZoneName instead.
     track = virtualRoomName

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -31,10 +31,10 @@ fun Shift.toSessionAppModel(
     room = virtualRoomName
     speakers = emptyList()
     startTime = minuteOfDay  // minutes since day start
-    title = typeName
-    subtitle = talkTitle
+    title = talkTitle
+    subtitle = locationName
     // Shift.timeZoneName is not mapped here. Using Meta.timeZoneName instead.
-    track = virtualRoomName
+    track = typeName
     url = talkUrl
 }
 
@@ -60,9 +60,6 @@ private val Shift.dateUtcMs
 val Shift.descriptionText: String
     get() {
         var text = ""
-        if (locationName.isNotEmpty()) {
-            text += locationName
-        }
         if (locationUrl.isNotEmpty()) {
             if (text.isNotEmpty()) {
                 text += "\n"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -28,7 +28,9 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.viewModels
 import info.metadude.android.eventfahrplan.commons.flow.observe
+import io.noties.markwon.AbstractMarkwonPlugin
 import io.noties.markwon.Markwon
+import io.noties.markwon.core.MarkwonTheme
 import io.noties.markwon.linkify.LinkifyPlugin
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
@@ -58,6 +60,15 @@ class SessionDetailsFragment : Fragment() {
         private const val SESSION_DETAILS_FRAGMENT_REQUEST_KEY = "SESSION_DETAILS_FRAGMENT_REQUEST_KEY"
         private const val SCHEDULE_FEEDBACK_URL = BuildConfig.SCHEDULE_FEEDBACK_URL
         private val SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL)
+
+        // Custom heading text size multipliers for each heading level.
+        // Docs: https://noties.io/Markwon/docs/v4/core/theme.html#typeface
+        private val HEADING_TEXT_SIZE_MULTIPLIERS = floatArrayOf(1.25f, 1.18f, 1.07F, 1.0f, .83F, .67F)
+        private val HEADINGS_PLUGIN = object : AbstractMarkwonPlugin() {
+            override fun configureTheme(builder: MarkwonTheme.Builder) {
+                builder.headingTextSizeMultipliers(HEADING_TEXT_SIZE_MULTIPLIERS)
+            }
+        }
 
         @JvmStatic
         fun replaceAtBackStack(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sidePane: Boolean) {
@@ -114,6 +125,7 @@ class SessionDetailsFragment : Fragment() {
         alarmServices = AlarmServices.newInstance(context, appRepository)
         notificationHelper = NotificationHelper(context)
         markwon = Markwon.builder(requireContext())
+            .usePlugin(HEADINGS_PLUGIN)
             .usePlugin(LinkifyPlugin.create())
             .build()
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
@@ -45,7 +45,7 @@ class ShiftExtensionsTest {
 
     @Test
     fun descriptionTextWithShiftWithLocationName() {
-        assertThat(Shift(locationName = "Room 23").descriptionText).isEqualTo("Room 23")
+        assertThat(Shift(locationName = "Room 23").descriptionText).isEqualTo("")
     }
 
     @Test
@@ -71,7 +71,7 @@ class ShiftExtensionsTest {
                 locationDescription = "The small orange room.",
                 userComment = "Take a bottle of water with you"
         )
-        val text = "Room 42\n<a href=\"https://conference.org\">https://conference.org</a>\n\nThe small orange room.\n\n_Take a bottle of water with you_"
+        val text = "<a href=\"https://conference.org\">https://conference.org</a>\n\nThe small orange room.\n\n_Take a bottle of water with you_"
         assertThat(shift.descriptionText).isEqualTo(text)
     }
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -63,7 +63,7 @@ object Libs {
         const val coreKtx = "1.9.0"
         const val coreTesting = "2.2.0"
         const val emailIntentBuilder = "2.0.0"
-        const val engelsystem = "7.3.0"
+        const val engelsystem = "8.0.0"
         const val espresso = "3.5.1"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.7.3"

--- a/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
+++ b/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
@@ -31,7 +31,7 @@ class EngelsystemNetworkRepositoryTest {
         const val VALID_ONE_ITEM_SHIFTS_JSON = """
                 [
                     {
-                        "Comment": "This is a very secret comment.",
+                        "user_comment": "This is a very secret comment.",
                         "Name": "Kirmes",
                         "RID": 12,
                         "SID": 579,
@@ -46,8 +46,9 @@ class EngelsystemNetworkRepositoryTest {
                         "event_timezone": "Europe/Berlin",
                         "freeloaded": 0,
                         "id": 37,
-                        "name": "Collect stickers",
                         "shifttype_id": 6,
+                        "shifttype_name": "Name of the shift type",
+                        "shifttype_description": "# Description of the shift type as markdown\n",
                         "start_date": "2019-08-21T13:00:00+02:00",
                         "title": "Tag 1: Decorate fridge"
                     }
@@ -65,12 +66,13 @@ class EngelsystemNetworkRepositoryTest {
             endsAtDate = ENDS_AT,
             locationDescription = "Kirmes are fun.",
             locationName = "Kirmes",
-            name = "Collect stickers",
             sID = 579,
             startsAtDate = STARTS_AT,
             talkTitle = "Tag 1: Decorate fridge",
             timeZoneName = "Europe/Berlin",
-            typeId = 6
+            typeId = 6,
+            typeName = "Name of the shift type",
+            typeDescription = "# Description of the shift type as markdown\n",
         ))
         const val URL = "https://example.com/test/shifts-json-export/file.json?key=111111"
 


### PR DESCRIPTION
# Description
+ Prepend shift type description before the individual (location) description.
   + Context: The shift type description provides general information about the kind of work. Only shift specific information are contained in the (location) description of a shift to avoid repetition and ease maintenance in the backend system. Hence, the (location) description would not provide enough information by itself.
+ Rearrange shift properties to show the important information at a glance.
  + Card shows the title and location and the shift type in the bottom right.
  + Other information are readable in the details screen.
+ Customize heading text size for Markdown content in session details.
+ Library changelog: https://github.com/johnjohndoe/engelsystem/blob/master/CHANGELOG.md#v800.

# Before
![engelsystem-before1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/b22c590c-4c38-4c75-9853-12fac8f09398) ![engelsystem-before](https://github.com/EventFahrplan/EventFahrplan/assets/144518/4b780748-2f06-457f-9d0b-8d82bfa1f686)

# After
![engelsystem-after1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/bea31746-e376-47f2-bad8-1fa49a8563a0) ![engelsystem-after](https://github.com/EventFahrplan/EventFahrplan/assets/144518/bf8489b0-320e-4643-b6b4-6ef0f6a31881)

# Successfully tested on
with `cccamp2023` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 13 (API 33)

# Related
- https://github.com/johnjohndoe/engelsystem/pull/11
- https://github.com/johnjohndoe/engelsystem/pull/12
- https://github.com/engelsystem/engelsystem/pull/1233