### PR TITLE
Restrict Google Play engagements to be shown only when installed via this store.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/GooglePlayBetaTestingSnack.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/GooglePlayBetaTestingSnack.kt
@@ -16,7 +16,8 @@ class GooglePlayBetaTestingSnack(val context: Context) : GooglePlayOpenBetaTestS
         withConditions(
                 NeverAgainWhenClickedOnce(),
                 AfterNumberOfOpportunities(21),
-                IsConnectedViaWiFiOrUnknown()
+                IsConnectedViaWiFiOrUnknown(),
+                IsInstalledViaGooglePlay(), // Prevents the snack from being shown for local installs, too!
         )
         setActionColor(ContextCompat.getColor(context, R.color.colorAccent))
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/IsInstalledViaGooglePlay.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/IsInstalledViaGooglePlay.kt
@@ -1,0 +1,30 @@
+package nerd.tuxmobil.fahrplan.congress.engagements
+
+import android.content.Context
+import android.os.Build
+import org.ligi.snackengage.SnackContext
+import org.ligi.snackengage.conditions.SnackCondition
+import org.ligi.snackengage.snacks.Snack
+
+class IsInstalledViaGooglePlay : SnackCondition {
+
+    private companion object {
+        const val GOOGLE_PLAY_INSTALLER_PACKAGE_NAME = "com.android.vending"
+    }
+
+    override fun isAppropriate(context: SnackContext, snack: Snack): Boolean {
+        val installerPackageName = getInstallerPackageName(context.androidContext)
+        return installerPackageName != null && installerPackageName == GOOGLE_PLAY_INSTALLER_PACKAGE_NAME
+    }
+
+    private fun getInstallerPackageName(context: Context): String? {
+        val packageName = context.packageName
+        val installerPackageName = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            context.packageManager.getInstallerPackageName(packageName)
+        } else {
+            context.packageManager.getInstallSourceInfo(packageName).installingPackageName
+        }
+        return installerPackageName
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/RateSnack.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/RateSnack.kt
@@ -16,7 +16,8 @@ class RateSnack(val context: Context) : LibraryRateSnack() {
         withConditions(
                 NeverAgainWhenClickedOnce(),
                 AfterNumberOfOpportunities(13),
-                IsConnectedViaWiFiOrUnknown()
+                IsConnectedViaWiFiOrUnknown(),
+                IsInstalledViaGooglePlay(), // Prevents the snack from being shown for local installs, too!
         )
         setActionColor(ContextCompat.getColor(context, R.color.colorAccent))
     }


### PR DESCRIPTION
# Description
+ Google Play rating and Google Play beta tester engagements should not be shown if the app was installed via the F-Droid store.
+ Please mind that local installations (`DEBUG`, `RELEASE`) won't display these snack messages anymore because the installer package name is `null` in this case.
+ Please note that the implementation can only be verified once the next publication in both stores happened!

# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)