### PR TITLE
Consistently use Moment class to process date & time values

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
@@ -8,9 +8,11 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 import org.ligi.tracedroid.TraceDroid
-import java.util.Calendar
-import java.util.GregorianCalendar
-import java.util.TimeZone
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalTime
+import org.threeten.bp.ZoneId
+import org.threeten.bp.ZonedDateTime
+
 
 class MyApp : Application() {
 
@@ -36,12 +38,10 @@ class MyApp : Application() {
 
         @VisibleForTesting
         fun getMilliseconds(timeZoneId: String, year: Int, month: Int, day: Int): Long {
-            val zeroBasedMonth = month - 1
-            val zone = TimeZone.getTimeZone(timeZoneId)
-            return GregorianCalendar(zone).apply {
-                set(year, zeroBasedMonth, day, 0, 0, 0)
-                set(Calendar.MILLISECOND, 0)
-            }.timeInMillis
+            val zoneId = ZoneId.of(timeZoneId)
+            val localDate = LocalDate.of(year, month, day)
+            val zonedDateTime = ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, zoneId)
+            return zonedDateTime.toInstant().toEpochMilli()
         }
 
         val conferenceTimeFrame = ConferenceTimeFrame(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
@@ -5,6 +5,7 @@ import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.toMoment
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 import org.ligi.tracedroid.TraceDroid
@@ -22,14 +23,14 @@ class MyApp : Application() {
 
     companion object {
 
-        private val FIRST_DAY_START = getMilliseconds(
+        private val FIRST_DAY_START = getMoment(
             "Europe/Paris",
             BuildConfig.SCHEDULE_FIRST_DAY_START_YEAR,
             BuildConfig.SCHEDULE_FIRST_DAY_START_MONTH,
             BuildConfig.SCHEDULE_FIRST_DAY_START_DAY
         )
 
-        private val LAST_DAY_END = getMilliseconds(
+        private val LAST_DAY_END = getMoment(
             "Europe/Paris",
             BuildConfig.SCHEDULE_LAST_DAY_END_YEAR,
             BuildConfig.SCHEDULE_LAST_DAY_END_MONTH,
@@ -37,17 +38,14 @@ class MyApp : Application() {
         )
 
         @VisibleForTesting
-        fun getMilliseconds(timeZoneId: String, year: Int, month: Int, day: Int): Long {
+        fun getMoment(timeZoneId: String, year: Int, month: Int, day: Int): Moment {
             val zoneId = ZoneId.of(timeZoneId)
             val localDate = LocalDate.of(year, month, day)
             val zonedDateTime = ZonedDateTime.of(localDate, LocalTime.MIDNIGHT, zoneId)
-            return zonedDateTime.toInstant().toEpochMilli()
+            return zonedDateTime.toMoment()
         }
 
-        val conferenceTimeFrame = ConferenceTimeFrame(
-            Moment.ofEpochMilli(FIRST_DAY_START),
-            Moment.ofEpochMilli(LAST_DAY_END)
-        )
+        val conferenceTimeFrame = ConferenceTimeFrame(FIRST_DAY_START, LAST_DAY_END)
 
         @JvmField
         var taskRunning = TASKS.NONE

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress
 
 import android.app.Application
 import androidx.annotation.CallSuper
+import androidx.annotation.VisibleForTesting
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
@@ -33,7 +34,8 @@ class MyApp : Application() {
             BuildConfig.SCHEDULE_LAST_DAY_END_DAY
         )
 
-        private fun getMilliseconds(timeZoneId: String, year: Int, month: Int, day: Int): Long {
+        @VisibleForTesting
+        fun getMilliseconds(timeZoneId: String, year: Int, month: Int, day: Int): Long {
             val zeroBasedMonth = month - 1
             val zone = TimeZone.getTimeZone(timeZoneId)
             return GregorianCalendar(zone).apply {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/MyApp.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress
 import android.app.Application
 import androidx.annotation.CallSuper
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 import org.ligi.tracedroid.TraceDroid
@@ -41,7 +42,10 @@ class MyApp : Application() {
             }.timeInMillis
         }
 
-        val conferenceTimeFrame = ConferenceTimeFrame(FIRST_DAY_START, LAST_DAY_END)
+        val conferenceTimeFrame = ConferenceTimeFrame(
+            Moment.ofEpochMilli(FIRST_DAY_START),
+            Moment.ofEpochMilli(LAST_DAY_END)
+        )
 
         @JvmField
         var taskRunning = TASKS.NONE

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -17,7 +17,7 @@ class AlarmUpdater @JvmOverloads constructor(
 
     interface OnAlarmUpdateListener {
         fun onCancelUpdateAlarm()
-        fun onScheduleUpdateAlarm(interval: Long, nextFetch: Long)
+        fun onScheduleUpdateAlarm(interval: Long, nextFetch: Moment)
     }
 
     companion object {
@@ -36,18 +36,18 @@ class AlarmUpdater @JvmOverloads constructor(
         if (shouldUseDevelopmentInterval) {
             logging.d(LOG_TAG, "Schedule refresh interval = $developmentRefreshInterval")
             listener.onCancelUpdateAlarm()
-            val nextFetch = moment.toMilliseconds() + developmentRefreshInterval
+            val nextFetch = moment.plusMilliseconds(developmentRefreshInterval)
             listener.onScheduleUpdateAlarm(developmentRefreshInterval, nextFetch)
             return developmentRefreshInterval
         }
 
         var interval: Long
-        var nextFetch: Long
+        var nextFetch: Moment
         when {
             conference.contains(moment) -> {
                 logging.d(LOG_TAG, "START <= moment < END")
                 interval = TWO_HOURS
-                nextFetch = moment.toMilliseconds() + interval
+                nextFetch = moment.plusMilliseconds(interval)
             }
             conference.endsAtOrBefore(moment) -> {
                 logging.d(LOG_TAG, "START < END <= moment")
@@ -57,14 +57,14 @@ class AlarmUpdater @JvmOverloads constructor(
             else -> {
                 logging.d(LOG_TAG, "moment < END")
                 interval = ONE_DAY
-                nextFetch = moment.toMilliseconds() + interval
+                nextFetch = moment.plusMilliseconds(interval)
             }
         }
         val shiftedTime = moment.plusDays(1)
         if (conference.startsAfter(moment) && conference.startsAtOrBefore(shiftedTime)) {
             logging.d(LOG_TAG, "moment < START && START <= shiftedTime")
             interval = TWO_HOURS
-            nextFetch = conference.firstDayStartTime.toMilliseconds()
+            nextFetch = conference.firstDayStartTime
             if (!isInitial) {
                 listener.onCancelUpdateAlarm()
                 listener.onScheduleUpdateAlarm(interval, nextFetch)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -63,7 +63,7 @@ class AlarmUpdater @JvmOverloads constructor(
         if (conference.startsAfter(time) && conference.startsAtOrBefore(shiftedTime)) {
             logging.d(LOG_TAG, "time < START && START <= shiftedTime")
             interval = TWO_HOURS
-            nextFetch = conference.firstDayStartTime
+            nextFetch = conference.firstDayStartTime.toMilliseconds()
             if (!isInitial) {
                 listener.onCancelUpdateAlarm()
                 listener.onScheduleUpdateAlarm(interval, nextFetch)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 
 import android.app.AlarmManager
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 
@@ -43,12 +44,12 @@ class AlarmUpdater @JvmOverloads constructor(
         var interval: Long
         var nextFetch: Long
         when {
-            conference.contains(time) -> {
+            conference.contains(Moment.ofEpochMilli(time)) -> {
                 logging.d(LOG_TAG, "START <= time < END")
                 interval = TWO_HOURS
                 nextFetch = time + interval
             }
-            conference.endsAtOrBefore(time) -> {
+            conference.endsAtOrBefore(Moment.ofEpochMilli(time)) -> {
                 logging.d(LOG_TAG, "START < END <= time")
                 listener.onCancelUpdateAlarm()
                 return 0
@@ -60,7 +61,7 @@ class AlarmUpdater @JvmOverloads constructor(
             }
         }
         val shiftedTime = time + ONE_DAY
-        if (conference.startsAfter(time) && conference.startsAtOrBefore(shiftedTime)) {
+        if (conference.startsAfter(Moment.ofEpochMilli(time)) && conference.startsAtOrBefore(Moment.ofEpochMilli(shiftedTime))) {
             logging.d(LOG_TAG, "time < START && START <= shiftedTime")
             interval = TWO_HOURS
             nextFetch = conference.firstDayStartTime.toMilliseconds()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdater.kt
@@ -48,7 +48,7 @@ class AlarmUpdater @JvmOverloads constructor(
                 interval = TWO_HOURS
                 nextFetch = time + interval
             }
-            conference.endsBefore(time) -> {
+            conference.endsAtOrBefore(time) -> {
                 logging.d(LOG_TAG, "START < END <= time")
                 listener.onCancelUpdateAlarm()
                 return 0

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -18,13 +18,18 @@ class ConferenceTimeFrame(
         get() = firstDayStartTime.isBefore(lastDayEndTime)
 
     operator fun contains(time: Long) =
-        startsAtOrBefore(time) && time < lastDayEndTime.toMilliseconds()
+        startsAtOrBefore(time) && Moment.ofEpochMilli(time).isBefore(lastDayEndTime)
 
-    fun endsAtOrBefore(time: Long) = time >= lastDayEndTime.toMilliseconds()
+    fun endsAtOrBefore(time: Long) = with(Moment.ofEpochMilli(time)) {
+        lastDayEndTime.isSimultaneousWith(this) || lastDayEndTime.isBefore(this)
+    }
 
-    fun startsAfter(time: Long) = time < firstDayStartTime.toMilliseconds()
+    fun startsAfter(time: Long) =
+        firstDayStartTime.isAfter(Moment.ofEpochMilli(time))
 
-    fun startsAtOrBefore(time: Long) = time >= firstDayStartTime.toMilliseconds()
+    fun startsAtOrBefore(time: Long) = with(Moment.ofEpochMilli(time)) {
+        firstDayStartTime.isSimultaneousWith(this) || firstDayStartTime.isBefore(this)
+    }
 
     override fun toString() =
         "firstDayStartTime = $firstDayStartTime, lastDayEndTime = $lastDayEndTime"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -1,10 +1,12 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
-// TODO Use Moment class, merge with Conference class?
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+
+// TODO Merge with Conference class?
 class ConferenceTimeFrame(
 
-        val firstDayStartTime: Long,
-        private val lastDayEndTime: Long
+    val firstDayStartTime: Moment,
+    private val lastDayEndTime: Moment
 
 ) {
 
@@ -13,16 +15,18 @@ class ConferenceTimeFrame(
     }
 
     val isValid: Boolean
-        get() = firstDayStartTime.compareTo(lastDayEndTime) == -1
+        get() = firstDayStartTime.isBefore(lastDayEndTime)
 
-    operator fun contains(time: Long) = startsAtOrBefore(time) && time < lastDayEndTime
+    operator fun contains(time: Long) =
+        startsAtOrBefore(time) && time < lastDayEndTime.toMilliseconds()
 
-    fun endsAtOrBefore(time: Long) = time >= lastDayEndTime
+    fun endsAtOrBefore(time: Long) = time >= lastDayEndTime.toMilliseconds()
 
-    fun startsAfter(time: Long) = time < firstDayStartTime
+    fun startsAfter(time: Long) = time < firstDayStartTime.toMilliseconds()
 
-    fun startsAtOrBefore(time: Long) = time >= firstDayStartTime
+    fun startsAtOrBefore(time: Long) = time >= firstDayStartTime.toMilliseconds()
 
-    override fun toString() = "firstDayStartTime = $firstDayStartTime, lastDayEndTime = $lastDayEndTime"
+    override fun toString() =
+        "firstDayStartTime = $firstDayStartTime, lastDayEndTime = $lastDayEndTime"
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -17,7 +17,7 @@ class ConferenceTimeFrame(
 
     operator fun contains(time: Long) = startsAtOrBefore(time) && time < lastDayEndTime
 
-    fun endsBefore(time: Long) = time >= lastDayEndTime
+    fun endsAtOrBefore(time: Long) = time >= lastDayEndTime
 
     fun startsAfter(time: Long) = time < firstDayStartTime
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -17,19 +17,17 @@ class ConferenceTimeFrame(
     val isValid: Boolean
         get() = firstDayStartTime.isBefore(lastDayEndTime)
 
-    operator fun contains(time: Long) =
-        startsAtOrBefore(time) && Moment.ofEpochMilli(time).isBefore(lastDayEndTime)
+    operator fun contains(moment: Moment) =
+        startsAtOrBefore(moment) && lastDayEndTime.isAfter(moment)
 
-    fun endsAtOrBefore(time: Long) = with(Moment.ofEpochMilli(time)) {
-        lastDayEndTime.isSimultaneousWith(this) || lastDayEndTime.isBefore(this)
-    }
+    fun endsAtOrBefore(moment: Moment) =
+        lastDayEndTime.isSimultaneousWith(moment) || lastDayEndTime.isBefore(moment)
 
-    fun startsAfter(time: Long) =
-        firstDayStartTime.isAfter(Moment.ofEpochMilli(time))
+    fun startsAfter(moment: Moment) =
+        firstDayStartTime.isAfter(moment)
 
-    fun startsAtOrBefore(time: Long) = with(Moment.ofEpochMilli(time)) {
-        firstDayStartTime.isSimultaneousWith(this) || firstDayStartTime.isBefore(this)
-    }
+    fun startsAtOrBefore(moment: Moment) =
+        firstDayStartTime.isSimultaneousWith(moment) || firstDayStartTime.isBefore(moment)
 
     override fun toString() =
         "firstDayStartTime = $firstDayStartTime, lastDayEndTime = $lastDayEndTime"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
@@ -51,11 +51,12 @@ object FahrplanMisc {
                 alarmManager.cancel(pendingIntent)
             }
 
-            override fun onScheduleUpdateAlarm(interval: Long, nextFetch: Long) {
-                logging.d(LOG_TAG, "Scheduling update alarm to interval $interval, next in ~${nextFetch - now.toMilliseconds()}")
+            override fun onScheduleUpdateAlarm(interval: Long, nextFetch: Moment) {
+                val next = nextFetch.minusMilliseconds(now.toMilliseconds()).toMilliseconds()
+                logging.d(LOG_TAG, "Scheduling update alarm to interval $interval, next in ~$next")
                 // Redesign might be needed as of Android 12 (API level 31)
                 // See https://developer.android.com/training/scheduling/alarms
-                alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingIntent)
+                alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, nextFetch.toMilliseconds(), interval, pendingIntent)
             }
 
         }).calculateInterval(now, isInitial)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMisc.kt
@@ -42,7 +42,7 @@ object FahrplanMisc {
         val pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, FLAG_IMMUTABLE)
 
         logging.d(LOG_TAG, "set update alarm")
-        val now = Moment.now().toMilliseconds()
+        val now = Moment.now()
 
         return AlarmUpdater(MyApp.conferenceTimeFrame, object : AlarmUpdater.OnAlarmUpdateListener {
 
@@ -52,7 +52,7 @@ object FahrplanMisc {
             }
 
             override fun onScheduleUpdateAlarm(interval: Long, nextFetch: Long) {
-                logging.d(LOG_TAG, "Scheduling update alarm to interval $interval, next in ~${nextFetch - now}")
+                logging.d(LOG_TAG, "Scheduling update alarm to interval $interval, next in ~${nextFetch - now.toMilliseconds()}")
                 // Redesign might be needed as of Android 12 (API level 31)
                 // See https://developer.android.com/training/scheduling/alarms
                 alarmManager.setInexactRepeating(AlarmManager.RTC_WAKEUP, nextFetch, interval, pendingIntent)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
@@ -1,20 +1,21 @@
 package nerd.tuxmobil.fahrplan.congress
 
 import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import org.junit.Test
 
 class MyAppTest {
 
     @Test
-    fun `getMilliseconds returns milliseconds representing midnight of first day, zone offset +1`() {
-        val milliseconds = MyApp.getMilliseconds("Europe/Paris", 2024, 12, 27)
-        assertThat(milliseconds).isEqualTo(1735254000000)
+    fun `getMilliseconds returns moment representing midnight of first day, zone offset +1`() {
+        val moment = MyApp.getMoment("Europe/Paris", 2024, 12, 27)
+        assertThat(moment).isEqualTo(Moment.ofEpochMilli(1735254000000))
     }
 
     @Test
-    fun `getMilliseconds returns milliseconds representing midnight of last day, zone offset +1`() {
-        val milliseconds = MyApp.getMilliseconds("Europe/Paris", 2024, 12, 31)
-        assertThat(milliseconds).isEqualTo(1735599600000)
+    fun `getMilliseconds returns moment representing midnight of last day, zone offset +1`() {
+        val moment = MyApp.getMoment("Europe/Paris", 2024, 12, 31)
+        assertThat(moment).isEqualTo(Moment.ofEpochMilli(1735599600000))
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
@@ -1,0 +1,20 @@
+package nerd.tuxmobil.fahrplan.congress
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MyAppTest {
+
+    @Test
+    fun `getMilliseconds returns milliseconds representing midnight of first day, zone offset +1`() {
+        val milliseconds = MyApp.getMilliseconds("Europe/Paris", 2024, 12, 27)
+        assertThat(milliseconds).isEqualTo(1735254000000)
+    }
+
+    @Test
+    fun `getMilliseconds returns milliseconds representing midnight of last day, zone offset +1`() {
+        val milliseconds = MyApp.getMilliseconds("Europe/Paris", 2024, 12, 31)
+        assertThat(milliseconds).isEqualTo(1735599600000)
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -26,6 +26,7 @@ class AlarmUpdaterTest {
         val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451516400000L)
 
         const val NEVER_USED: Long = -1
+        val NEVER_USED_MOMENT: Moment = Moment.ofEpochMilli(NEVER_USED)
 
         val conferenceTimeFrame = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
     }
@@ -67,7 +68,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(3000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.toMilliseconds() + 3000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.plusSeconds(3))
     }
 
     @Test
@@ -76,7 +77,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, true)
         assertThat(interval).isEqualTo(3000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.toMilliseconds() + 3000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.plusSeconds(3))
     }
 
     // Start <= Time < End
@@ -87,7 +88,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
-        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
     }
 
     @Test
@@ -96,7 +97,8 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451212200000L + 7200000L)
+        val expectedNextFetch = Moment.ofEpochMilli(1451212200000L).plusMilliseconds(7200000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, expectedNextFetch)
     }
 
     // Time == End
@@ -107,7 +109,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
     }
 
     @Test
@@ -116,7 +118,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
     }
 
     // Time < Start, diff == 1 second
@@ -127,7 +129,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, Moment.ofEpochMilli(1451170800000L))
     }
 
     @Test
@@ -136,7 +138,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, Moment.ofEpochMilli(1451170800000L))
     }
 
     // Time < Start, diff == 1 day
@@ -147,7 +149,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, Moment.ofEpochMilli(1451170800000L))
     }
 
     @Test
@@ -156,7 +158,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, Moment.ofEpochMilli(1451170800000L))
     }
 
     // Time < Start, diff > 1 day
@@ -168,7 +170,7 @@ class AlarmUpdaterTest {
         assertThat(interval).isEqualTo(86400000L)
         // TODO Is this behavior intended?
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
-        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
+        verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
     }
 
     @Test
@@ -177,7 +179,8 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), true)
         assertThat(interval).isEqualTo(86400000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(86400000L, 1451084399000L + 86400000L)
+        val expectedNextFetch = Moment.ofEpochMilli(1451084399000L).plusMilliseconds(86400000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(86400000L, expectedNextFetch)
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.alarms
 
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import nerd.tuxmobil.fahrplan.congress.NoLogging
@@ -26,7 +27,10 @@ class AlarmUpdaterTest {
 
         const val NEVER_USED: Long = -1
 
-        val conferenceTimeFrame = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
+        val conferenceTimeFrame = ConferenceTimeFrame(
+            Moment.ofEpochMilli(FIRST_DAY_START_TIME),
+            Moment.ofEpochMilli(LAST_DAY_END_TIME)
+        )
     }
 
     private val sharedPreferencesRepository = mock<SharedPreferencesRepository>()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -20,17 +20,14 @@ class AlarmUpdaterTest {
     private companion object {
 
         // 2015-12-27T00:00:00+0100, in milliseconds: 1451170800000
-        const val FIRST_DAY_START_TIME = 1451170800000L
+        val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451170800000L)
 
         // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
-        const val LAST_DAY_END_TIME = 1451516400000L
+        val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451516400000L)
 
         const val NEVER_USED: Long = -1
 
-        val conferenceTimeFrame = ConferenceTimeFrame(
-            Moment.ofEpochMilli(FIRST_DAY_START_TIME),
-            Moment.ofEpochMilli(LAST_DAY_END_TIME)
-        )
+        val conferenceTimeFrame = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
     }
 
     private val sharedPreferencesRepository = mock<SharedPreferencesRepository>()
@@ -70,7 +67,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(3000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME + 3000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.toMilliseconds() + 3000L)
     }
 
     @Test
@@ -79,7 +76,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, true)
         assertThat(interval).isEqualTo(3000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME + 3000L)
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(3000L, LAST_DAY_END_TIME.toMilliseconds() + 3000L)
     }
 
     // Start <= Time < End
@@ -87,7 +84,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time of first day`() {
         // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
-        val interval = alarmUpdater.calculateInterval(1451212200000L, false)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
@@ -96,7 +93,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time of first day initial`() {
         // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
-        val interval = alarmUpdater.calculateInterval(1451212200000L, true)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451212200000L + 7200000L)
@@ -107,7 +104,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time of last day end time`() {
         // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
-        val interval = alarmUpdater.calculateInterval(1451516400000L, false)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
@@ -116,7 +113,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time of last day end time initial`() {
         // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
-        val interval = alarmUpdater.calculateInterval(1451516400000L, true)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED)
@@ -127,7 +124,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time one second before first day`() {
         // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
-        val interval = alarmUpdater.calculateInterval(1451170799000L, false)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
@@ -136,7 +133,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time one second before first day initial`() {
         // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
-        val interval = alarmUpdater.calculateInterval(1451170799000L, true)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
@@ -147,7 +144,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time one day before first day`() {
         // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
-        val interval = alarmUpdater.calculateInterval(1451084400000L, false)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
@@ -156,7 +153,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time one day before first day initial`() {
         // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
-        val interval = alarmUpdater.calculateInterval(1451084400000L, true)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(7200000L, 1451170800000L)
@@ -167,7 +164,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time more than one day before first day`() {
         // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
-        val interval = alarmUpdater.calculateInterval(1451084399000L, false)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), false)
         assertThat(interval).isEqualTo(86400000L)
         // TODO Is this behavior intended?
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -177,7 +174,7 @@ class AlarmUpdaterTest {
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
         // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
-        val interval = alarmUpdater.calculateInterval(1451084399000L, true)
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), true)
         assertThat(interval).isEqualTo(86400000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(86400000L, 1451084399000L + 86400000L)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -18,10 +18,10 @@ class AlarmUpdaterTest {
 
     private companion object {
 
-        // 2015-12-27T00:00:00+0100, in seconds: 1451170800000
+        // 2015-12-27T00:00:00+0100, in milliseconds: 1451170800000
         const val FIRST_DAY_START_TIME = 1451170800000L
 
-        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
         const val LAST_DAY_END_TIME = 1451516400000L
 
         const val NEVER_USED: Long = -1
@@ -82,7 +82,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day`() {
-        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(1451212200000L, false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -91,7 +91,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day initial`() {
-        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(1451212200000L, true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -102,7 +102,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time`() {
-        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -111,7 +111,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time initial`() {
-        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(1451516400000L, true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -122,7 +122,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day`() {
-        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -131,7 +131,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day initial`() {
-        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(1451170799000L, true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -142,7 +142,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day`() {
-        // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
+        // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, false)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -151,7 +151,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day initial`() {
-        // 2015-12-26T00:00:00+0100, in seconds: 1451084400000
+        // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(1451084400000L, true)
         assertThat(interval).isEqualTo(7200000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -162,7 +162,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day`() {
-        // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
+        // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(1451084399000L, false)
         assertThat(interval).isEqualTo(86400000L)
         // TODO Is this behavior intended?
@@ -172,7 +172,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
-        // 2015-12-25T23:59:59+0100, in seconds: 1451084399000
+        // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(1451084399000L, true)
         assertThat(interval).isEqualTo(86400000L)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -70,13 +70,13 @@ class ConferenceTimeFrameTest {
     }
 
     @Test
-    fun `endsBefore returns true if time marks a session at the last day end time`() {
-        assertThat(conference.endsBefore(LAST_DAY_END_TIME)).isTrue()
+    fun `endsAtOrBefore returns true if time marks a session at the last day end time`() {
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME)).isTrue()
     }
 
     @Test
-    fun `endsBefore returns false if time marks a session starting one millisecond before the last day end time`() {
-        assertThat(conference.endsBefore(LAST_DAY_END_TIME - 1)).isFalse()
+    fun `endsAtOrBefore returns false if time marks a session starting one millisecond before the last day end time`() {
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME - 1)).isFalse()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -90,6 +90,11 @@ class ConferenceTimeFrameTest {
     }
 
     @Test
+    fun `endsAtOrBefore returns true if time marks a session starting one millisecond after the last day end time`() {
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME + 1)).isTrue()
+    }
+
+    @Test
     fun `startsAfter returns false if time marks a session at the first day`() {
         assertThat(conference.startsAfter(FIRST_DAY_START_TIME)).isFalse()
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -65,58 +65,58 @@ class ConferenceTimeFrameTest {
     @Test
     fun `contains returns true if time marks a session at the first day`() {
         // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
-        assertThat(conference.contains(1451212200000L)).isTrue()
+        assertThat(conference.contains(Moment.ofEpochMilli(1451212200000L))).isTrue()
     }
 
     @Test
     fun `contains returns false if time marks a session starting one second before the first day`() {
         // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
-        assertThat(conference.contains(1451170799000L)).isFalse()
+        assertThat(conference.contains(Moment.ofEpochMilli(1451170799000L))).isFalse()
     }
 
     @Test
     fun `contains returns false if time marks a session at the last day end time`() {
-        assertThat(conference.contains(LAST_DAY_END_TIME)).isFalse()
+        assertThat(conference.contains(Moment.ofEpochMilli(LAST_DAY_END_TIME))).isFalse()
     }
 
     @Test
     fun `endsAtOrBefore returns true if time marks a session at the last day end time`() {
-        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME)).isTrue()
+        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME))).isTrue()
     }
 
     @Test
-    fun `endsAtOrBefore returns false if time marks a session starting one millisecond before the last day end time`() {
-        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME - 1)).isFalse()
+    fun `endsAtOrBefore returns false if time marks a session starting one second before the last day end time`() {
+        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME).minusSeconds(1))).isFalse()
     }
 
     @Test
-    fun `endsAtOrBefore returns true if time marks a session starting one millisecond after the last day end time`() {
-        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME + 1)).isTrue()
+    fun `endsAtOrBefore returns true if time marks a session starting one second after the last day end time`() {
+        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME).plusSeconds(1))).isTrue()
     }
 
     @Test
     fun `startsAfter returns false if time marks a session at the first day`() {
-        assertThat(conference.startsAfter(FIRST_DAY_START_TIME)).isFalse()
+        assertThat(conference.startsAfter(Moment.ofEpochMilli(FIRST_DAY_START_TIME))).isFalse()
     }
 
     @Test
-    fun `startsAfter returns true if time marks a session starting on millisecond before the first day`() {
-        assertThat(conference.startsAfter(FIRST_DAY_START_TIME - 1)).isTrue()
+    fun `startsAfter returns true if time marks a session starting on second before the first day`() {
+        assertThat(conference.startsAfter(Moment.ofEpochMilli(FIRST_DAY_START_TIME).minusSeconds(1))).isTrue()
     }
 
     @Test
     fun `startsAtOrBefore returns true if time marks a session at the first day`() {
-        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME)).isTrue()
+        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME))).isTrue()
     }
 
     @Test
-    fun `startsAtOrBefore returns true if time marks a session starting one millisecond after the first day`() {
-        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME + 1)).isTrue()
+    fun `startsAtOrBefore returns true if time marks a session starting one second after the first day`() {
+        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME).plusSeconds(1))).isTrue()
     }
 
     @Test
-    fun `startsAtOrBefore returns false if time marks a session starting one millisecond before the first day`() {
-        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME - 1)).isFalse()
+    fun `startsAtOrBefore returns false if time marks a session starting one second before the first day`() {
+        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME).minusSeconds(1))).isFalse()
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
@@ -19,7 +20,10 @@ class ConferenceTimeFrameTest {
 
     @Before
     fun setUp() {
-        conference = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
+        conference = ConferenceTimeFrame(
+            Moment.ofEpochMilli(FIRST_DAY_START_TIME),
+            Moment.ofEpochMilli(LAST_DAY_END_TIME)
+        )
     }
 
     @Test
@@ -30,7 +34,10 @@ class ConferenceTimeFrameTest {
     @Test
     fun `isValid throws an exception for last day followed by first day`() {
         try {
-            ConferenceTimeFrame(LAST_DAY_END_TIME, FIRST_DAY_START_TIME)
+            ConferenceTimeFrame(
+                Moment.ofEpochMilli(LAST_DAY_END_TIME),
+                Moment.ofEpochMilli(FIRST_DAY_START_TIME)
+            )
             fail("Expect an IllegalStateException to be thrown.")
         } catch (e: IllegalStateException) {
             assertThat(e.message).startsWith("Invalid conference time frame:")
@@ -40,7 +47,10 @@ class ConferenceTimeFrameTest {
     @Test
     fun `isValid throws an exception for same day twice`() {
         try {
-            ConferenceTimeFrame(FIRST_DAY_START_TIME, FIRST_DAY_START_TIME)
+            ConferenceTimeFrame(
+                Moment.ofEpochMilli(FIRST_DAY_START_TIME),
+                Moment.ofEpochMilli(FIRST_DAY_START_TIME)
+            )
             fail("Expect an IllegalStateException to be thrown.")
         } catch (e: IllegalStateException) {
             assertThat(e.message).startsWith("Invalid conference time frame:")
@@ -49,7 +59,7 @@ class ConferenceTimeFrameTest {
 
     @Test
     fun `firstDayStart returns the first day`() {
-        assertThat(conference.firstDayStartTime).isEqualTo(FIRST_DAY_START_TIME)
+        assertThat(conference.firstDayStartTime).isEqualTo(Moment.ofEpochMilli(FIRST_DAY_START_TIME))
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -9,21 +9,18 @@ import org.junit.Test
 class ConferenceTimeFrameTest {
 
     private companion object {
-        // 2015-12-27T00:00:00+0100, in milliseconds: 1451170800000
-        const val FIRST_DAY_START_TIME = 1451170800000L
+        // 2015-12-27T00:00:00+0100
+        val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451170800000L)
 
-        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
-        const val LAST_DAY_END_TIME = 1451516400000L
+        // 2015-12-31T00:00:00+0100
+        val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451516400000L)
     }
 
     private lateinit var conference: ConferenceTimeFrame
 
     @Before
     fun setUp() {
-        conference = ConferenceTimeFrame(
-            Moment.ofEpochMilli(FIRST_DAY_START_TIME),
-            Moment.ofEpochMilli(LAST_DAY_END_TIME)
-        )
+        conference = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
     }
 
     @Test
@@ -34,10 +31,7 @@ class ConferenceTimeFrameTest {
     @Test
     fun `isValid throws an exception for last day followed by first day`() {
         try {
-            ConferenceTimeFrame(
-                Moment.ofEpochMilli(LAST_DAY_END_TIME),
-                Moment.ofEpochMilli(FIRST_DAY_START_TIME)
-            )
+            ConferenceTimeFrame(LAST_DAY_END_TIME, FIRST_DAY_START_TIME)
             fail("Expect an IllegalStateException to be thrown.")
         } catch (e: IllegalStateException) {
             assertThat(e.message).startsWith("Invalid conference time frame:")
@@ -47,10 +41,7 @@ class ConferenceTimeFrameTest {
     @Test
     fun `isValid throws an exception for same day twice`() {
         try {
-            ConferenceTimeFrame(
-                Moment.ofEpochMilli(FIRST_DAY_START_TIME),
-                Moment.ofEpochMilli(FIRST_DAY_START_TIME)
-            )
+            ConferenceTimeFrame(FIRST_DAY_START_TIME, FIRST_DAY_START_TIME)
             fail("Expect an IllegalStateException to be thrown.")
         } catch (e: IllegalStateException) {
             assertThat(e.message).startsWith("Invalid conference time frame:")
@@ -59,7 +50,7 @@ class ConferenceTimeFrameTest {
 
     @Test
     fun `firstDayStart returns the first day`() {
-        assertThat(conference.firstDayStartTime).isEqualTo(Moment.ofEpochMilli(FIRST_DAY_START_TIME))
+        assertThat(conference.firstDayStartTime).isEqualTo(FIRST_DAY_START_TIME)
     }
 
     @Test
@@ -76,47 +67,47 @@ class ConferenceTimeFrameTest {
 
     @Test
     fun `contains returns false if time marks a session at the last day end time`() {
-        assertThat(conference.contains(Moment.ofEpochMilli(LAST_DAY_END_TIME))).isFalse()
+        assertThat(conference.contains(LAST_DAY_END_TIME)).isFalse()
     }
 
     @Test
     fun `endsAtOrBefore returns true if time marks a session at the last day end time`() {
-        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME))).isTrue()
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME)).isTrue()
     }
 
     @Test
     fun `endsAtOrBefore returns false if time marks a session starting one second before the last day end time`() {
-        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME).minusSeconds(1))).isFalse()
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME.minusSeconds(1))).isFalse()
     }
 
     @Test
     fun `endsAtOrBefore returns true if time marks a session starting one second after the last day end time`() {
-        assertThat(conference.endsAtOrBefore(Moment.ofEpochMilli(LAST_DAY_END_TIME).plusSeconds(1))).isTrue()
+        assertThat(conference.endsAtOrBefore(LAST_DAY_END_TIME.plusSeconds(1))).isTrue()
     }
 
     @Test
     fun `startsAfter returns false if time marks a session at the first day`() {
-        assertThat(conference.startsAfter(Moment.ofEpochMilli(FIRST_DAY_START_TIME))).isFalse()
+        assertThat(conference.startsAfter(FIRST_DAY_START_TIME)).isFalse()
     }
 
     @Test
     fun `startsAfter returns true if time marks a session starting on second before the first day`() {
-        assertThat(conference.startsAfter(Moment.ofEpochMilli(FIRST_DAY_START_TIME).minusSeconds(1))).isTrue()
+        assertThat(conference.startsAfter(FIRST_DAY_START_TIME.minusSeconds(1))).isTrue()
     }
 
     @Test
     fun `startsAtOrBefore returns true if time marks a session at the first day`() {
-        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME))).isTrue()
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME)).isTrue()
     }
 
     @Test
     fun `startsAtOrBefore returns true if time marks a session starting one second after the first day`() {
-        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME).plusSeconds(1))).isTrue()
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME.plusSeconds(1))).isTrue()
     }
 
     @Test
     fun `startsAtOrBefore returns false if time marks a session starting one second before the first day`() {
-        assertThat(conference.startsAtOrBefore(Moment.ofEpochMilli(FIRST_DAY_START_TIME).minusSeconds(1))).isFalse()
+        assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME.minusSeconds(1))).isFalse()
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -8,10 +8,10 @@ import org.junit.Test
 class ConferenceTimeFrameTest {
 
     private companion object {
-        // 2015-12-27T00:00:00+0100, in seconds: 1451170800000
+        // 2015-12-27T00:00:00+0100, in milliseconds: 1451170800000
         const val FIRST_DAY_START_TIME = 1451170800000L
 
-        // 2015-12-31T00:00:00+0100, in seconds: 1451516400000
+        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
         const val LAST_DAY_END_TIME = 1451516400000L
     }
 
@@ -54,13 +54,13 @@ class ConferenceTimeFrameTest {
 
     @Test
     fun `contains returns true if time marks a session at the first day`() {
-        // 2015-12-27T11:30:00+0100, in seconds: 1451212200000
+        // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
         assertThat(conference.contains(1451212200000L)).isTrue()
     }
 
     @Test
     fun `contains returns false if time marks a session starting one second before the first day`() {
-        // 2015-12-26T23:59:59+0100, in seconds: 1451170799000
+        // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
         assertThat(conference.contains(1451170799000L)).isFalse()
     }
 
@@ -75,7 +75,7 @@ class ConferenceTimeFrameTest {
     }
 
     @Test
-    fun `endsBefore returns false if time marks a session starting one second before the last day end time`() {
+    fun `endsBefore returns false if time marks a session starting one millisecond before the last day end time`() {
         assertThat(conference.endsBefore(LAST_DAY_END_TIME - 1)).isFalse()
     }
 
@@ -85,7 +85,7 @@ class ConferenceTimeFrameTest {
     }
 
     @Test
-    fun `startsAfter returns true if time marks a session starting on second before the first day`() {
+    fun `startsAfter returns true if time marks a session starting on millisecond before the first day`() {
         assertThat(conference.startsAfter(FIRST_DAY_START_TIME - 1)).isTrue()
     }
 
@@ -95,12 +95,12 @@ class ConferenceTimeFrameTest {
     }
 
     @Test
-    fun `startsAtOrBefore returns true if time marks a session starting one second after the first day`() {
+    fun `startsAtOrBefore returns true if time marks a session starting one millisecond after the first day`() {
         assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME + 1)).isTrue()
     }
 
     @Test
-    fun `startsAtOrBefore returns false if time marks a session starting one second before the first day`() {
+    fun `startsAtOrBefore returns false if time marks a session starting one millisecond before the first day`() {
         assertThat(conference.startsAtOrBefore(FIRST_DAY_START_TIME - 1)).isFalse()
     }
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -101,6 +101,11 @@ class Moment private constructor(private val time: Instant) {
     fun plusMinutes(minutes: Long): Moment = Moment(time.plus(minutes, ChronoUnit.MINUTES))
 
     /**
+     * Returns a moment with the given [days] added.
+     */
+    fun plusDays(days: Long): Moment = Moment(time.plus(days, ChronoUnit.DAYS))
+
+    /**
      * Returns true if this moment is before the given [moment].
      */
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
@@ -151,6 +156,11 @@ class Moment private constructor(private val time: Instant) {
          * 1 hour = 3,600,000 milliseconds
          */
         const val MILLISECONDS_OF_ONE_HOUR: Long = 60L * MILLISECONDS_OF_ONE_MINUTE
+
+        /**
+         * 1 day = 86,400,000 milliseconds
+         */
+        const val MILLISECONDS_OF_ONE_DAY: Long = 24L * MILLISECONDS_OF_ONE_HOUR
 
         /**
          * 1 day = 1,440 minutes

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -91,6 +91,16 @@ class Moment private constructor(private val time: Instant) {
     fun minusSeconds(seconds: Long): Moment = Moment(time.minusSeconds(seconds))
 
     /**
+     * Returns a moment with the given [milliseconds] subtracted.
+     */
+    fun minusMilliseconds(milliseconds: Long): Moment = Moment(time.minusMillis(milliseconds))
+
+    /**
+     * Returns a moment with the given [milliseconds] added.
+     */
+    fun plusMilliseconds(milliseconds: Long): Moment = Moment(time.plusMillis(milliseconds))
+
+    /**
      * Returns a moment with the given [seconds] added.
      */
     fun plusSeconds(seconds: Long): Moment = Moment(time.plusSeconds(seconds))

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -86,6 +86,11 @@ class Moment private constructor(private val time: Instant) {
     fun minusMinutes(minutes: Long): Moment = Moment(time.minus(minutes, ChronoUnit.MINUTES))
 
     /**
+     * Returns a moment with the given [seconds] subtracted.
+     */
+    fun minusSeconds(seconds: Long): Moment = Moment(time.minusSeconds(seconds))
+
+    /**
      * Returns a moment with the given [seconds] added.
      */
     fun plusSeconds(seconds: Long): Moment = Moment(time.plusSeconds(seconds))

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -204,6 +204,15 @@ class MomentTest {
     }
 
     @Test
+    fun plusMilliseconds() {
+        val momentOne = Moment.ofEpochMilli(0).plusMilliseconds(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(1)
+
+        val momentTwo = Moment.ofEpochMilli(1).plusMilliseconds(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(0)
+    }
+
+    @Test
     fun plusSeconds() {
         val momentOne = Moment.ofEpochMilli(0).plusSeconds(1)
         assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_SECOND.toLong())
@@ -255,6 +264,15 @@ class MomentTest {
 
         val momentTwo = Moment.ofEpochMilli(0).minusSeconds(-1)
         assertThat(momentTwo.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_SECOND.toLong())
+    }
+
+    @Test
+    fun minusMilliseconds() {
+        val momentOne = Moment.ofEpochMilli(1).minusMilliseconds(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(0)
+
+        val momentTwo = Moment.ofEpochMilli(0).minusMilliseconds(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(1)
     }
 
 }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -31,6 +31,52 @@ class MomentTest {
     }
 
     @Test
+    fun `equals returns true for equal moments`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+        val momentTwo = Moment.ofEpochMilli(DEC_30_22_47_2019)
+
+        assertThat(momentOne == momentTwo).isTrue
+    }
+
+    @Test
+    fun `equals returns false for unequal moments`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+        val momentTwo = Moment.ofEpochMilli(DEC_30_22_47_2019).plusSeconds(1)
+
+        assertThat(momentOne == momentTwo).isFalse()
+    }
+
+    @Test
+    fun `equals returns false for null moment`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+
+        assertThat(momentOne.equals(null)).isFalse()
+    }
+
+    @Test
+    fun `hashCode returns same value for equal moments`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+        val momentTwo = Moment.ofEpochMilli(DEC_30_22_47_2019)
+
+        assertThat(momentOne.hashCode()).isEqualTo(momentTwo.hashCode())
+    }
+
+    @Test
+    fun `hashCode returns different values for unequal moments`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+        val momentTwo = Moment.ofEpochMilli(DEC_30_22_47_2019).plusSeconds(1)
+
+        assertThat(momentOne.hashCode()).isNotEqualTo(momentTwo.hashCode())
+    }
+
+    @Test
+    fun `toString returns toString representation of internal instant`() {
+        val moment = Moment.ofEpochMilli(DEC_30_22_47_2019)
+
+        assertThat(moment.toString()).isEqualTo("2019-12-30T22:47:57.615Z")
+    }
+
+    @Test
     fun dateTimeFieldsAreCorrectlyMapped() {
         val moment = Moment.ofEpochMilli(DEC_30_22_47_2019)
 

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -1,5 +1,6 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_DAY
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_HOUR
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
@@ -27,6 +28,7 @@ class MomentTest {
         assertThat(MILLISECONDS_OF_ONE_SECOND).isEqualTo(1_000)
         assertThat(MILLISECONDS_OF_ONE_MINUTE).isEqualTo(60_000)
         assertThat(MILLISECONDS_OF_ONE_HOUR).isEqualTo(3_600_000L)
+        assertThat(MILLISECONDS_OF_ONE_DAY).isEqualTo(86_400_000L)
         assertThat(MINUTES_OF_ONE_DAY).isEqualTo(1_440)
     }
 
@@ -216,6 +218,15 @@ class MomentTest {
         assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_MINUTE.toLong())
 
         val momentTwo = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_MINUTE.toLong()).plusMinutes(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(0)
+    }
+
+    @Test
+    fun plusDays() {
+        val momentOne = Moment.ofEpochMilli(0).plusDays(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_DAY)
+
+        val momentTwo = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_DAY).plusDays(-1)
         assertThat(momentTwo.toMilliseconds()).isEqualTo(0)
     }
 

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -237,4 +237,13 @@ class MomentTest {
         assertThat(momentTwo.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_MINUTE.toLong())
     }
 
+    @Test
+    fun minusSeconds() {
+        val momentOne = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_SECOND.toLong()).minusSeconds(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(0)
+
+        val momentTwo = Moment.ofEpochMilli(0).minusSeconds(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_SECOND.toLong())
+    }
+
 }


### PR DESCRIPTION
# Description
- In order to consistently use the `Moment` class to process date & time values the following parts are refactored step by step:
  - `ConferenceTimeFrame`
  - `AlarmUpdater` & `OnAlarmUpdateListener`
  - `MyApp`
- Existing unit tests are refactored and new ones are added.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)