### PR TITLE
Refactor ConferenceTimeFrame to use closed range internally.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -14,31 +14,36 @@ import nerd.tuxmobil.fahrplan.congress.schedule.Conference
 // TODO Merge with Conference class?
 class ConferenceTimeFrame(
 
-    val firstDayStartTime: Moment,
-    private val lastDayEndTime: Moment
+    firstDayStartTime: Moment,
+    lastDayEndTime: Moment
 
 ) {
+
+    private val timeFrame = firstDayStartTime..lastDayEndTime
 
     init {
         check(isValid) { "Invalid conference time frame: $this" }
     }
 
+    val firstDayStartTime: Moment
+        get() = timeFrame.start
+
     val isValid: Boolean
-        get() = firstDayStartTime.isBefore(lastDayEndTime)
+        get() = timeFrame.start.isBefore(timeFrame.endInclusive)
 
     operator fun contains(moment: Moment) =
-        startsAtOrBefore(moment) && lastDayEndTime.isAfter(moment)
+        startsAtOrBefore(moment) && timeFrame.endInclusive.isAfter(moment)
 
     fun endsAtOrBefore(moment: Moment) =
-        lastDayEndTime.isSimultaneousWith(moment) || lastDayEndTime.isBefore(moment)
+        timeFrame.endInclusive.isSimultaneousWith(moment) || timeFrame.endInclusive.isBefore(moment)
 
     fun startsAfter(moment: Moment) =
-        firstDayStartTime.isAfter(moment)
+        timeFrame.start.isAfter(moment)
 
     fun startsAtOrBefore(moment: Moment) =
-        firstDayStartTime.isSimultaneousWith(moment) || firstDayStartTime.isBefore(moment)
+        timeFrame.start.isSimultaneousWith(moment) || timeFrame.start.isBefore(moment)
 
     override fun toString() =
-        "firstDayStartTime = $firstDayStartTime, lastDayEndTime = $lastDayEndTime"
+        timeFrame.toString()
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrame.kt
@@ -1,7 +1,16 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmUpdater
+import nerd.tuxmobil.fahrplan.congress.schedule.Conference
 
+/**
+ * Represents the time frame of a conference which is taken into account by the [AlarmUpdater]
+ * to calculate if and when alarms should fire.
+ *
+ * This class should not be used for other purposes.
+ * It is not a replacement for the [Conference] class.
+ */
 // TODO Merge with Conference class?
 class ConferenceTimeFrame(
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -18,7 +18,7 @@ import org.threeten.bp.temporal.ChronoUnit
  *
  * > Moment.now().toZonedDateTime(ZoneOffset.of("GMT+1"))
  */
-class Moment private constructor(private val time: Instant) {
+class Moment private constructor(private val time: Instant): Comparable<Moment> {
 
     val year: Int
         get() = time.atZone(ZoneOffset.UTC).year
@@ -135,6 +135,10 @@ class Moment private constructor(private val time: Instant) {
      */
     fun minutesUntil(moment: Moment): Long {
         return Duration.between(time, moment.time).toMinutes()
+    }
+
+    override fun compareTo(other: Moment): Int {
+        return time.compareTo(other.time)
     }
 
     override fun equals(other: Any?): Boolean {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -72,6 +72,16 @@ class MomentTest {
     }
 
     @Test
+    fun `compareTo returns the correct integer value when comparing moments`() {
+        val momentOne = Moment.ofEpochMilli(DEC_30_22_47_2019)
+        val momentTwo = Moment.ofEpochMilli(DEC_30_22_47_2019).plusSeconds(1)
+
+        assertThat(momentOne.compareTo(momentTwo)).isEqualTo(-1)
+        assertThat(momentOne.compareTo(momentTwo.minusSeconds(1))).isEqualTo(0)
+        assertThat(momentTwo.compareTo(momentOne)).isEqualTo(1)
+    }
+
+    @Test
     fun `toString returns toString representation of internal instant`() {
         val moment = Moment.ofEpochMilli(DEC_30_22_47_2019)
 


### PR DESCRIPTION
# Description
- Some clean up:
  - Refactor `ConferenceTimeFrame` to use closed range internally.
  - Document purpose of `ConferenceTimeFrame` class.
  - Let `Moment` class be comparable.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/602