### PR TITLE
Display session subtitle as title if the latter is empty.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -164,6 +164,10 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
 }
 
 fun Session.sanitize(): Session {
+    if (title.isEmpty() && subtitle.isNotEmpty()) {
+        title = subtitle
+        subtitle = ""
+    }
     if (title == subtitle) {
         subtitle = ""
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -197,6 +197,19 @@ class SessionExtensionsTest {
     }
 
     @Test
+    fun sanitizeWithEmptyTitleAndSubtitle() {
+        val session = Session("").apply {
+            subtitle = "Lorem ipsum"
+            title = ""
+        }.sanitize()
+        val expected = Session("").apply {
+            subtitle = ""
+            title = "Lorem ipsum"
+        }
+        assertThat(session).isEqualTo(expected)
+    }
+
+    @Test
     fun sanitizeWithSameTitleAndSubtitle() {
         val session = Session("").apply {
             subtitle = "Lorem ipsum"
@@ -271,10 +284,12 @@ class SessionExtensionsTest {
         val session = Session("").apply {
             speakers = listOf("Luke Skywalker")
             subtitle = "Luke Skywalker"
+            title = "Some title"
         }.sanitize()
         val expected = Session("").apply {
             speakers = listOf("Luke Skywalker")
             subtitle = ""
+            title = "Some title"
         }
         assertThat(session).isEqualTo(expected)
     }
@@ -284,10 +299,12 @@ class SessionExtensionsTest {
         val session = Session("").apply {
             speakers = listOf("Darth Vader")
             subtitle = "Lorem ipsum"
+            title = "Some title"
         }.sanitize()
         val expected = Session("").apply {
             speakers = listOf("Darth Vader")
             subtitle = "Lorem ipsum"
+            title = "Some title"
         }
         assertThat(session).isEqualTo(expected)
     }


### PR DESCRIPTION
# Description
+ Improves the rendering of Engelsystem shifts where the `title` property is empty while the `name` (`locationName`) property has been set.

# Before
![session-title-before](https://github.com/EventFahrplan/EventFahrplan/assets/144518/6528d5b3-1c9a-4e2d-8643-426c01331aab)

# After
![session-title-after](https://github.com/EventFahrplan/EventFahrplan/assets/144518/ae6c5b31-602b-483f-97ed-36041447f327)

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)