### PR TITLE
Cleanup Session class to its prepare migration to Kotlin data class 

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -109,7 +109,7 @@ class AlarmServices @VisibleForTesting constructor(
         for (alarmTimeString in alarmTimeStrings) {
             alarmTimes.add(alarmTimeString.toInt())
         }
-        val sessionStartTime = session.startTimeMilliseconds
+        val sessionStartTime = session.startsAt.toMilliseconds()
         val alarmTimeOffset = alarmTimes[alarmTimesIndex] * Moment.MILLISECONDS_OF_ONE_MINUTE.toLong()
         val alarmTime = sessionStartTime - alarmTimeOffset
         val moment = Moment.ofEpochMilli(alarmTime)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -79,7 +79,7 @@ internal class AlarmsViewModel(
                                 found.subtitle
                             )
                             val alarmOffset =
-                                (found.startTimeMilliseconds - alarm.startTime).toMinutes()
+                                (found.startsAt.toMilliseconds() - alarm.startTime).toMinutes()
                             val alarmOffsetContentDescription = when (alarmOffset == 0) {
                                 true -> resourceResolving.getString(R.string.alarms_item_alarm_time_zero_minutes_content_description)
                                 false -> resourceResolving.getString(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharing.kt
@@ -36,7 +36,7 @@ class CalendarSharing @JvmOverloads constructor(
         val title = this.title
         val description = calendarDescriptionComposition.getCalendarDescription(this)
         val location = this.roomName
-        val startTime = startTimeMilliseconds
+        val startTime = startsAt.toMilliseconds()
         val endTime = startTime + this.duration * MILLISECONDS_OF_ONE_MINUTE
         return Intent(Intent.ACTION_INSERT, CalendarContract.Events.CONTENT_URI).withExtras(
             CalendarContract.Events.TITLE to title,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -21,14 +21,6 @@ fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
 
 fun Session.toRoom() = Room(identifier = roomIdentifier, name = roomName)
 
-/**
- * Returns a moment based on the start time of this session.
- */
-fun Session.toStartsAtMoment(): Moment {
-    require(dateUTC > 0) { "Field 'dateUTC' is 0." }
-    return Moment.ofEpochMilli(dateUTC)
-}
-
 fun Session.toDateInfo(): DateInfo = DateInfo(day, Moment.parseDate(date))
 
 fun Session.toHighlightDatabaseModel() = HighlightDatabaseModel(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -76,7 +76,7 @@ class StarredListAdapter internal constructor(
     }
 
     private val Session.tookPlace
-        get() = endsAtDateUtc < Moment.now().toMilliseconds()
+        get() = endsAt.isBefore(Moment.now())
 
     private fun TextView.setPastSessionTextColor() = setTextColor(pastSessionTextColor)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -163,12 +163,12 @@ class StarredListFragment :
         if (!::starredList.isInitialized) {
             return
         }
-        val nowMillis = Moment.now().toMilliseconds()
+        val now = Moment.now()
         var numSeparators = 0
         var i = 0
         while (i < starredList.size) {
             val session = starredList[i]
-            if (session.endsAt.toMilliseconds() > nowMillis) {
+            if (session.endsAt.isAfter(now)) {
                 numSeparators = session.day
                 break
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -168,7 +168,7 @@ class StarredListFragment :
         var i = 0
         while (i < starredList.size) {
             val session = starredList[i]
-            if (session.endsAtDateUtc > nowMillis) {
+            if (session.endsAt.toMilliseconds() > nowMillis) {
                 numSeparators = session.day
                 break
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -8,6 +8,7 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.util.ObjectsCompat;
 
 import org.threeten.bp.ZoneOffset;
@@ -177,6 +178,7 @@ public class Session {
         return links == null ? "" : links;
     }
 
+    @VisibleForTesting
     public Moment getStartTimeMoment() {
         long startOfDayTimestamp = DateParser.getDateTime(date);
         return Moment.ofEpochMilli(startOfDayTimestamp).plusMinutes(relStartTime);

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -8,7 +8,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import androidx.core.util.ObjectsCompat;
 
 import org.threeten.bp.ZoneOffset;
@@ -18,7 +17,6 @@ import java.util.List;
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
-import info.metadude.android.eventfahrplan.network.temporal.DateParser;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.repositories.SessionsTransformer;
 import nerd.tuxmobil.fahrplan.congress.schedule.Conference;
@@ -176,12 +174,6 @@ public class Session {
     @NonNull
     public String getLinks() {
         return links == null ? "" : links;
-    }
-
-    @VisibleForTesting
-    public Moment getStartTimeMoment() {
-        long startOfDayTimestamp = DateParser.getDateTime(date);
-        return Moment.ofEpochMilli(startOfDayTimestamp).plusMinutes(relStartTime);
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -205,6 +205,14 @@ public class Session {
         return dateUTC + (long) duration * MILLISECONDS_OF_ONE_MINUTE;
     }
 
+    /**
+     * Returns a moment based on summing up the start time milliseconds and the duration.
+     */
+    @NonNull
+    public Moment getEndsAt() {
+        return Moment.ofEpochMilli(getEndsAtDateUtc());
+    }
+
     @SuppressWarnings("RedundantIfStatement")
     @Override
     public boolean equals(Object o) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -206,13 +206,6 @@ public class Session {
     }
 
     /**
-     * Returns the end time since day start in minutes.
-     */
-    public int getEndsAtTime() {
-        return startTime + duration;
-    }
-
-    /**
      * Returns a moment based on summing up the start time milliseconds and the duration.
      */
     @NonNull

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -185,16 +185,6 @@ public class Session {
     }
 
     /**
-     * Returns the start time in milliseconds.
-     * <p>
-     * The {@link #dateUTC} is given precedence if its value is bigger then `0`.
-     * Otherwise the start time is determined based on {@link #getStartTimeMoment}.
-     */
-    public long getStartTimeMilliseconds() {
-        return (dateUTC > 0) ? dateUTC : getStartTimeMoment().toMilliseconds();
-    }
-
-    /**
      * Returns a moment based on the start time milliseconds.
      * <p/>
      * Don't use in {@link Conference.Companion#ofSessions)} as long as {@link #relStartTime} is supported.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -20,6 +20,7 @@ import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
 import info.metadude.android.eventfahrplan.network.temporal.DateParser;
 import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.repositories.SessionsTransformer;
+import nerd.tuxmobil.fahrplan.congress.schedule.Conference;
 
 /**
  * Application model representing a lecture, a workshop or any similar time-framed happening.
@@ -189,6 +190,19 @@ public class Session {
      */
     public long getStartTimeMilliseconds() {
         return (dateUTC > 0) ? dateUTC : getStartTimeMoment().toMilliseconds();
+    }
+
+    /**
+     * Returns a moment based on the start time milliseconds.
+     * <p/>
+     * Don't use in {@link Conference.Companion#ofSessions)} as long as {@link #relStartTime} is supported.
+     * See: <a href="https://github.com/EventFahrplan/EventFahrplan/commit/5a4022b00434700274a824cc63f6d54a18b06fac">5a402</a>
+     */
+    public Moment getStartsAt() {
+        if (dateUTC <= 0) {
+            throw new IllegalArgumentException("Field 'dateUTC' must be more than 0.");
+        }
+        return Moment.ofEpochMilli(dateUTC);
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -213,18 +213,11 @@ public class Session {
     }
 
     /**
-     * Returns the end date and time in milliseconds.
-     */
-    public long getEndsAtDateUtc() {
-        return dateUTC + (long) duration * MILLISECONDS_OF_ONE_MINUTE;
-    }
-
-    /**
      * Returns a moment based on summing up the start time milliseconds and the duration.
      */
     @NonNull
     public Moment getEndsAt() {
-        return Moment.ofEpochMilli(getEndsAtDateUtc());
+        return Moment.ofEpochMilli(dateUTC + (long) duration * MILLISECONDS_OF_ONE_MINUTE);
     }
 
     @SuppressWarnings("RedundantIfStatement")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
@@ -40,8 +40,7 @@ data class Conference(
             val first = Moment.ofEpochMilli(firstSession.dateUTC)
             // TODO Replace with firstSession.toStartsAtMoment() once Session#relStartTime is no longer used.
             val endingLatest = sessions.endingLatest()
-            val endsAt = endingLatest.endsAtDateUtc
-            val last = Moment.ofEpochMilli(endsAt)
+            val last = endingLatest.endsAt
             val minutesToAdd = if (first.monthDay == last.monthDay) 0 else MINUTES_OF_ONE_DAY
             // Here we are assuming all sessions have the same time zone offset.
             val timeZoneOffset = firstSession.timeZoneOffset

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/Conference.kt
@@ -61,10 +61,10 @@ data class Conference(
  * Returns the [Session] which ends the latest compared to all other [sessions][this].
  */
 private fun List<Session>.endingLatest(): Session {
-    var endsAt = 0L
+    var endsAt = Moment.ofEpochMilli(0L)
     var latestSession = first()
-    map { it to it.endsAtDateUtc }.forEach { (session, sessionEndsAt) ->
-        if (endsAt == 0L || sessionEndsAt > endsAt) {
+    map { it to it.endsAt }.forEach { (session, sessionEndsAt) ->
+        if (endsAt.isSimultaneousWith(Moment.ofEpochMilli(0L)) || sessionEndsAt.isAfter(endsAt)) {
             latestSession = session
             endsAt = sessionEndsAt
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -216,7 +216,7 @@ internal class FahrplanViewModel(
 
     private fun List<Session>.toTimeTextViewParameters(nowMoment: Moment, normalizedBoxHeight: Int): List<TimeTextViewParameter> {
         val earliestSession = repository.loadEarliestSession()
-        val firstDayStartDay = earliestSession.startTimeMoment.monthDay
+        val firstDayStartDay = earliestSession.startsAt.monthDay
         val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
         val dayIndex = repository.readDisplayDayIndex()
         val conference = Conference.ofSessions(this)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -5,7 +5,6 @@ import android.widget.LinearLayout
 import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
-import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.threeten.bp.Duration
@@ -80,7 +79,7 @@ data class LayoutCalculator @JvmOverloads constructor(
     private fun getStartTime(session: Session, previousSessionEndsAt: Int): Int {
         var startTime: Int
         if (session.dateUTC > 0) {
-            startTime = session.toStartsAtMoment().minuteOfDay
+            startTime = session.startsAt.minuteOfDay
             if (startTime < previousSessionEndsAt) {
                 startTime += Duration.ofDays(1).toMinutes().toInt()
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
@@ -89,7 +90,8 @@ data class LayoutCalculator @JvmOverloads constructor(
         return startTime
     }
 
-    private fun fixOverlappingSessions(sessionIndex: Int, sessions: List<Session>) {
+    @VisibleForTesting
+    fun fixOverlappingSessions(sessionIndex: Int, sessions: List<Session>) {
         val session = sessions[sessionIndex]
         val next = sessions.getOrNull(sessionIndex + 1)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.logging.Logging
-import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.threeten.bp.Duration
@@ -95,11 +94,11 @@ data class LayoutCalculator @JvmOverloads constructor(
         val next = sessions.getOrNull(sessionIndex + 1)
 
         if (next != null && next.dateUTC > 0) {
-            val nextStartsBeforeCurrentEnds = session.endsAtDateUtc > next.dateUTC
+            val nextStartsBeforeCurrentEnds = next.startsAt.isBefore(session.endsAt)
             if (nextStartsBeforeCurrentEnds) {
                 logging.d(LOG_TAG, """Collision: "${session.title}" + "${next.title}"""")
                 // cut current at the end, to match next sessions start time
-                session.duration = ((next.dateUTC - session.dateUTC) / MILLISECONDS_OF_ONE_MINUTE).toInt()
+                session.duration = session.startsAt.minutesUntil(next.startsAt).toInt()
             }
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
-import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -83,7 +82,7 @@ internal class ScrollAmountCalculator(
      * This calculation is independent of the time zone offset of the device nor conference.
      */
     fun calculateScrollAmount(conference: Conference, session: Session, boxHeight: Int): Int {
-        val sessionStartsAt = session.toStartsAtMoment()
+        val sessionStartsAt = session.startsAt
         val firstSessionStartsAt = conference.firstSessionStartsAt
         val minutes = firstSessionStartsAt.minutesUntil(sessionStartsAt).toInt()
         return minutes / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -60,7 +60,7 @@ internal class ScrollAmountCalculator(
             if (columnIndex >= 0 && columnIndex < roomDataList.size) {
                 val roomData = roomDataList[columnIndex]
                 for (session in roomData.sessions) {
-                    if (session.startTime <= time && session.endsAtTime > time) {
+                    if (session.startsAt.minuteOfDay <= time && session.endsAt.minuteOfDay > time) {
                         logging.d(LOG_TAG, session.title)
                         logging.d(LOG_TAG, "$time ${session.startTime}/${session.duration}")
                         scrollAmount -= (time - session.startTime) / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -52,7 +52,7 @@ class SimpleSessionFormat {
     }
 
     private fun StringBuilder.appendSession(session: Session, timeZoneId: ZoneId?) {
-        val startTime = session.startTimeMilliseconds
+        val startTime = session.startsAt.toMilliseconds()
         val useDeviceTimeZone = false // Always share in the original session time zone.
         val shareableStartTime = DateFormatter.newInstance(useDeviceTimeZone).getFormattedShareable(startTime, timeZoneId)
         append(session.title)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -66,6 +66,16 @@ class AlarmServicesTest {
         alarmServices.addSessionAlarm(session, alarmTimesValues.indexOf("60"))
         // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
         assertThat(session.hasAlarm).isTrue()
+        val expectedAlarm = Alarm(
+            alarmTimeInMin = 60,
+            day = 1,
+            displayTime = 1536332400000,
+            sessionId = "S1",
+            sessionTitle = "Title",
+            startTime = 1536328800000,
+            timeText = "not relevant"
+        )
+        verifyInvokedOnce(repository).updateAlarm(expectedAlarm)
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -6,7 +6,6 @@ import info.metadude.android.eventfahrplan.database.models.Session.Companion.REC
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.fail
 import org.junit.Test
 import org.threeten.bp.ZoneOffset
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
@@ -148,24 +147,6 @@ class SessionExtensionsTest {
             changedTrack = true
         }
         assertThat(sessionNetworkModel.toSessionAppModel()).isEqualTo(sessionAppModel)
-    }
-
-    @Test
-    fun `toStartsAtMoment returns Moment object if dateUTC has proper value`() {
-        val session = Session("").apply { dateUTC = 1582963200000L }
-        val moment = session.toStartsAtMoment()
-        assertThat(moment).isEqualTo(Moment.ofEpochMilli(1582963200000L))
-    }
-
-    @Test
-    fun `toStartsAtMoment throws exception if dateUTC is 0`() {
-        val session = Session("")
-        try {
-            session.toStartsAtMoment()
-            fail("Expect an IllegalArgumentException to be thrown.")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Field 'dateUTC' is 0.")
-        }
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -390,15 +390,6 @@ class SessionTest {
     }
 
     @Test
-    fun `getEndsAt equals endsAtDateUtc converted to Moment`() {
-        val session = Session("").apply {
-            dateUTC = 1584662400000L
-            duration = 90
-        }
-        assertThat(session.endsAt).isEqualTo(Moment.ofEpochMilli(session.endsAtDateUtc))
-    }
-
-    @Test
     fun `getEndsAt sums dateUTC and duration`() {
         val session = Session("").apply {
             dateUTC = 1584662400000L

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -372,15 +372,6 @@ class SessionTest {
     }
 
     @Test
-    fun `endsAtTime sums startTime and duration`() {
-        val session = Session("").apply {
-            startTime = 300
-            duration = 30
-        }
-        assertThat(session.endsAtTime).isEqualTo(330)
-    }
-
-    @Test
     fun `endsAtDateUtc sums dateUTC and duration`() {
         val session = Session("").apply {
             dateUTC = 10_000

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.models
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
-import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -303,38 +302,6 @@ class SessionTest {
             changedIsCanceled = true
         }
         assertThat(session.apply { cancel() }).isEqualTo(canceledSession)
-    }
-
-    @Test
-    fun `getStartTimeMoment based on date and relStartTime in the morning`() {
-        val session = Session("1")
-        session.relStartTime = 121
-        session.date = "2019-12-27"
-        session.dateUTC = 0 // Not evaluated by startTimeMoment
-
-        val moment = session.startTimeMoment
-        assertThat(moment.minute).isEqualTo(1)
-        assertThat(moment.minuteOfDay).isEqualTo(121)
-        assertThat(moment.hour).isEqualTo(2)
-        assertThat(moment.month).isEqualTo(12)
-        assertThat(moment.monthDay).isEqualTo(27)
-        assertThat(moment.year).isEqualTo(2019)
-    }
-
-    @Test
-    fun `getStartTimeMoment based on date and relStartTime after midnight`() {
-        val session = Session("1")
-        session.relStartTime = MINUTES_OF_ONE_DAY + 121 // 2:01:00 AM
-        session.date = "2019-12-27"
-        session.dateUTC = 0 // Not evaluated by startTimeMoment
-
-        val moment = session.startTimeMoment
-        assertThat(moment.minute).isEqualTo(1)
-        assertThat(moment.minuteOfDay).isEqualTo(121)
-        assertThat(moment.hour).isEqualTo(2)
-        assertThat(moment.month).isEqualTo(12)
-        assertThat(moment.monthDay).isEqualTo(28) // Unexpected depending on where startTimeMoment is used!
-        assertThat(moment.year).isEqualTo(2019)
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -356,6 +356,22 @@ class SessionTest {
     }
 
     @Test
+    fun `startsAt returns the start date converted to Moment`() {
+        val session = Session("").apply { dateUTC = 1582963200000L }
+        assertThat(session.startsAt).isEqualTo(Moment.ofEpochMilli(1582963200000L))
+    }
+
+    @Test
+    fun `startsAt throws exception if dateUTC is less then or equal to 0`() {
+        val session = Session("").apply { dateUTC = 0 }
+        try {
+            session.startsAt
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("Field 'dateUTC' must be more than 0.")
+        }
+    }
+
+    @Test
     fun `endsAtTime sums startTime and duration`() {
         val session = Session("").apply {
             startTime = 300

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -1,5 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.models
 
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -368,7 +370,26 @@ class SessionTest {
             dateUTC = 10_000
             duration = 60
         }
-        assertThat(session.endsAtDateUtc).isEqualTo(3_610_000L)
+        assertThat(session.endsAt.toMilliseconds()).isEqualTo(3_610_000L)
+    }
+
+    @Test
+    fun `getEndsAt equals endsAtDateUtc converted to Moment`() {
+        val session = Session("").apply {
+            dateUTC = 1584662400000L
+            duration = 90
+        }
+        assertThat(session.endsAt).isEqualTo(Moment.ofEpochMilli(session.endsAtDateUtc))
+    }
+
+    @Test
+    fun `getEndsAt sums dateUTC and duration`() {
+        val session = Session("").apply {
+            dateUTC = 1584662400000L
+            duration = 120
+        }
+        val endsAt = Moment.ofEpochMilli(1584662400000L + 120 * MILLISECONDS_OF_ONE_MINUTE)
+        assertThat(session.endsAt).isEqualTo(endsAt)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -338,24 +338,6 @@ class SessionTest {
     }
 
     @Test
-    fun `startTimeMilliseconds returns the dateUTC value when dateUTC is set`() {
-        val session = Session("1").apply {
-            dateUTC = 1
-            date = "2020-03-20"
-        }
-        assertThat(session.startTimeMilliseconds).isEqualTo(1)
-    }
-
-    @Test
-    fun `startTimeMilliseconds returns the date value when dateUTC is not set`() {
-        val session = Session("1").apply {
-            dateUTC = 0
-            date = "2020-03-20"
-        }
-        assertThat(session.startTimeMilliseconds).isEqualTo(1584662400000L)
-    }
-
-    @Test
     fun `startsAt returns the start date converted to Moment`() {
         val session = Session("").apply { dateUTC = 1582963200000L }
         assertThat(session.startsAt).isEqualTo(Moment.ofEpochMilli(1582963200000L))

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -226,7 +226,7 @@ class FahrplanViewModelTest {
     fun `fillTimes posts TimeTextViewParameter to timeTextViewParameters property`() = runTest {
         val startsAt = 1582963200000L // February 29, 2020 08:00:00 AM GMT
         val earliestSession = mock<Session> {
-            on { startTimeMoment } doReturn Moment.ofEpochMilli(startsAt)
+            on { this@on.startsAt } doReturn Moment.ofEpochMilli(startsAt)
         }
         val session = Session("session-01").apply {
             dateUTC = startsAt

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -194,6 +194,55 @@ class LayoutCalculatorTest {
         assertMargins(session2Params, 35, 0)
     }
 
+    @Test
+    fun `fixOverlappingSessions decreases the duration of a session with an overlapping successor`() {
+        val duration1 = 45
+        val duration2 = 45
+        val startTime1 = 10 * 60 // 10:00am
+        val startTime2 = startTime1 + duration1 - 10 // 10:35am (10 minutes overlap)
+
+        val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
+        val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
+        val sessions = listOf(session1, session2)
+
+        layoutCalculator.fixOverlappingSessions(0, sessions)
+        assertThat(sessions[0].duration).isEqualTo(35) // gets cut
+        assertThat(sessions[1].duration).isEqualTo(45) // stays the same
+    }
+
+    @Test
+    fun `fixOverlappingSessions keeps the duration of a session with a consecutive successor`() {
+        val duration1 = 45
+        val duration2 = 45
+        val startTime1 = 10 * 60 // 10:00am
+        val startTime2 = startTime1 + duration1 // 10:45am (no overlap)
+
+        val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
+        val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
+        val sessions = listOf(session1, session2)
+
+        layoutCalculator.fixOverlappingSessions(0, sessions)
+        assertThat(sessions[0].duration).isEqualTo(45) // stays the same
+        assertThat(sessions[1].duration).isEqualTo(45) // stays the same
+    }
+
+    @Test
+    fun `fixOverlappingSessions keeps the duration of a session without a successor`() {
+        val duration1 = 45
+        val duration2 = 45
+        val startTime1 = 10 * 60 // 10:00am
+        val startTime2 = startTime1 + duration1 - 10 // 10:35am (10 minutes overlap)
+
+        val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
+        val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
+        val sessions = listOf(session1, session2)
+
+        layoutCalculator.fixOverlappingSessions(1, sessions)
+        assertThat(sessions[0].duration).isEqualTo(45) // stays the same
+        assertThat(sessions[1].duration).isEqualTo(45) // unmodified because no session follows
+    }
+
+
     private fun assertMargins(sessionParams: LinearLayout.LayoutParams?, top: Int, bottom: Int) {
         assertThat(sessionParams!!).isNotNull()
         assertThat(sessionParams.topMargin).isEqualTo(layoutCalculator.calculateDisplayDistance(top))

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.NoLogging
-import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
@@ -24,7 +23,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = session.toStartsAtMoment(),
+                nowMoment = session.startsAt,
                 currentDayIndex = session.day,
                 columnIndex = -1
         )
@@ -36,7 +35,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = session.toStartsAtMoment(),
+                nowMoment = session.startsAt,
                 currentDayIndex = session.day,
                 columnIndex = COLUMN_INDEX + 1
         )
@@ -48,7 +47,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = session.toStartsAtMoment().minusMinutes(1),
+                nowMoment = session.startsAt.minusMinutes(1),
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(0)
@@ -59,7 +58,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = session.toStartsAtMoment(),
+                nowMoment = session.startsAt,
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(0)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -70,7 +70,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = Moment.ofEpochMilli(session.endsAtDateUtc).minusMinutes(1),
+                nowMoment = session.endsAt.minusMinutes(1),
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(0)
@@ -81,7 +81,7 @@ class ScrollAmountCalculatorTest {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = Moment.ofEpochMilli(session.endsAtDateUtc),
+                nowMoment = session.endsAt,
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(408)
@@ -92,7 +92,7 @@ class ScrollAmountCalculatorTest {
         val session = createLateSession()
         val scrollAmount = calculateScrollAmount(
                 session = session,
-                nowMoment = Moment.ofEpochMilli(session.endsAtDateUtc),
+                nowMoment = session.endsAt,
                 currentDayIndex = session.day
         )
         assertThat(scrollAmount).isEqualTo(408)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -4,7 +4,6 @@ import androidx.annotation.LayoutRes
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
-import nerd.tuxmobil.fahrplan.congress.dataconverters.toStartsAtMoment
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.schedule.Conference
 import org.junit.After
@@ -38,7 +37,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters without -now- view parameter`() {
         val moment = Moment.ofEpochMilli(1582963200000L) // February 29, 2020 08:00:00 AM GMT)
-        val nowMoment = createSession(moment).toStartsAtMoment()
+        val nowMoment = createSession(moment).startsAt
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, 60, dayIndex)
         assertThat(parameters.size).isEqualTo(4)
@@ -51,7 +50,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters including one -now- view parameter`() {
         val moment = Moment.ofEpochMilli(1582963200000L) // February 29, 2020 08:00:00 AM GMT)
-        val nowMoment = createSession(moment).toStartsAtMoment().plusMinutes(30)
+        val nowMoment = createSession(moment).startsAt.plusMinutes(30)
         val dayIndex = 1 // represents today
         val parameters = parametersOf(nowMoment, moment, 60, dayIndex)
         assertThat(parameters.size).isEqualTo(4)
@@ -64,7 +63,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns four view parameters for a session crossing the intra-day limit`() {
         val moment = Moment.ofEpochMilli(1583019000000L) // February 29, 2020 11:30:00 PM GMT
-        val nowMoment = createSession(moment).toStartsAtMoment()
+        val nowMoment = createSession(moment).startsAt
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, 60, dayIndex)
         assertThat(parameters.size).isEqualTo(4)
@@ -77,7 +76,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns 20 view parameters for a session crossing the daylight saving time start`() {
         val moment = Moment.ofEpochMilli(1616889600000L) // March 28, 2021 12:00:00 AM GMT
-        val nowMoment = createSession(moment).toStartsAtMoment()
+        val nowMoment = createSession(moment).startsAt
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, 300, dayIndex)
         assertThat(parameters.size).isEqualTo(20)
@@ -95,7 +94,7 @@ class TimeTextViewParameterTest {
     @Test
     fun `parametersOf returns 20 view parameters for a session crossing the daylight saving time end`() {
         val moment = Moment.ofEpochMilli(1635638400000L) // October 31, 2021 12:00:00 AM GMT
-        val nowMoment = createSession(moment).toStartsAtMoment()
+        val nowMoment = createSession(moment).startsAt
         val dayIndex = 2 // represents tomorrow
         val parameters = parametersOf(nowMoment, moment, 300, dayIndex)
         assertThat(parameters.size).isEqualTo(20)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.sharing
 
 import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.DateParser
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
@@ -29,6 +30,7 @@ class SimpleSessionFormatTest {
         title = "A talk which changes your life"
         roomName = "Yellow pavilion"
         date = "2019-12-27T11:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(date)
         url = "https://example.com/2019/LD3FX9.html"
         slug = "LD3FX9"
     }
@@ -37,6 +39,7 @@ class SimpleSessionFormatTest {
         title = "The most boring workshop ever"
         roomName = "Dark cellar"
         date = "2019-12-28T17:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(date)
         url = "https://example.com/2019/U28VSA.html"
         slug = "U28VSA"
     }
@@ -45,6 +48,7 @@ class SimpleSessionFormatTest {
         title = "Angel shifts planning"
         roomName = "Main hall"
         date = "2019-12-29T09:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(date)
         links = "https://events.ccc.de/congress/2019/wiki/index.php/Session:A/V_Angel_Meeting"
         url = "https://example.com/2019/U28VSA.html"
         slug = "U28VSA"
@@ -54,6 +58,7 @@ class SimpleSessionFormatTest {
         title = "Central european summer time"
         roomName = "Sunshine tent"
         date = "2019-09-01T16:00:00+02:00"
+        dateUTC = DateParser.parseDateTime(date)
         url = "https://example.com/2019/U9SD23.html"
         slug = "U9SD23"
     }

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -96,7 +96,7 @@ class Moment private constructor(private val time: Instant) {
     fun plusMinutes(minutes: Long): Moment = Moment(time.plus(minutes, ChronoUnit.MINUTES))
 
     /**
-     * Returns true if this moment is before given [moment].
+     * Returns true if this moment is before the given [moment].
      */
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -101,6 +101,11 @@ class Moment private constructor(private val time: Instant) {
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
 
     /**
+     * Returns true if this moment is at the same time as the given [moment].
+     */
+    fun isSimultaneousWith(moment: Moment): Boolean = time.toEpochMilli() == moment.toMilliseconds()
+
+    /**
      * Returns true if this moment is after the given [moment].
      */
     fun isAfter(moment: Moment): Boolean = moment.isBefore(this)

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -101,6 +101,11 @@ class Moment private constructor(private val time: Instant) {
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
 
     /**
+     * Returns true if this moment is after the given [moment].
+     */
+    fun isAfter(moment: Moment): Boolean = moment.isBefore(this)
+
+    /**
      * Returns the duration in minutes between this and the given [moment].
      */
     fun minutesUntil(moment: Moment): Long {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -126,6 +126,16 @@ class MomentTest {
     }
 
     @Test
+    fun isAfter() {
+        val momentOne = Moment.now()
+        val momentTwo = Moment.now().plusSeconds(1)
+
+        assertThat(momentOne.isAfter(momentTwo)).isFalse
+        assertThat(momentTwo.isAfter(momentOne)).isTrue
+        assertThat(momentOne.isAfter(momentOne)).isFalse
+    }
+
+    @Test
     fun durationUntil() {
         val momentOne = Moment.now()
         val momentTwo = momentOne.plusMinutes(1)

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -126,6 +126,16 @@ class MomentTest {
     }
 
     @Test
+    fun isSimultaneousWith() {
+        val momentOne = Moment.now()
+        val momentTwo = Moment.now().plusSeconds(1)
+
+        assertThat(momentOne.isSimultaneousWith(momentTwo)).isFalse()
+        assertThat(momentTwo.isSimultaneousWith(momentOne)).isFalse
+        assertThat(momentOne.plusSeconds(1).isSimultaneousWith(momentTwo)).isTrue()
+    }
+
+    @Test
     fun isAfter() {
         val momentOne = Moment.now()
         val momentTwo = Moment.now().plusSeconds(1)


### PR DESCRIPTION
# Description
+ Reduce public interface of `Session` class (`app` module).
+ Facilitate `Moment` type to be exposed by `getStartsAt()` and `getEndsAt()` functions of a `Session` instead of accessing primitive data types exposed by the `Session` class.
+ Remove various former functions - now unused.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 13 (API 33)

# Related
- #448
