### PR TITLE
Support caching via "Last-Modified" & "If-Modified-Since" HTTP headers.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HttpHeaderExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HttpHeaderExtensions.kt
@@ -1,0 +1,17 @@
+package nerd.tuxmobil.fahrplan.congress.dataconverters
+
+import info.metadude.android.eventfahrplan.database.models.HttpHeader as HttpHeaderDatabaseModel
+import info.metadude.android.eventfahrplan.network.models.HttpHeader as HttpHeaderNetworkModel
+import nerd.tuxmobil.fahrplan.congress.models.HttpHeader as HttpHeaderAppModel
+
+fun HttpHeaderAppModel.toHttpHeaderNetworkModel() = HttpHeaderNetworkModel(
+    eTag = eTag,
+)
+
+fun HttpHeaderDatabaseModel.toHttpHeaderAppModel() = HttpHeaderAppModel(
+    eTag = eTag,
+)
+
+fun HttpHeaderNetworkModel.toHttpHeaderDatabaseModel() = HttpHeaderDatabaseModel(
+    eTag = eTag,
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HttpHeaderExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HttpHeaderExtensions.kt
@@ -6,12 +6,15 @@ import nerd.tuxmobil.fahrplan.congress.models.HttpHeader as HttpHeaderAppModel
 
 fun HttpHeaderAppModel.toHttpHeaderNetworkModel() = HttpHeaderNetworkModel(
     eTag = eTag,
+    lastModified = lastModified,
 )
 
 fun HttpHeaderDatabaseModel.toHttpHeaderAppModel() = HttpHeaderAppModel(
     eTag = eTag,
+    lastModified = lastModified,
 )
 
 fun HttpHeaderNetworkModel.toHttpHeaderDatabaseModel() = HttpHeaderDatabaseModel(
     eTag = eTag,
+    lastModified = lastModified,
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensions.kt
@@ -8,7 +8,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
 
 
 fun MetaAppModel.toMetaNetworkModel() = MetaNetworkModel(
-        eTag = eTag,
+        httpHeader = httpHeader.toHttpHeaderNetworkModel(),
         numDays = numDays,
         subtitle = subtitle,
         timeZoneName = timeZoneId?.id,
@@ -17,7 +17,7 @@ fun MetaAppModel.toMetaNetworkModel() = MetaNetworkModel(
 )
 
 fun MetaDatabaseModel.toMetaAppModel() = MetaAppModel(
-        eTag = eTag,
+        httpHeader = httpHeader.toHttpHeaderAppModel(),
         numDays = numDays,
         subtitle = subtitle,
         timeZoneId = timeZoneName?.let {
@@ -34,7 +34,7 @@ fun MetaDatabaseModel.toMetaAppModel() = MetaAppModel(
 )
 
 fun MetaNetworkModel.toMetaDatabaseModel() = MetaDatabaseModel(
-        eTag = eTag,
+        httpHeader = httpHeader.toHttpHeaderDatabaseModel(),
         numDays = numDays,
         subtitle = subtitle,
         timeZoneName = timeZoneName,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/HttpHeader.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/HttpHeader.kt
@@ -5,4 +5,5 @@ package nerd.tuxmobil.fahrplan.congress.models
  */
 data class HttpHeader(
     val eTag: String = "",
+    val lastModified: String = "",
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/HttpHeader.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/HttpHeader.kt
@@ -1,0 +1,8 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+/**
+ * Application model that wraps HTTP header values for the purpose of easily passing them around.
+ */
+data class HttpHeader(
+    val eTag: String = "",
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Meta.kt
@@ -6,7 +6,7 @@ import org.threeten.bp.ZoneId
 data class Meta(
 
         @Deprecated("To be removed. Access from AppRepository only. Left here only for data transfer.")
-        var eTag: String = "",
+        var httpHeader: HttpHeader = HttpHeader(),
         var numDays: Int = MetasTable.Defaults.NUM_DAYS_DEFAULT,
         var subtitle: String = "",
         var timeZoneId: ZoneId? = null,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult as NetworkFetchScheduleResult
@@ -14,7 +15,7 @@ class FetchScheduleResultExtensionsTest {
         val networkFetchScheduleResult = NetworkFetchScheduleResult(
                 httpStatus = NetworkHttpStatus.HTTP_NOT_MODIFIED,
                 scheduleXml = "<xml></xml>",
-                eTag = "mno456",
+                httpHeader = HttpHeader("mno456"),
                 hostName = "example.com",
                 exceptionMessage = "SSLException"
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
@@ -15,7 +15,10 @@ class FetchScheduleResultExtensionsTest {
         val networkFetchScheduleResult = NetworkFetchScheduleResult(
                 httpStatus = NetworkHttpStatus.HTTP_NOT_MODIFIED,
                 scheduleXml = "<xml></xml>",
-                httpHeader = HttpHeader("mno456"),
+                httpHeader = HttpHeader(
+                    eTag = "mno456",
+                    lastModified = "2023-12-31T23:59:59+01:00",
+                ),
                 hostName = "example.com",
                 exceptionMessage = "SSLException"
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -3,14 +3,17 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.threeten.bp.ZoneId
+import info.metadude.android.eventfahrplan.database.models.HttpHeader as HttpHeaderDatabaseModel
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
+import info.metadude.android.eventfahrplan.network.models.HttpHeader as HttpHeaderNetworkModel
 import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
+import nerd.tuxmobil.fahrplan.congress.models.HttpHeader as HttpHeaderAppModel
 import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
 
 class MetaExtensionsTest {
 
     private val metaAppModel = MetaAppModel(
-            eTag = "abc123",
+            httpHeader = HttpHeaderAppModel("abc123"),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneId = ZoneId.of("Europe/Berlin"),
@@ -19,7 +22,7 @@ class MetaExtensionsTest {
     )
 
     private val metaDatabaseModel = MetaDatabaseModel(
-            eTag = "abc123",
+            httpHeader = HttpHeaderDatabaseModel("abc123"),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneName = "Europe/Berlin",
@@ -28,7 +31,7 @@ class MetaExtensionsTest {
     )
 
     private val metaNetworkModel = MetaNetworkModel(
-            eTag = "abc123",
+            httpHeader = HttpHeaderNetworkModel("abc123"),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneName = "Europe/Berlin",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -13,7 +13,10 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
 class MetaExtensionsTest {
 
     private val metaAppModel = MetaAppModel(
-            httpHeader = HttpHeaderAppModel("abc123"),
+            httpHeader = HttpHeaderAppModel(
+                eTag = "abc123",
+                lastModified = "2019-12-31T23:59:59+01:00",
+            ),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneId = ZoneId.of("Europe/Berlin"),
@@ -22,7 +25,10 @@ class MetaExtensionsTest {
     )
 
     private val metaDatabaseModel = MetaDatabaseModel(
-            httpHeader = HttpHeaderDatabaseModel("abc123"),
+            httpHeader = HttpHeaderDatabaseModel(
+                eTag = "abc123",
+                lastModified = "2019-12-31T23:59:59+01:00",
+            ),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneName = "Europe/Berlin",
@@ -31,7 +37,10 @@ class MetaExtensionsTest {
     )
 
     private val metaNetworkModel = MetaNetworkModel(
-            httpHeader = HttpHeaderNetworkModel("abc123"),
+            httpHeader = HttpHeaderNetworkModel(
+                eTag = "abc123",
+                lastModified = "2019-12-31T23:59:59+01:00",
+            ),
             numDays = 23,
             subtitle = "My subtitle",
             timeZoneName = "Europe/Berlin",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -306,7 +306,7 @@ class AppRepositoryLoadAndParseScheduleTest {
         NetworkFetchScheduleResult(
             httpStatus = httpStatus,
             scheduleXml = "some fahrplan xml",
-            httpHeader = HttpHeader("a1b2bc3"),
+            httpHeader = HttpHeader(eTag = "a1b2bc3", lastModified = "2023-12-31T23:59:59+01:00"),
             hostName = HOST_NAME
         )
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -9,6 +9,7 @@ import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseR
 import info.metadude.android.eventfahrplan.database.repositories.HighlightsDatabaseRepository
 import info.metadude.android.eventfahrplan.database.repositories.MetaDatabaseRepository
 import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
 import info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository
 import kotlinx.coroutines.test.runTest
 import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
@@ -302,7 +303,12 @@ class AppRepositoryLoadAndParseScheduleTest {
         }
 
     private fun createFetchScheduleResult(httpStatus: NetworkHttpStatus) =
-        NetworkFetchScheduleResult(httpStatus, "some fahrplan xml", eTag = "a1b2bc3", HOST_NAME)
+        NetworkFetchScheduleResult(
+            httpStatus = httpStatus,
+            scheduleXml = "some fahrplan xml",
+            httpHeader = HttpHeader("a1b2bc3"),
+            hostName = HOST_NAME
+        )
 
     private fun createFetchFailure(httpStatus: HttpStatus, isUserRequest: Boolean) =
         FetchFailure(
@@ -336,7 +342,7 @@ class AppRepositoryLoadAndParseScheduleTest {
         override fun fetchSchedule(
             okHttpClient: OkHttpClient,
             url: String,
-            eTag: String,
+            httpHeader: HttpHeader,
             onFetchScheduleFinished: OnFetchScheduleFinished
         ) {
             this.onFetchScheduleFinished = onFetchScheduleFinished
@@ -344,7 +350,7 @@ class AppRepositoryLoadAndParseScheduleTest {
 
         override fun parseSchedule(
             scheduleXml: String,
-            eTag: String,
+            httpHeader: HttpHeader,
             onUpdateSessions: (sessions: List<NetworkSession>) -> Unit,
             onUpdateMeta: (meta: NetworkMeta) -> Unit,
             onParsingDone: (result: Boolean, version: String) -> Unit

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
@@ -7,6 +7,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.VERSION
+import info.metadude.android.eventfahrplan.database.models.HttpHeader
 import info.metadude.android.eventfahrplan.database.models.Meta
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -18,7 +19,7 @@ class MetaExtensionsTest {
     @Test
     fun toContentValues() {
         val meta = Meta(
-                eTag = "abc123",
+                httpHeader = HttpHeader(eTag = "abc123"),
                 numDays = 23,
                 subtitle = "My subtitle",
                 timeZoneName = "Europe/Berlin",

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
@@ -3,6 +3,7 @@ package info.metadude.android.eventfahrplan.database.extensions
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SCHEDULE_LAST_MODIFIED
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SUBTITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
@@ -19,7 +20,7 @@ class MetaExtensionsTest {
     @Test
     fun toContentValues() {
         val meta = Meta(
-                httpHeader = HttpHeader(eTag = "abc123"),
+                httpHeader = HttpHeader(eTag = "abc123", lastModified = "2023-12-31T23:59:59+01:00"),
                 numDays = 23,
                 subtitle = "My subtitle",
                 timeZoneName = "Europe/Berlin",
@@ -28,6 +29,7 @@ class MetaExtensionsTest {
         )
         val values = meta.toContentValues()
         assertThat(values.getAsString(ETAG)).isEqualTo("abc123")
+        assertThat(values.getAsString(SCHEDULE_LAST_MODIFIED)).isEqualTo("2023-12-31T23:59:59+01:00")
         assertThat(values.getAsInteger(NUM_DAYS)).isEqualTo(23)
         assertThat(values.getAsString(SUBTITLE)).isEqualTo("My subtitle")
         assertThat(values.getAsString(TIME_ZONE_NAME)).isEqualTo("Europe/Berlin")

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -18,6 +18,7 @@ public interface FahrplanContract {
             /* 5 */ String ETAG = "etag";
             /* 6 */ String NUM_DAYS = "numdays";
             /* 7 */ String TIME_ZONE_NAME = "time_zone_name";
+            /* 8 */ String SCHEDULE_LAST_MODIFIED = "schedule_last_modified";
         }
 
         interface Defaults {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
@@ -3,6 +3,7 @@ package info.metadude.android.eventfahrplan.database.extensions
 import androidx.core.content.contentValuesOf
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SCHEDULE_LAST_MODIFIED
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SUBTITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
@@ -11,6 +12,7 @@ import info.metadude.android.eventfahrplan.database.models.Meta
 
 fun Meta.toContentValues() = contentValuesOf(
         ETAG to httpHeader.eTag,
+        SCHEDULE_LAST_MODIFIED to httpHeader.lastModified,
         NUM_DAYS to numDays,
         SUBTITLE to subtitle,
         TIME_ZONE_NAME to timeZoneName,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensions.kt
@@ -10,7 +10,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 import info.metadude.android.eventfahrplan.database.models.Meta
 
 fun Meta.toContentValues() = contentValuesOf(
-        ETAG to eTag,
+        ETAG to httpHeader.eTag,
         NUM_DAYS to numDays,
         SUBTITLE to subtitle,
         TIME_ZONE_NAME to timeZoneName,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/HttpHeader.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/HttpHeader.kt
@@ -5,5 +5,6 @@ package info.metadude.android.eventfahrplan.database.models
  */
 data class HttpHeader(
     val eTag: String = "",
+    val lastModified: String = "",
 )
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/HttpHeader.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/HttpHeader.kt
@@ -1,0 +1,9 @@
+package info.metadude.android.eventfahrplan.database.models
+
+/**
+ * Database model that wraps HTTP header values for the purpose of easily passing them around.
+ */
+data class HttpHeader(
+    val eTag: String = "",
+)
+

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Meta.kt
@@ -4,7 +4,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 
 data class Meta(
 
-        val eTag: String = "",
+        val httpHeader: HttpHeader = HttpHeader(),
         val numDays: Int = NUM_DAYS_DEFAULT,
         val subtitle: String = "",
         val timeZoneName: String? = null,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealMetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealMetaDatabaseRepository.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteException
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SCHEDULE_LAST_MODIFIED
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SUBTITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
@@ -54,6 +55,7 @@ class RealMetaDatabaseRepository(
                         subtitle = cursor.getString(SUBTITLE),
                         httpHeader = HttpHeader(
                             eTag = cursor.getString(ETAG),
+                            lastModified = cursor.getString(SCHEDULE_LAST_MODIFIED),
                         ),
                 )
             } else {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealMetaDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealMetaDatabaseRepository.kt
@@ -16,6 +16,7 @@ import info.metadude.android.eventfahrplan.database.extensions.getStringOrNull
 import info.metadude.android.eventfahrplan.database.extensions.insert
 import info.metadude.android.eventfahrplan.database.extensions.read
 import info.metadude.android.eventfahrplan.database.extensions.upsert
+import info.metadude.android.eventfahrplan.database.models.HttpHeader
 import info.metadude.android.eventfahrplan.database.models.Meta
 import info.metadude.android.eventfahrplan.database.sqliteopenhelper.MetaDBOpenHelper
 
@@ -51,7 +52,9 @@ class RealMetaDatabaseRepository(
                         timeZoneName = cursor.getStringOrNull(TIME_ZONE_NAME),
                         title = cursor.getString(TITLE),
                         subtitle = cursor.getString(SUBTITLE),
-                        eTag = cursor.getString(ETAG)
+                        httpHeader = HttpHeader(
+                            eTag = cursor.getString(ETAG),
+                        ),
                 )
             } else {
                 Meta()

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.java
@@ -9,10 +9,11 @@ import androidx.annotation.NonNull;
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable;
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns;
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Defaults;
+import info.metadude.android.eventfahrplan.database.extensions.SQLiteDatabaseExtensions;
 
 public class MetaDBOpenHelper extends SQLiteOpenHelper {
 
-    private static final int DATABASE_VERSION = 8;
+    private static final int DATABASE_VERSION = 9;
 
     private static final String DATABASE_NAME = "meta";
 
@@ -23,7 +24,8 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
                     Columns.TITLE + " TEXT, " +
                     Columns.SUBTITLE + " TEXT, " +
                     Columns.ETAG + " TEXT, " +
-                    Columns.TIME_ZONE_NAME + " TEXT);";
+                    Columns.TIME_ZONE_NAME + " TEXT, " +
+                    Columns.SCHEDULE_LAST_MODIFIED + " TEXT DEFAULT '');";
 
     public MetaDBOpenHelper(@NonNull Context context) {
         super(context.getApplicationContext(), DATABASE_NAME, null, DATABASE_VERSION);
@@ -63,6 +65,13 @@ public class MetaDBOpenHelper extends SQLiteOpenHelper {
             // Clear database from rC3 NOWHERE 12/2021 & 36C3 2019.
             db.execSQL("DROP TABLE IF EXISTS " + MetasTable.NAME);
             onCreate(db);
+        }
+        if (oldVersion < 9) {
+            boolean columnExists = SQLiteDatabaseExtensions.columnExists(db, MetasTable.NAME, Columns.SCHEDULE_LAST_MODIFIED);
+            if (!columnExists) {
+                db.execSQL("ALTER TABLE " + MetasTable.NAME + " ADD COLUMN " +
+                        Columns.SCHEDULE_LAST_MODIFIED + " TEXT DEFAULT ''");
+            }
         }
     }
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
@@ -13,6 +13,7 @@ import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
 
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -22,9 +23,9 @@ internal class FetchFahrplan(private val logging: Logging) {
     private lateinit var task: FetchFahrplanTask
     private lateinit var onFetchScheduleResult: (fetchScheduleResult: FetchScheduleResult) -> Unit
 
-    fun fetch(okHttpClient: OkHttpClient, url: String, eTag: String) {
+    fun fetch(okHttpClient: OkHttpClient, url: String, httpHeader: HttpHeader) {
         task = FetchFahrplanTask(okHttpClient, logging, onFetchScheduleResult)
-        task.execute(url, eTag)
+        task.execute(url, httpHeader.eTag)
     }
 
     fun cancel() {
@@ -94,13 +95,13 @@ internal class FetchFahrplanTask(
         if (status == HttpStatus.HTTP_OK) {
             logging.d(LOG_TAG, "Fetch done successfully")
             onFetchScheduleResult(
-                FetchScheduleResult(status, responseStr, eTagStr, host, exceptionMessage)
+                FetchScheduleResult(status, responseStr, HttpHeader(eTagStr), host, exceptionMessage)
             )
         } else {
             logging.d(LOG_TAG, "Fetch failed")
             onFetchScheduleResult(
                 FetchScheduleResult(
-                    status, EMPTY_RESPONSE_STRING, eTagStr, host, exceptionMessage
+                    status, EMPTY_RESPONSE_STRING, HttpHeader(eTagStr), host, exceptionMessage
                 )
             )
         }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
@@ -52,6 +52,8 @@ internal class FetchFahrplanTask(
     private companion object {
         const val EMPTY_RESPONSE_STRING = ""
         const val LOG_TAG = "FetchFahrplan"
+        const val HTTP_HEADER_NAME_ETAG = "ETag"
+        const val HTTP_HEADER_NAME_IF_NONE_MATCH = "If-None-Match"
     }
 
     private var responseStr = EMPTY_RESPONSE_STRING
@@ -107,11 +109,11 @@ internal class FetchFahrplanTask(
 
     private fun fetch(url: String, eTag: String): HttpStatus {
         logging.d(LOG_TAG, url)
-        logging.d(LOG_TAG, "ETag: '$eTag'")
+        logging.d(LOG_TAG, "$HTTP_HEADER_NAME_ETAG: '$eTag'")
         val requestBuilder = Request.Builder().apply {
             url(url)
             if (eTag.isNotEmpty()) {
-                addHeader("If-None-Match", eTag)
+                addHeader(HTTP_HEADER_NAME_IF_NONE_MATCH, eTag)
             }
         }
 
@@ -152,11 +154,11 @@ internal class FetchFahrplanTask(
             }
         }
 
-        eTagStr = response.header("ETag").orEmpty()
+        eTagStr = response.header(HTTP_HEADER_NAME_ETAG).orEmpty()
         if (eTagStr.isEmpty()) {
-            logging.d(LOG_TAG, "ETag is missing.")
+            logging.d(LOG_TAG, "$HTTP_HEADER_NAME_ETAG is missing.")
         } else {
-            logging.d(LOG_TAG, "ETag: '$eTagStr'")
+            logging.d(LOG_TAG, "$HTTP_HEADER_NAME_ETAG: '$eTagStr'")
         }
 
         responseStr = try {

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
@@ -154,7 +154,7 @@ internal class FetchFahrplanTask(
 
         eTagStr = response.header("ETag").orEmpty()
         if (eTagStr.isEmpty()) {
-            logging.d(LOG_TAG, "ETag missing?")
+            logging.d(LOG_TAG, "ETag is missing.")
         } else {
             logging.d(LOG_TAG, "ETag: '$eTagStr'")
         }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchScheduleResult.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchScheduleResult.kt
@@ -1,10 +1,12 @@
 package info.metadude.android.eventfahrplan.network.fetching
 
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
+
 data class FetchScheduleResult(
 
         val httpStatus: HttpStatus,
         val scheduleXml: String = "",
-        val eTag: String = "",
+        val httpHeader: HttpHeader,
         val hostName: String,
         val exceptionMessage: String = ""
 

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/HttpHeader.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/HttpHeader.kt
@@ -8,4 +8,5 @@ import info.metadude.android.eventfahrplan.network.fetching.FetchFahrplan
  */
 data class HttpHeader(
     val eTag: String = "",
+    val lastModified: String = "",
 )

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/HttpHeader.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/HttpHeader.kt
@@ -1,0 +1,11 @@
+package info.metadude.android.eventfahrplan.network.models
+
+import info.metadude.android.eventfahrplan.network.fetching.FetchFahrplan
+
+/**
+ * Network model that wraps HTTP header values for the purpose of easily passing them around.
+ * Values in this class are parsed from HTTP responses in [FetchFahrplan].
+ */
+data class HttpHeader(
+    val eTag: String = "",
+)

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Meta.kt
@@ -2,7 +2,7 @@ package info.metadude.android.eventfahrplan.network.models
 
 data class Meta(
 
-        var eTag: String = "",
+        var httpHeader: HttpHeader = HttpHeader(),
         var numDays: Int = 0,
         var subtitle: String = "",
         var title: String = "",

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/RealScheduleNetworkRepository.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/RealScheduleNetworkRepository.kt
@@ -3,6 +3,7 @@ package info.metadude.android.eventfahrplan.network.repositories
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.network.fetching.FetchFahrplan
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
 import info.metadude.android.eventfahrplan.network.models.Meta
 import info.metadude.android.eventfahrplan.network.models.Session
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser
@@ -19,14 +20,14 @@ class RealScheduleNetworkRepository(
 
     override fun fetchSchedule(okHttpClient: OkHttpClient,
                                url: String,
-                               eTag: String,
+                               httpHeader: HttpHeader,
                                onFetchScheduleFinished: (fetchScheduleResult: FetchScheduleResult) -> Unit) {
         fetcher.setListener(onFetchScheduleFinished::invoke)
-        fetcher.fetch(okHttpClient, url, eTag)
+        fetcher.fetch(okHttpClient, url, httpHeader)
     }
 
     override fun parseSchedule(scheduleXml: String,
-                               eTag: String,
+                               httpHeader: HttpHeader,
                                onUpdateSessions: (sessions: List<Session>) -> Unit,
                                onUpdateMeta: (meta: Meta) -> Unit,
                                onParsingDone: (result: Boolean, version: String) -> Unit) {
@@ -35,7 +36,7 @@ class RealScheduleNetworkRepository(
             override fun onUpdateMeta(meta: Meta) = onUpdateMeta.invoke(meta)
             override fun onParseDone(result: Boolean, version: String) = onParsingDone.invoke(result, version)
         })
-        parser.parse(scheduleXml, eTag)
+        parser.parse(scheduleXml, httpHeader)
     }
 
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/ScheduleNetworkRepository.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/ScheduleNetworkRepository.kt
@@ -1,6 +1,7 @@
 package info.metadude.android.eventfahrplan.network.repositories
 
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult
+import info.metadude.android.eventfahrplan.network.models.HttpHeader
 import info.metadude.android.eventfahrplan.network.models.Meta
 import info.metadude.android.eventfahrplan.network.models.Session
 import okhttp3.OkHttpClient
@@ -9,11 +10,11 @@ interface ScheduleNetworkRepository {
 
     fun fetchSchedule(okHttpClient: OkHttpClient,
                       url: String,
-                      eTag: String,
+                      httpHeader: HttpHeader,
                       onFetchScheduleFinished: (fetchScheduleResult: FetchScheduleResult) -> Unit)
 
     fun parseSchedule(scheduleXml: String,
-                      eTag: String,
+                      httpHeader: HttpHeader,
                       onUpdateSessions: (sessions: List<Session>) -> Unit,
                       onUpdateMeta: (meta: Meta) -> Unit,
                       onParsingDone: (result: Boolean, version: String) -> Unit)

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging;
+import info.metadude.android.eventfahrplan.network.models.HttpHeader;
 import info.metadude.android.eventfahrplan.network.models.Meta;
 import info.metadude.android.eventfahrplan.network.models.Session;
 import info.metadude.android.eventfahrplan.network.serialization.exceptions.MissingXmlAttributeException;
@@ -47,9 +48,9 @@ public class FahrplanParser {
         task = null;
     }
 
-    public void parse(String fahrplan, String eTag) {
+    public void parse(String fahrplan, HttpHeader httpHeader) {
         task = new ParserTask(logging, listener);
-        task.execute(fahrplan, eTag);
+        task.execute(fahrplan, httpHeader.getETag());
     }
 
     public void cancel() {
@@ -147,7 +148,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                     case XmlPullParser.START_DOCUMENT:
                         sessions = new ArrayList<>();
                         meta = new Meta();
-                        meta.setETag(eTag);
+                        meta.setHttpHeader(new HttpHeader(eTag));
                         break;
                     case XmlPullParser.END_TAG:
                         name = parser.getName();

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -147,6 +147,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                     case XmlPullParser.START_DOCUMENT:
                         sessions = new ArrayList<>();
                         meta = new Meta();
+                        meta.setETag(eTag);
                         break;
                     case XmlPullParser.END_TAG:
                         name = parser.getName();
@@ -365,7 +366,6 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                 return false;
             }
             meta.setNumDays(numdays);
-            meta.setETag(eTag);
             return true;
         } catch (Exception e) {
             e.printStackTrace();

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -50,7 +50,7 @@ public class FahrplanParser {
 
     public void parse(String fahrplan, HttpHeader httpHeader) {
         task = new ParserTask(logging, listener);
-        task.execute(fahrplan, httpHeader.getETag());
+        task.execute(fahrplan, httpHeader.getETag(), httpHeader.getLastModified());
     }
 
     public void cancel() {
@@ -98,7 +98,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
 
     @Override
     protected Boolean doInBackground(String... args) {
-        boolean parsingSuccessful = parseFahrplan(args[0], args[1]);
+        boolean parsingSuccessful = parseFahrplan(args[0], args[1], args[2]);
         if (parsingSuccessful) {
             DateFieldValidation dateFieldValidation = new DateFieldValidation(logging);
             dateFieldValidation.validate(sessions);
@@ -126,7 +126,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
         }
     }
 
-    private Boolean parseFahrplan(String fahrplan, String eTag) {
+    private Boolean parseFahrplan(String fahrplan, String eTag, String lastModified) {
         XmlPullParser parser = Xml.newPullParser();
         try {
             parser.setInput(new StringReader(fahrplan));
@@ -148,7 +148,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                     case XmlPullParser.START_DOCUMENT:
                         sessions = new ArrayList<>();
                         meta = new Meta();
-                        meta.setHttpHeader(new HttpHeader(eTag));
+                        meta.setHttpHeader(new HttpHeader(eTag, lastModified));
                         break;
                     case XmlPullParser.END_TAG:
                         name = parser.getName();


### PR DESCRIPTION
# Description
+ The `Last-Modified`/ `If-Modified-Since` caching mechanism is used if an `ETag` header is missing in the server response.
+ Add `schedule_last_modified` column to `meta` table. Increase `meta` database version.

# Docs
+ https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching
+ https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since

# Related
+ https://github.com/FOSDEM/website/issues/235
+ https://git.cccv.de/hub/hub/-/issues/564

# Scenarios tested
- Fresh install
- Update install from `ccc37c3 1.62.0`, `fosdem 1.57.0`

# Successfully tested on
with `ccc37c3`, `fosdem` flavors, `debug` builds
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)