### PR TITLE
Protect BroadcastReceiver in ConnectivityObserver from access by external apps.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityObserver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/ConnectivityObserver.kt
@@ -9,6 +9,8 @@ import android.content.IntentFilter
 import android.net.ConnectivityManager
 import android.net.Network
 import android.os.Build
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 import androidx.core.content.getSystemService
 
 /**
@@ -79,7 +81,12 @@ class ConnectivityObserver @JvmOverloads constructor(
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             // Decouple from component lifecycle, use application context.
             // See: https://developer.android.com/reference/android/content/Context.html#getApplicationContext()
-            context.applicationContext.registerReceiver(broadCastReceiver, intentFilter)
+            ContextCompat.registerReceiver(
+                context.applicationContext,
+                broadCastReceiver,
+                intentFilter,
+                RECEIVER_NOT_EXPORTED
+            )
         } else {
             connectivityManager.registerDefaultNetworkCallback(networkCallback)
         }


### PR DESCRIPTION
# Description
+ Affects Android 13 (API 33) or newer.
+ https://developer.android.com/about/versions/13/features#runtime-receivers
+ https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
+ https://developer.android.com/develop/background-work/background-tasks/broadcast

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6, Android 14 (API 34)