### PR TITLE
Use device time zone by default to display sessions with local times.

### DIFF
--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -91,7 +91,7 @@
 
     <!-- Device time zone -->
     <string name="preference_key_use_device_time_zone_enabled" translatable="false">use_device_time_zone</string>
-    <bool name="preference_default_value_use_device_time_zone_enabled">false</bool>
+    <bool name="preference_default_value_use_device_time_zone_enabled">true</bool>
     <string name="preference_title_use_device_time_zone_enabled">Use device time zone</string>
     <string name="preference_summary_use_device_time_zone_enabled">Displays dates and times accordingly.</string>
 


### PR DESCRIPTION
# Description
+ Use device time zone by default to display sessions with local times.
+ Users who participate at an event from remote by watching streams now see session times in their local time zone.
+ Users who physically take part in an event and have their device configured to the time zone of the event do not experience any change.

# Before and after screenshots
![device-time-zone-before](https://github.com/EventFahrplan/EventFahrplan/assets/144518/7b5b1fb3-e7b3-4d93-b94d-405250c74932) ![device-time-zone-after](https://github.com/EventFahrplan/EventFahrplan/assets/144518/9594aade-4c1f-4731-8974-df4345ea8c42)


# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

# Related
- #69.
