### PR TITLE
Add link to translation platform to "info" screen.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,6 +33,7 @@ android {
 
         // Build configuration / feature flags
         buildConfigField "String", "F_DROID_URL", '""'
+        buildConfigField "String", "TRANSLATION_PLATFORM_URL", '"https://crowdin.com/project/eventfahrplan"'
         buildConfigField "String", "SOURCE_CODE_URL", '"https://github.com/EventFahrplan/EventFahrplan"'
         buildConfigField "String", "ISSUES_URL", '"https://github.com/EventFahrplan/EventFahrplan/issues"'
         buildConfigField "String", "DATA_PRIVACY_STATEMENT_DE_URL", '"https://github.com/EventFahrplan/EventFahrplan/blob/master/DATA-PRIVACY-DE.md"'

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutDialog.kt
@@ -123,6 +123,12 @@ class AboutDialog : DialogFragment() {
         val websiteUrl = BuildConfig.EVENT_WEBSITE_URL
         conferenceUrl.setLinkText(websiteUrl, null, movementMethod, linkTextColor)
 
+        // Translation platform link
+        val translationPlatform = view.requireViewByIdCompat<TextView>(R.id.about_translation_platform_view)
+        val translationPlatformUrl = BuildConfig.TRANSLATION_PLATFORM_URL
+        val translationPlatformTitle = getString(R.string.about_translation_platform)
+        translationPlatform.setLinkText(translationPlatformUrl, translationPlatformTitle, movementMethod, linkTextColor)
+
         // Source code link
         val sourceCode = view.requireViewByIdCompat<TextView>(R.id.about_source_code_view)
         val sourceCodeUrl = BuildConfig.SOURCE_CODE_URL

--- a/app/src/main/res/layout/about_dialog.xml
+++ b/app/src/main/res/layout/about_dialog.xml
@@ -76,6 +76,11 @@
         <include layout="@layout/horizontal_line" />
 
         <TextView
+            android:id="@+id/about_translation_platform_view"
+            style="@style/AboutSection.Text"
+            tools:text="@string/about_translation_platform" />
+
+        <TextView
             android:id="@+id/about_source_code_view"
             style="@style/AboutSection.Text"
             tools:text="@string/about_source_code" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="about_google_play_listing">Google Play listing</string>
     <string name="about_issues_or_feature_requests">Issues or feature requests</string>
     <string name="about_source_code">Source code</string>
+    <string name="about_translation_platform">Translation platform</string>
     <string name="copyright_notes" translatable="false">
         Copyright 2013-2024 johnjohndoe.
         \nCopyright 2011-2015 Daniel Dorau.


### PR DESCRIPTION
# Description
- Add a link to [Crowdin translation platform](https://crowdin.com/project/eventfahrplan) to the "info" screen to be easy accessible for users.

# Before and after
![link0](https://github.com/EventFahrplan/EventFahrplan/assets/144518/9d5cea15-accc-4c80-a73e-3f1032877afe) ![link1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/258233f4-6656-457a-96a8-67633decbbab)


# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 14 (API 34)