### PR TITLE
Allow customizing the text color for room name headers.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -336,7 +336,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         }
         val paddingRight = sessionPadding
         val context = roomTitlesRowLayout.context
-        val titleTextColor = ContextCompat.getColor(context, android.R.color.white)
+        val titleTextColor = ContextCompat.getColor(context, R.color.schedule_room_name_header_text)
         for (roomName in roomNames) {
             val roomTitle = TextView(context).apply {
                 layoutParams = params


### PR DESCRIPTION
# Description
+ Verified with `cccamp2023`, `ccc36c3`, `jev2022` product flavors. No visual change happens because all of them use white as the text color.
+ Broken since: 957fa0efd60024c1afba98d9d57539d3713d94b1 and a528d92881d4a307a1a2b06a3342c15a859f109e.

![tablet](https://github.com/EventFahrplan/EventFahrplan/assets/144518/3f1e8afb-48d7-4b18-9d1e-2a184503d1ec)

# Successfully tested on
with `cccamp2023`, `ccc36c3`, `jev2022` flavors, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)