### PR TITLE
Add support for the dedicated feedback URL field.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -44,6 +44,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         dayIndex = day,
         description = description,
         duration = duration, // minutes
+        feedbackUrl = feedbackUrl,
         hasAlarm = hasAlarm,
         language = lang,
         links = links,
@@ -87,6 +88,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.day = dayIndex
     session.description = description
     session.duration = duration // minutes
+    session.feedbackUrl = feedbackUrl
     session.hasAlarm = hasAlarm
     session.lang = language
     session.links = links
@@ -132,6 +134,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.day = dayIndex
     session.description = description
     session.duration = duration // minutes
+    session.feedbackUrl = feedbackUrl
     session.hasAlarm = hasAlarm
     session.lang = language
     session.links = links

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -58,8 +58,6 @@ class SessionDetailsFragment : Fragment() {
 
         const val FRAGMENT_TAG = "detail"
         private const val SESSION_DETAILS_FRAGMENT_REQUEST_KEY = "SESSION_DETAILS_FRAGMENT_REQUEST_KEY"
-        private const val SCHEDULE_FEEDBACK_URL = BuildConfig.SCHEDULE_FEEDBACK_URL
-        private val SHOW_FEEDBACK_MENU_ITEM = !TextUtils.isEmpty(SCHEDULE_FEEDBACK_URL)
 
         // Custom heading text size multipliers for each heading level.
         // Docs: https://noties.io/Markwon/docs/v4/core/theme.html#typeface
@@ -385,7 +383,7 @@ class SessionDetailsFragment : Fragment() {
             menu.setMenuItemVisibility(R.id.menu_item_set_alarm, false)
             menu.setMenuItemVisibility(R.id.menu_item_delete_alarm, true)
         }
-        menu.setMenuItemVisibility(R.id.menu_item_feedback, SHOW_FEEDBACK_MENU_ITEM && model.supportsFeedback)
+        menu.setMenuItemVisibility(R.id.menu_item_feedback, model.supportsFeedback)
         if (sidePane) {
             menu.setMenuItemVisibility(R.id.menu_item_close_session_details, true)
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -28,6 +28,8 @@ public class Session {
 
     public String title;
     public String subtitle;
+    @Nullable
+    public String feedbackUrl;          // URL to Frab/Pretalx feedback system, e.g. feedbackUrl = "https://talks.event.net/2023/talk/V8LUNA/feedback"
     public String url;
     public int day;                     // XML values start with 1
     public String date;                 // YYYY-MM-DD
@@ -87,6 +89,7 @@ public class Session {
     public Session(String sessionId) {
         title = "";
         subtitle = "";
+        feedbackUrl = null;
         url = "";
         day = 0;
         roomName = "";
@@ -128,6 +131,7 @@ public class Session {
     public Session(@NonNull Session session) {
         this.title = session.title;
         this.subtitle = session.subtitle;
+        this.feedbackUrl = session.feedbackUrl;
         this.url = session.url;
         this.day = session.day;
         this.date = session.date;
@@ -209,6 +213,7 @@ public class Session {
 
         Session session = (Session) o;
 
+        if (!ObjectsCompat.equals(feedbackUrl, session.feedbackUrl)) return false;
         if (day != session.day) return false;
         if (duration != session.duration) return false;
         if (recordingOptOut != session.recordingOptOut) return false;
@@ -234,6 +239,7 @@ public class Session {
     public int hashCode() {
         int result = title.hashCode();
         result = 31 * result + ObjectsCompat.hashCode(subtitle);
+        result = 31 * result + ObjectsCompat.hashCode(feedbackUrl);
         result = 31 * result + day;
         result = 31 * result + ObjectsCompat.hashCode(roomName);
         result = 31 * result + ObjectsCompat.hashCode(roomIdentifier);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -12,18 +12,23 @@ class FeedbackUrlComposer(
 ) {
 
     /**
-     * Returns the feedback URL for the [session] if it can be composed
-     * otherwise an empty string.
+     * Returns the feedback URL for the [session] if it is available or can be composed otherwise
+     * an empty string.
      *
-     * The [Frab schedule feedback URL][getFrabScheduleFeedbackUrl] is
-     * composed from the session id.
-     * For sessions extracted from the wiki of the Chaos Communication Congress
-     * aka. "self organized sessions" an empty string is returned because
-     * there is no feedback system for them.
+     * The dedicated [Session.feedbackUrl] provides the feedback URL of the Frab or Pretalx instance
+     * independent from the domain where the schedule.xml is hosted.
+     *
+     * The [Frab schedule feedback URL][getFrabScheduleFeedbackUrl] is composed from the session id.
+     * For sessions extracted from the wiki of the Chaos Communication Congress aka. "self organized
+     * sessions" an empty string is returned because there is no feedback system for them.
      */
     fun getFeedbackUrl(session: Session): String {
         if (session.originatesFromWiki) {
             return NO_URL
+        }
+        val feedbackUrl = session.feedbackUrl
+        if (feedbackUrl != null) {
+            return feedbackUrl.ifEmpty { NO_URL }
         }
         return if (session.originatesFromPretalx) {
             session.pretalxScheduleFeedbackUrl

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -71,6 +71,7 @@ class SessionExtensionsTest {
                 dateUTC = 1439478900000L,
                 description = "Lorem ipsum dolor sit amet",
                 duration = 45,
+                feedbackUrl = "https://talks.mrmcd.net/2018/talk/V3FUNG/feedback",
                 hasAlarm = true,
                 isHighlight = true,
                 language = "en",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -25,6 +25,7 @@ class SessionExtensionsTest {
                 dateUTC = 1439478900000L,
                 description = "Lorem ipsum dolor sit amet",
                 duration = 45,
+                feedbackUrl = "https://talks.mrmcd.net/2018/talk/V3FUNG/feedback",
                 hasAlarm = true,
                 isHighlight = true,
                 language = "en",
@@ -112,6 +113,7 @@ class SessionExtensionsTest {
             dateUTC = 1439478900000L
             description = "Lorem ipsum dolor sit amet"
             duration = 45
+            feedbackUrl = "https://talks.mrmcd.net/2018/talk/V3FUNG/feedback"
             hasAlarm = true
             highlight = true
             lang = "en"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -13,6 +13,7 @@ class SessionTest {
         fun createSession() = Session("s1").apply {
             title = "Lorem ipsum"
             subtitle = "Gravida arcu ac tortor"
+            feedbackUrl = "https://example.com/feedback"
             day = 3
             date = "2020-02-29"
             dateUTC = 1439478900000L
@@ -153,6 +154,13 @@ class SessionTest {
     @Test
     fun `equals evaluates false and hashCode differ for sessions with odd subtitle`() {
         val session2Modification: SessionModification = { subtitle = "Odd subtitle" }
+        assertOddSessionsAreNotEqual { session2Modification() }
+        assertOddSessionsHaveOddHashCodes { session2Modification() }
+    }
+
+    @Test
+    fun `equals evaluates false and hashCode differ for sessions with odd feedback URL`() {
+        val session2Modification: SessionModification = { feedbackUrl = "https://example.net/feedback" }
         assertOddSessionsAreNotEqual { session2Modification() }
         assertOddSessionsHaveOddHashCodes { session2Modification() }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -11,21 +11,48 @@ class FeedbackUrlComposerTest {
 
         const val FRAB_SCHEDULE_FEEDBACK_URL = "https://frab.cccv.de/en/35C3/public/events/%s/feedback/new"
 
+        val HUB_PRETALX_SESSION = Session("3723").apply {
+            url = "https://fahrplan.events.ccc.de/congress/2023/hub/events/37c3_opening.html"
+            slug = "37c3_opening"
+            feedbackUrl = "https://talks.c3voc.de/2023/talk/7B2KMD/feedback/"
+        }
+
+        val HUB_SOS_SESSION = Session("3724").apply {
+            url = "https://fahrplan.events.ccc.de/congress/2023/hub/events/lockpicking_workshop.html"
+            slug = "lockpicking_workshop"
+            feedbackUrl = ""
+        }
+
         val FRAB_SESSION = Session("9985").apply {
             url = "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html"
             slug = "35c3-9985-opening_ceremony"
+            feedbackUrl = null
         }
 
         val PRETALX_SESSION = Session("202").apply {
             url = "https://talks.mrmcd.net/2019/talk/9XL7SP/"
             slug = "2019-202-board-games-of-medieval-europe"
+            feedbackUrl = null
         }
 
         val WIKI_SESSION = Session("1346").apply {
             track = WIKI_SESSION_TRACK_NAME
             url = "https://events.ccc.de/congress/2019/wiki/index.php/Session:Mobile_Apps"
+            feedbackUrl = null
         }
 
+    }
+
+    @Test
+    fun `getFeedbackUrl returns valid string for Hub Pretalx session`() {
+        assertThat(FeedbackUrlComposer("")
+                .getFeedbackUrl(HUB_PRETALX_SESSION)).isEqualTo("https://talks.c3voc.de/2023/talk/7B2KMD/feedback/")
+    }
+
+    @Test
+    fun `getFeedbackUrl returns empty string for Hub SOS session`() {
+        assertThat(FeedbackUrlComposer("")
+            .getFeedbackUrl(HUB_SOS_SESSION)).isEmpty()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -29,27 +29,27 @@ class FeedbackUrlComposerTest {
     }
 
     @Test
-    fun getFeedbackUrlWithFrabSessionWithoutScheduleFeedbackUrl() {
+    fun `getFeedbackUrl returns empty string for Frab session if schedule feedback URL is missing`() {
         assertThat(FeedbackUrlComposer("")
                 .getFeedbackUrl(FRAB_SESSION)).isEmpty()
     }
 
     @Test
-    fun getFeedbackUrlWithFrabSessionWithFrabScheduleFeedbackUrl() {
+    fun `getFeedbackUrl returns valid feedback URL for Frab session if schedule feedback URL is present`() {
         assertThat(FeedbackUrlComposer(FRAB_SCHEDULE_FEEDBACK_URL)
                 .getFeedbackUrl(FRAB_SESSION)).isEqualTo("https://frab.cccv.de/en/35C3/public/events/9985/feedback/new")
     }
 
     @Test
-    fun getFeedbackUrlWithPretalxSessionWithFrabScheduleFeedbackUrl() {
+    fun `getFeedbackUrl returns valid feedback URL for Pretalx session if schedule feedback URL is present`() {
         assertThat(FeedbackUrlComposer(FRAB_SCHEDULE_FEEDBACK_URL)
                 .getFeedbackUrl(PRETALX_SESSION)).isEqualTo("https://talks.mrmcd.net/2019/talk/9XL7SP/feedback/")
     }
 
     @Test
-    fun getFeedbackUrlWithWikiSession() {
+    fun `getFeedbackUrl returns empty string for wiki session`() {
         assertThat(FeedbackUrlComposer("")
-                .getFeedbackUrl(WIKI_SESSION)).isEqualTo("")
+                .getFeedbackUrl(WIKI_SESSION)).isEmpty()
     }
 
 }

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
@@ -19,6 +19,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -54,6 +55,7 @@ class SessionExtensionsTest {
                 dateUTC = 1439478900000L,
                 description = "Lorem ipsum dolor sit amet",
                 duration = 45,
+                feedbackUrl = "https://talks.mrmcd.net/2018/talk/V3FUNG/feedback",
                 hasAlarm = true,
                 isHighlight = true,
                 language = "en",
@@ -94,6 +96,7 @@ class SessionExtensionsTest {
         assertThat(values.getAsLong(DATE_UTC)).isEqualTo(1439478900000L)
         assertThat(values.getAsString(DESCR)).isEqualTo("Lorem ipsum dolor sit amet")
         assertThat(values.getAsInteger(DURATION)).isEqualTo(45)
+        assertThat(values.getAsString(FEEDBACK_URL)).isEqualTo("https://talks.mrmcd.net/2018/talk/V3FUNG/feedback")
         // The value of "hasAlarms" is not persisted.
         // The value of "isHighlight" is not persisted.
         assertThat(values.getAsString(LANG)).isEqualTo("en")

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -125,6 +125,7 @@ public interface FahrplanContract {
             /* 33 */ String URL = "url";
             /* 34 */ String TIME_ZONE_OFFSET = "time_zone_offset";
             /* 35 */ String ROOM_IDENTIFIER = "room_identifier";
+            /* 36 */ String FEEDBACK_URL = "feedback_url";
         }
 
         interface Defaults {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
@@ -21,6 +21,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -51,6 +52,7 @@ fun Session.toContentValues() = contentValuesOf(
         DATE_UTC to dateUTC,
         DESCR to description,
         DURATION to duration,
+        FEEDBACK_URL to feedbackUrl,
         LANG to language,
         LINKS to links,
         REC_LICENSE to recordingLicense,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
@@ -12,6 +12,7 @@ data class Session(
         val dateUTC: Long = 0,
         val description: String = "",
         val duration: Int = 0,          // minutes
+        val feedbackUrl: String? = null,
         val hasAlarm: Boolean = false,
         val isHighlight: Boolean = false,
         val language: String = "",

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
@@ -26,6 +26,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -50,6 +51,7 @@ import info.metadude.android.eventfahrplan.database.extensions.getInt
 import info.metadude.android.eventfahrplan.database.extensions.getIntOrNull
 import info.metadude.android.eventfahrplan.database.extensions.getLong
 import info.metadude.android.eventfahrplan.database.extensions.getString
+import info.metadude.android.eventfahrplan.database.extensions.getStringOrNull
 import info.metadude.android.eventfahrplan.database.extensions.insert
 import info.metadude.android.eventfahrplan.database.extensions.map
 import info.metadude.android.eventfahrplan.database.extensions.read
@@ -204,6 +206,7 @@ class RealSessionsDatabaseRepository(
                     dayIndex = cursor.getInt(DAY),
                     description = cursor.getString(DESCR),
                     duration = cursor.getInt(DURATION),
+                    feedbackUrl = cursor.getStringOrNull(FEEDBACK_URL),
                     language = cursor.getString(LANG),
                     links = cursor.getString(LINKS),
                     recordingLicense = cursor.getString(REC_LICENSE),

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.java
@@ -16,7 +16,7 @@ import info.metadude.android.eventfahrplan.database.extensions.SQLiteDatabaseExt
 
 public class SessionsDBOpenHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 14;
+    private static final int DATABASE_VERSION = 15;
 
     private static final String DATABASE_NAME = "lectures"; // Keep table name to avoid database migration.
 
@@ -31,6 +31,7 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
                     Columns.SLUG + " TEXT, " +
                     Columns.START + " INTEGER, " +
                     Columns.DURATION + " INTEGER, " +
+                    Columns.FEEDBACK_URL + " TEXT DEFAULT NULL, " +
                     Columns.SPEAKERS + " STRING, " +
                     Columns.TRACK + " STRING, " +
                     Columns.TYPE + " STRING, " +
@@ -157,6 +158,13 @@ public class SessionsDBOpenHelper extends SQLiteOpenHelper {
                 db.execSQL("ALTER TABLE " + SessionsTable.NAME + " ADD COLUMN " + Columns.ROOM_IDENTIFIER + " TEXT DEFAULT ''");
             }
         }
+        if (oldVersion < 15) {
+            boolean columnExists = SQLiteDatabaseExtensions.columnExists(db, SessionsTable.NAME, Columns.FEEDBACK_URL);
+            if (!columnExists) {
+                db.execSQL("ALTER TABLE " + SessionsTable.NAME + " ADD COLUMN " + Columns.FEEDBACK_URL + " TEXT DEFAULT NULL");
+            }
+        }
+
 
     }
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
@@ -15,6 +15,7 @@ data class Session(
         var dateUTC: Long = 0,
         var description: String = "",
         var duration: Int = 0, // minutes
+        var feedbackUrl: String? = null,
         var hasAlarm: Boolean = false,
         var isHighlight: Boolean = false,
         var language: String = "",

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -216,6 +216,9 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                         } else if (name.equals("slug")) {
                                             parser.next();
                                             session.setSlug(XmlPullParsers.getSanitizedText(parser));
+                                        } else if (name.equals("feedback_url")) {
+                                            parser.next();
+                                            session.setFeedbackUrl(XmlPullParsers.getSanitizedText(parser));
                                         } else if (name.equals("url")) {
                                             parser.next();
                                             session.setUrl(XmlPullParsers.getSanitizedText(parser));


### PR DESCRIPTION
# Description
+ The `feedback_url` field has been added to the `schedule.xml` to allow specifying a URL which is independent from the domain where the `schedule.xml` itself is hosted. A typical scenario is a merged `schedule.xml` provided by a central backend and multiple schedule provider instances (Frab, Pretalx, ...) with their own feedback URLs.
+ Possible values and their meaning:
  + null -> `feedback_url` is not supported, probably an older backend version of Frab, Pretalx, Wafer, ...
  + empty -> no feedback form available for this session, probably a self-organized session parsed from a wiki
  + value -> valid full qualified URL pointing to the feedback form not necessarily hosted on the same domain as the `schedule.xml`
+ The field can be `null` if not supported by any given backend.

# Successfully tested on
with `ccc36c3` flavor, `release` builds, with 36C3 v.1.55.0 and this branch, update scenario
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

# Related
+ https://git.cccv.de/hub/hub/-/issues/430
