### PR TITLE
Fix article not matching the grammatical gender of the conference name.

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -147,7 +147,7 @@
     <string name="snack_engage_rate_action">Bewerte die App</string>
     <string name="snack_engage_google_play_beta_testing_title">Neugierig?</string>
     <string name="snack_engage_google_play_beta_testing_action">Werde Beta-Tester</string>
-    <string name="snack_engage_c3nav_title">Indoor-Navigation auf dem <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Mit der c3nav-App</string>
+    <string name="snack_engage_c3nav_title">Indoor-Navigation @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Mit der c3nav-App</string>
     <string name="snack_engage_c3nav_action">Jetzt installieren!</string>
     <string name="snack_engage_landscape_orientation_title">Schon Querformat probiert?</string>
     <string name="snack_engage_landscape_orientation_action">Dreh dein Gerät!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -123,7 +123,7 @@
     <string name="snack_engage_rate_action">Califique la aplicación</string>
     <string name="snack_engage_google_play_beta_testing_title">¿Usuario avanzado?</string>
     <string name="snack_engage_google_play_beta_testing_action">Conviértase en probador beta</string>
-    <string name="snack_engage_c3nav_title">¡Navegación en el <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Con la aplicación c3nav</string>
+    <string name="snack_engage_c3nav_title">¡Navegación @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Con la aplicación c3nav</string>
     <string name="snack_engage_c3nav_action">¡Obténgalo ahora!</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">    Enviar reporte de fallo <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> &#8230;

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -128,7 +128,7 @@
     <string name="snack_engage_rate_action">Arvostele sovellus</string>
     <string name="snack_engage_google_play_beta_testing_title">Oletko tehokäyttäjä?</string>
     <string name="snack_engage_google_play_beta_testing_action">Ryhdy beta-koestajaksi</string>
-    <string name="snack_engage_c3nav_title">Sisäsuuntima kohteessa <xliff:g esimerkki="35C3" id="tpaahtumaNimi">%s</xliff:g>! c3nav -sovelluksen avulla</string>
+    <string name="snack_engage_c3nav_title">Sisäsuuntima @ <xliff:g esimerkki="35C3" id="tpaahtumaNimi">%s</xliff:g>! c3nav -sovelluksen avulla</string>
     <string name="snack_engage_c3nav_action">Hae se heti!</string>
     <string name="snack_engage_landscape_orientation_title">Koetitko pystysuuntaista tilaa?</string>
     <string name="snack_engage_landscape_orientation_action">Kierrä laitettasi!</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -120,7 +120,7 @@
     <string name="snack_engage_rate_action">Notez l’app</string>
     <string name="snack_engage_google_play_beta_testing_title">Utilisateur·rice avancé·e \?</string>
     <string name="snack_engage_google_play_beta_testing_action">Devenir bêta-testeur</string>
-    <string name="snack_engage_c3nav_title">La navigation interne au <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Avec l’application c3nav</string>
+    <string name="snack_engage_c3nav_title">La navigation interne @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Avec l’application c3nav</string>
     <string name="snack_engage_c3nav_action">Obtenez-la maintenant !</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title"> Envoi du rapport de crash du programme <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> … </string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -109,7 +109,7 @@
     <string name="snack_engage_rate_action">Valutare l\'applicazione</string>
     <string name="snack_engage_google_play_beta_testing_title">Utente Avanzato?</string>
     <string name="snack_engage_google_play_beta_testing_action">Diventare beta tester</string>
-    <string name="snack_engage_c3nav_title">Navigazione indoor al <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Con l\'app c3nav</string>
+    <string name="snack_engage_c3nav_title">Navigazione indoor @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Con l\'app c3nav</string>
     <string name="snack_engage_c3nav_action">Ottenerla subito</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">Invio del rapporto di errore <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> &#8230;</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -119,7 +119,7 @@
     <string name="snack_engage_rate_action">Beoordeel de App</string>
     <string name="snack_engage_google_play_beta_testing_title">Nieuwgierig?</string>
     <string name="snack_engage_google_play_beta_testing_action">Wordt een Beta-Tester</string>
-    <string name="snack_engage_c3nav_title">Indoor-navigatie tijdens <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Met de c3nav-App</string>
+    <string name="snack_engage_c3nav_title">Indoor-navigatie @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Met de c3nav-App</string>
     <string name="snack_engage_c3nav_action">Installeer nu!</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">        <xliff:g example="33C3 Fahrplan" id="appName">%s</xliff:g> crash-rapport versturen &#8230;

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -136,7 +136,7 @@
     <string name="snack_engage_rate_action">Oceń tę aplikację</string>
     <string name="snack_engage_google_play_beta_testing_title">Superużytkownik?</string>
     <string name="snack_engage_google_play_beta_testing_action">Zostań betatesterem</string>
-    <string name="snack_engage_c3nav_title">Nawigacja we wnętrzach na <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Z programem c3nav</string>
+    <string name="snack_engage_c3nav_title">Nawigacja we wnętrzach @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Z programem c3nav</string>
     <string name="snack_engage_c3nav_action">Pobierz teraz!</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">        Wyślij <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> raport o błędzie &#8230;

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -120,7 +120,7 @@
     <string name="snack_engage_rate_action">Avalie o aplicativo</string>
     <string name="snack_engage_google_play_beta_testing_title">Usuário avançado?</string>
     <string name="snack_engage_google_play_beta_testing_action">Torne-se um testador beta</string>
-    <string name="snack_engage_c3nav_title">Navegue dentro do prédio da <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Com o aplicativo c3nav</string>
+    <string name="snack_engage_c3nav_title">Navegue dentro do prédio @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Com o aplicativo c3nav</string>
     <string name="snack_engage_c3nav_action">Baixe agora!</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">        Enviar <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> relatório de falha &#8230;

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -118,7 +118,7 @@
     <string name="snack_engage_rate_action">Оценить</string>
     <string name="snack_engage_google_play_beta_testing_title">Любишь всё новое?</string>
     <string name="snack_engage_google_play_beta_testing_action">Стать бета-тестером</string>
-    <string name="snack_engage_c3nav_title">Навигация внутри <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! с приложением c3nav</string>
+    <string name="snack_engage_c3nav_title">Навигация внутри @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! с приложением c3nav</string>
     <string name="snack_engage_c3nav_action">Скачать сейчас!</string>
     <!-- TraceDroid -->
     <string name="trace_droid_dialog_title">        Отправить отчёт об ошибке <xliff:g example="33C3 Schedule" id="appName">%s</xliff:g> &#8230;

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -123,7 +123,7 @@
     <string name="snack_engage_rate_action">Betygsätt appen</string>
     <string name="snack_engage_google_play_beta_testing_title">Expertanvändare?</string>
     <string name="snack_engage_google_play_beta_testing_action">Bli en beta testare</string>
-    <string name="snack_engage_c3nav_title">Inomhusnavigering vid <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Med c3nav appen</string>
+    <string name="snack_engage_c3nav_title">Inomhusnavigering @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! Med c3nav appen</string>
     <string name="snack_engage_c3nav_action">Installera nu!</string>
     <string name="snack_engage_landscape_orientation_title">Har du prövat landskapsläget?</string>
     <string name="snack_engage_landscape_orientation_action">Rotera din enhet!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,7 +170,7 @@
         https://play.google.com/store/apps/details?id=de.c3nav.droid
     </string>
     <string name="snack_engage_c3nav_unique_id" translatable="false">c3nav</string>
-    <string name="snack_engage_c3nav_title">Indoor navigation at <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! With the c3nav app</string>
+    <string name="snack_engage_c3nav_title">Indoor navigation @ <xliff:g example="35C3" id="conferenceName">%s</xliff:g>! With the c3nav app</string>
     <string name="snack_engage_c3nav_action">Get it now!</string>
 
     <string name="snack_engage_landscape_orientation_title">Tried landscape mode?</string>


### PR DESCRIPTION
# Description
+ Buggy example (German): `Indoor-Navigation auf dem FOSDEM! Mit der c3nav-App`
+ Due to the amount of possible article-gender combination in various languages and other gender dependent modifications of related words we decide to avoid such a case here.
+ Read more: https://en.wikipedia.org/wiki/Grammatical_gender

# Before and after screenshots
![c3nav-before-en](https://github.com/EventFahrplan/EventFahrplan/assets/144518/75e61968-b890-4b29-bf87-87827c0ab6b3) ![c3nav-after-en](https://github.com/EventFahrplan/EventFahrplan/assets/144518/43059685-16b1-411c-956f-c1d220217986)
![c3nav-before-de](https://github.com/EventFahrplan/EventFahrplan/assets/144518/e7e91150-6ad2-4026-b5d7-4ff483c2e30f) ![c3nav-after-de](https://github.com/EventFahrplan/EventFahrplan/assets/144518/5227f23c-bee4-4350-b4aa-1a6ca905c00e)


# Successfully tested on
with `ccc36c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

---

Thanks to @cketti for his input! :heart_eyes_cat: 