### PR TITLE
Restrict landscape mode engagement to be shown only in portrait mode.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/IsInPortraitOrientation.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/IsInPortraitOrientation.kt
@@ -1,0 +1,13 @@
+package nerd.tuxmobil.fahrplan.congress.engagements
+
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import org.ligi.snackengage.SnackContext
+import org.ligi.snackengage.conditions.SnackCondition
+import org.ligi.snackengage.snacks.Snack
+
+class IsInPortraitOrientation : SnackCondition {
+
+    override fun isAppropriate(context: SnackContext, snack: Snack) =
+        context.androidContext.applicationContext.resources.configuration.orientation == ORIENTATION_PORTRAIT
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/LandscapeOrientationSnack.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/LandscapeOrientationSnack.kt
@@ -20,6 +20,7 @@ class LandscapeOrientationSnack(
         withConditions(
             NeverAgainWhenClickedOnce(),
             AfterNumberOfOpportunities(2),
+            IsInPortraitOrientation(),
         )
     }
 


### PR DESCRIPTION
# Description
Showing the toast message in any orientation confuses users. Hence, it should be restricted to when the device is in portrait mode.

# Before
![landscape](https://github.com/EventFahrplan/EventFahrplan/assets/144518/2b05260a-dbfa-49fb-944f-276728035b76)

# After
![portrait](https://github.com/EventFahrplan/EventFahrplan/assets/144518/1e41ab87-568f-45eb-9285-c2626bbee604)

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

# Related
- #497 