### PR TITLE
Fix NavigationMenuEntriesGenerator creating wrong number of menu entries.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 import info.metadude.android.eventfahrplan.commons.temporal.DayRange
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
 
@@ -16,6 +17,19 @@ fun List<Session>.toDayIndices(): Set<Int> {
         dayIndices.add(it.day)
     }
     return dayIndices
+}
+
+/**
+ * Splits the given sessions into [VirtualDay]s. The [Session.date] field is used to separate them.
+ * This field is unique for a virtual day, even for sessions after midnight.
+ */
+fun List<Session>.toVirtualDays(): List<VirtualDay> {
+    var index = 0
+    return groupBy { it.date }
+        .map { (_, sessions) ->
+            val sorted = sessions.sortedBy { it.dateUTC }
+            VirtualDay(++index, sorted)
+        }
 }
 
 fun List<Session>.toDateInfos() = map(Session::toDateInfo)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDay.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDay.kt
@@ -1,0 +1,37 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.schedule.Conference
+import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
+
+/**
+ * Represents a "conference day" that is not bound to a specific date. Sessions can take place on
+ * different days but still be grouped together in a virtual day. It does not have typical boundaries
+ * like a "natural day" (00:00 to 23:59) has.
+ *
+ * Similar: [Conference], [ConferenceTimeFrame].
+ */
+data class VirtualDay(
+    val index: Int,
+    val sessions: List<Session>,
+) {
+    init {
+        require(index > 0) { "Index must be greater than zero." }
+        require(sessions.isNotEmpty()) { "Sessions must not be empty." }
+    }
+
+    val timeFrame: ClosedRange<Moment>
+        get() {
+            val startsAtSorted = sessions.sortedBy { it.startsAt.toMilliseconds() }
+            val endsAtSorted = sessions.sortedBy { it.endsAt.toMilliseconds() }
+
+            val earliestMoment = startsAtSorted.first().startsAt
+            val latestMoment = endsAtSorted.last().endsAt
+
+            return earliestMoment..latestMoment
+        }
+
+    override fun toString(): String {
+        return "VirtualDay(index=$index, timeFrame=$timeFrame, sessions=${sessions.size})"
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -186,7 +186,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     private fun observeViewModel() {
         viewModel.fahrplanParameter
             .observe(this) { (scheduleData, useDeviceTimeZone, numDays, dayIndex, menuEntries) ->
-                menuEntries?.let { buildNavigationMenu(it, numDays) }
+                buildNavigationMenu(menuEntries, numDays)
                 viewModel.fillTimes(Moment.now(), getNormalizedBoxHeight())
                 viewDay(scheduleData, useDeviceTimeZone, numDays, dayIndex)
             }
@@ -429,7 +429,12 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         onSessionClickListener?.onSessionClick(session.sessionId)
     }
 
-    private fun buildNavigationMenu(dayMenuEntries: List<String?>, numDays: Int) {
+    /**
+     * Builds the navigation menu for switching between days.
+     * The [dayMenuEntries] can be passed both as an empty list or a list with entries.
+     * The empty list is important for [updateNavigationMenuSelection] to work correctly.
+     */
+    private fun buildNavigationMenu(dayMenuEntries: List<String>, numDays: Int) {
         val actionBar = (requireActivity() as AppCompatActivity).supportActionBar
         actionBar!!.navigationMode = NAVIGATION_MODE_LIST
         val arrayAdapter = ArrayAdapter(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
@@ -2,8 +2,9 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import nerd.tuxmobil.fahrplan.congress.models.DateInfo
-import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toVirtualDays
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
 
 internal class NavigationMenuEntriesGenerator @JvmOverloads constructor(
 
@@ -27,44 +28,49 @@ internal class NavigationMenuEntriesGenerator @JvmOverloads constructor(
     /**
      * Returns a [String] array of day menu entries.
      *
-     * If the [currentDate] matches a date in [dateInfos] then the corresponding day will be suffixed
-     * with the given [todayString]. Example: ["Day 1", "Day 2 - Today", "Day 3"]
+     * If the [currentDate] is within the time frame of a generated day then the corresponding
+     * day will be suffixed with the given [todayString]. Example: ["Day 1", "Day 2 - Today", "Day 3"]
      * An [IllegalArgumentException] is thrown the parameter restrictions are not met.
      *
-     * @param numDays Number of days. Must be 1 or more.
-     * @param dateInfos A [list of DateInfo objects][DateInfos]. The [dayIndex][DateInfo.dayIndex]
-     * of the first object must be 1 as defined in the schedule XML. The list cannot be null nor empty.
+     * @param numDays Expected number of days as outlined in the schedule. Sessions or days
+     * might still be missing. Must be 0 or more.
+     * @param sessions A list of session of all days. The list cannot be null.
      * @param currentDate A moment instance representing the day of interest.
      */
     fun getDayMenuEntries(
         numDays: Int,
-        dateInfos: DateInfos?,
-        currentDate: Moment = Moment.now().startOfDay()
+        sessions: List<Session>,
+        currentDate: Moment = Moment.now()
     ): List<String> {
-        if (numDays < 1) {
-            throw IllegalArgumentException("Invalid number of days: $numDays")
+        if (numDays < 0) {
+            throw IllegalArgumentException("Number of days is $numDays but must be 0 or more.")
         }
-        if (dateInfos.isNullOrEmpty()) {
-            throw IllegalArgumentException("Invalid date info list: $dateInfos")
+        val virtualDays = sessions.toVirtualDays()
+        virtualDays.forEach { logging.d(LOG_TAG, "$it") }
+        if (numDays < virtualDays.size) {
+            throw IllegalArgumentException("Expected maximum $numDays day(s) but days list contains ${virtualDays.size} items.")
         }
-        if (numDays < dateInfos.size) {
-            throw IllegalArgumentException("Too small number of days: $numDays, date info list contains ${dateInfos.size} items")
-        }
-        logging.d(LOG_TAG, "Today is " + currentDate.toUtcDateTime().toLocalDate())
-        val entries = mutableListOf<String>()
-        for (dayIndex in 0 until numDays) {
-            var entry = "$dayString ${dayIndex + 1}"
-            for (dateInfo in dateInfos) {
-                if (dateInfo.dayIndex == dayIndex + 1) {
-                    if (currentDate == dateInfo.date) {
-                        entry += " - $todayString"
-                    }
-                    break
-                }
-            }
-            entries.add(dayIndex, entry)
-        }
-        return entries.toList()
+        logging.d(LOG_TAG, "Today is $currentDate")
+        val menuEntries = virtualDays.toMenuEntries(
+            dayString = dayString,
+            todayString = todayString,
+            currentDate = currentDate
+        )
+        return menuEntries
     }
 
+}
+
+private fun List<VirtualDay>.toMenuEntries(
+    dayString: String,
+    todayString: String,
+    currentDate: Moment
+): List<String> {
+    return map { day ->
+        var entry = "$dayString ${day.index}"
+        if (currentDate in day.timeFrame) {
+            entry += " - $todayString"
+        }
+        entry
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
@@ -14,6 +14,6 @@ data class FahrplanParameter(
     val useDeviceTimeZone: Boolean,
     val numDays: Int,
     val dayIndex: Int,
-    val dayMenuEntries: List<String>?
+    val dayMenuEntries: List<String>
 
 )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -219,6 +219,7 @@ class AlarmsViewModelTest {
     ) = mock<AppRepository> {
         on { alarms } doReturn flowOf(alarmsList)
         on { sessions } doReturn sessionsFlow
+        on { sessionsWithoutShifts } doReturn emptyFlow()
         on { readAlarms(any()) } doReturn alarmsList
         on { readUseDeviceTimeZoneEnabled() } doReturn true
         on { deleteAlarmForSessionId(any()) } doReturn 0

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -1,0 +1,46 @@
+package nerd.tuxmobil.fahrplan.congress.dataconverters
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
+import org.junit.Test
+
+/**
+ * Covers [SessionsExtensions.toVirtualDays][toVirtualDays].
+ */
+class SessionsExtensionsToVirtualDaysTest {
+
+    @Test
+    fun `toVirtualDays returns empty list of days`() {
+        val virtualDays = emptyList<Session>().toVirtualDays()
+        assertThat(virtualDays).isEmpty()
+    }
+
+    @Test
+    fun `toVirtualDays returns list of days with sessions broken into virtual days`() {
+        val sessions = listOf(
+            createSession("2023-12-27", 1703671200000, 60), // 2023-12-27T10:00:00Z
+            createSession("2023-12-27", 1703728800000, 45), // 2023-12-28T02:00:00Z
+            createSession("2023-12-28", 1703757600000, 60), // 2023-12-28T10:00:00Z
+            createSession("2023-12-29", 1703844000000, 60), // 2023-12-29T10:00:00Z
+            createSession("2023-12-30", 1703930400000, 60), // 2023-12-30T10:00:00Z
+        )
+        val virtualDays = sessions.toVirtualDays()
+        val expectedVirtualDays = listOf(
+            VirtualDay(1, listOf(sessions[0], sessions[1])),
+            VirtualDay(2, listOf(sessions[2])),
+            VirtualDay(3, listOf(sessions[3])),
+            VirtualDay(4, listOf(sessions[4])),
+        )
+        assertThat(virtualDays.size).isEqualTo(4)
+        assertThat(virtualDays).isEqualTo(expectedVirtualDays)
+    }
+
+    private fun createSession(dateText: String, startsAt: Long, duration: Int) =
+        Session("").apply {
+            this.date = dateText
+            this.dateUTC = startsAt
+            this.duration = duration
+        }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -1,0 +1,71 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import org.junit.Test
+
+class VirtualDayTest {
+
+    @Test
+    fun `init throws exception if index less then 1`() {
+        try {
+            VirtualDay(
+                index = 0,
+                sessions = emptyList()
+            )
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("Index must be greater than zero.")
+        }
+    }
+
+    @Test
+    fun `init throws exception if sessions are empty`() {
+        try {
+            VirtualDay(
+                index = 1,
+                sessions = emptyList()
+            )
+        } catch (e: IllegalArgumentException) {
+            assertThat(e.message).isEqualTo("Sessions must not be empty.")
+        }
+    }
+
+    @Test
+    fun `timeFrame returns range spanning two natural days`() {
+        val virtualDay = VirtualDay(
+            index = 1,
+            sessions = listOf(
+                createSession("2023-12-27", 1703671200000, 60), // 2023-12-27T10:00:00Z
+                createSession("2023-12-27", 1703692800000, 30), // 2023-12-27T16:00:00Z
+                createSession("2023-12-27", 1703728800000, 45), // 2023-12-28T02:00:00Z
+            )
+        )
+        assertThat(virtualDay.index).isEqualTo(1)
+        assertThat(virtualDay.sessions.size).isEqualTo(3)
+        val expectedStartsAt = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
+        val expectedEndsAt = Moment.ofEpochMilli(1703731500000) // 2023-12-28T02:54:00Z
+        assertThat(virtualDay.timeFrame).isEqualTo(expectedStartsAt..expectedEndsAt)
+    }
+
+    @Test
+    fun `toString returns index, timeFrame and sessions size`() {
+        val virtualDay = VirtualDay(
+            index = 4,
+            sessions = listOf(
+                createSession("2023-12-30", 1703926800000, 90), // 2023-12-30T09:00:00Z
+                createSession("2023-12-30", 1703959200000, 30), // 2023-12-30T18:00:00Z
+            )
+        )
+        assertThat("$virtualDay").isEqualTo(
+            "VirtualDay(index=4, timeFrame=2023-12-30T09:00:00Z..2023-12-30T18:30:00Z, sessions=2)"
+        )
+    }
+
+    private fun createSession(dateText: String, startsAt: Long, duration: Int) =
+        Session("").apply {
+            this.date = dateText
+            this.dateUTC = startsAt
+            this.duration = duration
+        }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -2,13 +2,21 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.NoLogging
-import nerd.tuxmobil.fahrplan.congress.models.DateInfo
-import nerd.tuxmobil.fahrplan.congress.models.DateInfos
+import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
 
 class NavigationMenuEntriesGeneratorTest {
+
+    private companion object {
+        const val DAY_1_AT_8_AM = 1542528000000 // 2018-11-18T08:00:00Z
+        const val DAY_2_AT_230_AM = 1542594600000 // 2018-11-19T02:30:00Z
+        const val DAY_2_AT_8_AM = 1542614400000 // 2018-11-19T08:00:00Z
+        const val DAY_2_AT_810_AM = 1542615000000 // 2018-11-19T08:10:00Z
+        const val DAY_2_AT_830_AM = 1542616200000 // 2018-11-19T08:30:00Z
+        const val DAY_3_AT_8_AM = 1542700800000 // 2018-11-20T08:00:00Z
+    }
 
     private val generator = NavigationMenuEntriesGenerator(
         dayString = "Day",
@@ -18,11 +26,16 @@ class NavigationMenuEntriesGeneratorTest {
 
     @Test
     fun `getDayMenuEntries returns three day entries with today mark`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2018-11-18")))
-        dateInfoList.add(DateInfo(2, Moment.parseDate("2018-11-19")))
-        dateInfoList.add(DateInfo(3, Moment.parseDate("2018-11-20")))
-        val entries = getDayMenuEntries(3, dateInfoList, "2018-11-19")
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = 60),
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 120),
+            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = 180),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 3,
+            sessions,
+            DAY_2_AT_830_AM,
+        )
         assertThat(entries).isNotNull
         assertThat(entries.size).isEqualTo(3)
         assertThat(entries[0]).isEqualTo("Day 1")
@@ -31,89 +44,141 @@ class NavigationMenuEntriesGeneratorTest {
     }
 
     @Test
-    fun `getDayMenuEntries returns five day entries with today mark`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2022-11-18")))
-        dateInfoList.add(DateInfo(2, Moment.parseDate("2022-11-19")))
-        dateInfoList.add(DateInfo(3, Moment.parseDate("2022-11-20")))
-        val entries = getDayMenuEntries(5, dateInfoList, "2022-11-19")
+    fun `getDayMenuEntries returns three day entries although one session happens after midnight`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = 60),
+            createSession(dateText = "2018-11-18", startsAt = DAY_2_AT_230_AM, duration = 60),
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 10),
+            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = 180),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 3,
+            sessions,
+            DAY_2_AT_830_AM,
+        )
         assertThat(entries).isNotNull
-        assertThat(entries.size).isEqualTo(5)
+        assertThat(entries.size).isEqualTo(3)
+        assertThat(entries[0]).isEqualTo("Day 1")
+        assertThat(entries[1]).isEqualTo("Day 2")
+        assertThat(entries[2]).isEqualTo("Day 3")
+    }
+
+    @Test
+    fun `getDayMenuEntries returns three day entries with today mark expecting sessions for day four`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = 60),
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 120),
+            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = 180),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 4,
+            sessions,
+            DAY_2_AT_830_AM,
+        )
+        assertThat(entries).isNotNull
+        assertThat(entries.size).isEqualTo(3)
         assertThat(entries[0]).isEqualTo("Day 1")
         assertThat(entries[1]).isEqualTo("Day 2 - Today")
         assertThat(entries[2]).isEqualTo("Day 3")
-        assertThat(entries[3]).isEqualTo("Day 4")
-        assertThat(entries[4]).isEqualTo("Day 5")
     }
 
     @Test
-    fun `getDayMenuEntries fails when date info list is empty`() {
-        try {
-            getDayMenuEntries(1, DateInfos(), "2018-11-19")
-            fail("Expect an IllegalArgumentException to be thrown.")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Invalid date info list: []")
-        }
-    }
-
-    @Test
-    fun `getDayMenuEntries fails when date info list is null`() {
-        try {
-            getDayMenuEntries(1, null, "2018-11-19")
-            fail("Expect an IllegalArgumentException to be thrown.")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Invalid date info list: null")
-        }
-    }
-
-    @Test
-    fun `getDayMenuEntries returns a single day entry`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2018-11-18")))
-        val entries = getDayMenuEntries(1, dateInfoList, "2018-11-19")
+    fun `getDayMenuEntries returns a single day entry without today mark`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 10),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            sessions,
+            DAY_2_AT_830_AM,
+        )
         assertThat(entries).isNotNull
         assertThat(entries.size).isEqualTo(1)
-        assertThat(entries[0]).isEqualTo("Day 1")
+        assertThat(entries.first()).isEqualTo("Day 1")
     }
 
     @Test
-    fun `getDayMenuEntries fails when date info list lacks current date`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2018-11-18")))
+    fun `getDayMenuEntries returns a single day entry with today mark matching the session end`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 10),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            sessions,
+            DAY_2_AT_810_AM,
+        )
+        assertThat(entries).isNotNull
+        assertThat(entries.size).isEqualTo(1)
+        assertThat(entries.first()).isEqualTo("Day 1 - Today")
+    }
+
+    @Test
+    fun `getDayMenuEntries returns empty day entries when sessions is empty`() {
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            emptyList(),
+            DAY_2_AT_830_AM,
+        )
+        assertThat(entries).isNotNull
+        assertThat(entries.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `getDayMenuEntries returns empty day entries when number of days is 0`() {
+        val entries = getDayMenuEntries(
+            numDays = 0,
+            emptyList(),
+            DAY_2_AT_830_AM,
+        )
+        assertThat(entries).isNotNull
+        assertThat(entries.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `getDayMenuEntries throws exception when numDays is less than 0`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = 60),
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 120),
+            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = 180),
+        )
         try {
-            getDayMenuEntries(0, dateInfoList, "2018-11-19")
+            getDayMenuEntries(
+                numDays = -1,
+                sessions,
+                DAY_2_AT_830_AM,
+            )
             fail("Expect an IllegalArgumentException to be thrown.")
         } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Invalid number of days: 0")
+            assertThat(e.message).isEqualTo("Number of days is -1 but must be 0 or more.")
         }
     }
 
     @Test
-    fun `getDayMenuEntries fails when number of days is negative`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2018-11-18")))
+    fun `getDayMenuEntries throws exception when number of days is less than date list items size`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = 60),
+            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = 120),
+        )
         try {
-            getDayMenuEntries(-1, dateInfoList, "2018-11-19")
+            getDayMenuEntries(
+                numDays = 1,
+                sessions,
+                DAY_2_AT_830_AM,
+            )
             fail("Expect an IllegalArgumentException to be thrown.")
         } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Invalid number of days: -1")
+            assertThat(e.message).isEqualTo("Expected maximum 1 day(s) but days list contains 2 items.")
         }
     }
 
-    @Test
-    fun `getDayMenuEntries fails when number of days is less than date list items size`() {
-        val dateInfoList = DateInfos()
-        dateInfoList.add(DateInfo(1, Moment.parseDate("2022-11-18")))
-        dateInfoList.add(DateInfo(2, Moment.parseDate("2022-11-19")))
-        try {
-            getDayMenuEntries(1, dateInfoList, "2022-11-18")
-            fail("Expect an IllegalArgumentException to be thrown.")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).isEqualTo("Too small number of days: 1, date info list contains 2 items")
+    private fun createSession(dateText: String, startsAt: Long, duration: Int) =
+        Session("").apply {
+            this.date = dateText
+            this.dateUTC = startsAt
+            this.duration = duration
         }
-    }
 
-    private fun getDayMenuEntries(numDays: Int, dateInfos: DateInfos?, currentDate: String) =
-        generator.getDayMenuEntries(numDays, dateInfos, Moment.parseDate(currentDate))
+    private fun getDayMenuEntries(numDays: Int, sessions: List<Session>, currentDate: Long) =
+        generator.getDayMenuEntries(numDays, sessions, Moment.ofEpochMilli(currentDate))
 
 }


### PR DESCRIPTION
# Description
+ Fixes a crash in 37C3 Fahrplan App (1.62.0) when Engelsystem-JSON-URL is entered.
+ Menu entries were generated based on parsing the `Session#date` field which holds a `yyyy-mm-dd` string without time and timezone offset. This caused sessions to be incorrectly associated with a "virtual conference day". This resulted in an incorrect number of menu entries / days.
+ The `Session#date` field is still useful to associate a session with a "virtual conference day".

# Scenarios tested
- Tested with Engelsystem shifts reported in #590 which caused the crash.
- [37C3 / schedule.xml without days](https://gist.github.com/johnjohndoe/1f7ae8ad3d82721b3f49ae5cf6fc0364)
- [37C3 / schedule.xml without rooms and events](https://gist.github.com/johnjohndoe/7abb3f5ff4e5cc11b45222be3a04e93f)

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)

---

Fixes #590
Fixes #529