### PR TITLE
Update project setup (Compose compiler 1.5.6, kotlin 1.9.21, mockito 5.8.0, mockito-kotlin 5.2.1, command line tools 9862592)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk: openjdk11
 env:
   global:
   # Android command line tools, check for updates here https://developer.android.com/studio/#command-tools
-  - COMMAND_LINE_TOOLS_VERSION=9477386
+  - COMMAND_LINE_TOOLS_VERSION=9862592 # Version 10406996 requires Java 17
   - ANDROID_HOME=$HOME/android-sdk
   - TARGET_SDK_VERSION=`grep -H targetSdk buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt | grep -Po "\d+"`
   - BUILD_TOOLS_VERSION=`grep -H buildToolsVersion buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt | grep -Po "\d+.\d+.\d+"`

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -19,7 +19,7 @@ object Compose {
 
     object Versions {
         internal const val bom = "2023.06.01" // compileSdk 34 is required as of 2023.08.00
-        const val compiler = "1.5.3"
+        const val compiler = "1.5.6"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"
@@ -35,8 +35,8 @@ object Plugins {
         const val android = "7.4.2"
         const val androidJunitJacoco = "0.16.0"
         const val dexcount = "4.0.0"
-        const val kotlin = "1.9.10"
-        const val ksp = "1.9.10-1.0.13"
+        const val kotlin = "1.9.21"
+        const val ksp = "1.9.21-1.0.15"
         const val sonarQube = "4.4.1.3373"
         const val unMock = "0.7.9"
         const val versions = "0.50.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -70,7 +70,7 @@ object Libs {
         const val lifecycle = "2.6.2"
         const val markwon = "4.6.2"
         const val material = "1.9.0"
-        const val mockito = "5.7.0"
+        const val mockito = "5.8.0"
         const val mockitoKotlin = "5.1.0"
         const val moshi = "1.15.0"
         const val okhttp = "4.12.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -71,7 +71,7 @@ object Libs {
         const val markwon = "4.6.2"
         const val material = "1.9.0"
         const val mockito = "5.8.0"
-        const val mockitoKotlin = "5.1.0"
+        const val mockitoKotlin = "5.2.1"
         const val moshi = "1.15.0"
         const val okhttp = "4.12.0"
         const val preference = "1.2.1"


### PR DESCRIPTION
# Description
+ Use Jetpack Compose compiler 1.5.6 & kotlin v.1.9.21 & ksp v.1.9.21-1.0.15.
+ Use mockito v.5.8.0.
+ Use mockito-kotlin v.5.2.1.
+ Use command line tools 9862592.

# Successfully tested on
with `ccc36c3` flavor, `release` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)