### PR TITLE
Support scheduling exact alarms for sessions.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 
     <application
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -5,7 +5,10 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.S
 import androidx.annotation.VisibleForTesting
+import androidx.core.app.AlarmManagerCompat
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
@@ -31,7 +34,8 @@ class AlarmServices @VisibleForTesting constructor(
         private val alarmTimeValues: List<String>,
         private val logging: Logging,
         private val pendingIntentDelegate: PendingIntentDelegate = PendingIntentProvider,
-        private val formattingDelegate: FormattingDelegate = DateFormatterDelegate
+        private val formattingDelegate: FormattingDelegate = DateFormatterDelegate,
+        private val runsAtLeastOnAndroidSnowCone: Boolean = SDK_INT >= S,
 
 ) {
 
@@ -144,6 +148,17 @@ class AlarmServices @VisibleForTesting constructor(
     }
 
     /**
+     * Returns `true` if the app is allowed to schedule exact alarms. Otherwise `false`.
+     * Automatically allowed before Android 12, SnowCone (API level 31) but might be withdrawn
+     * by the user via the system settings.
+     *
+     * See: [AlarmManager.canScheduleExactAlarms].
+     */
+    val canScheduleExactAlarms: Boolean
+        @SuppressLint("NewApi")
+        get() = if (runsAtLeastOnAndroidSnowCone) alarmManager.canScheduleExactAlarms() else true
+
+    /**
      * Schedules the given [alarm] via the [AlarmManager].
      * Existing alarms for the associated session are discarded if configured via [discardExisting].
      */
@@ -161,15 +176,12 @@ class AlarmServices @VisibleForTesting constructor(
         if (discardExisting) {
             alarmManager.cancel(pendingIntent)
         }
-        // Alarms scheduled here are treated as inexact as of targeting Android 4.4 (API level 19).
-        // See https://developer.android.com/training/scheduling/alarms
-        // and https://developer.android.com/reference/android/os/Build.VERSION_CODES#KITKAT
-        // SCHEDULE_EXACT_ALARM permission is needed when switching to exact alarms as of targeting Android 12 (API level 31).
-        // See https://developer.android.com/about/versions/12/behavior-changes-12#exact-alarm-permission
-        // USE_EXACT_ALARM permission is needed when switching to exact alarms as of targeting Android 13 (API level 33).
-        // See https://developer.android.com/about/versions/13/features#use-exact-alarm-permission
-        // and https://support.google.com/googleplay/android-developer/answer/12253906#exact_alarm_preview
-        alarmManager.set(AlarmManager.RTC_WAKEUP, alarm.startTime, pendingIntent)
+        AlarmManagerCompat.setExactAndAllowWhileIdle(
+            alarmManager,
+            AlarmManager.RTC_WAKEUP,
+            alarm.startTime,
+            pendingIntent
+        )
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
@@ -1,0 +1,59 @@
+package nerd.tuxmobil.fahrplan.congress.alarms
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+
+/**
+ * Wraps all concerns related to adding and deleting sessions alarms
+ * and the related permission checks. This handling is centralized here
+ * to avoid code duplication in the individual view models.
+ */
+internal class SessionAlarmViewModelDelegate(
+    private val viewModelScope: CoroutineScope,
+    private val notificationHelper: NotificationHelper,
+    private val alarmServices: AlarmServices,
+    private val runsAtLeastOnAndroidTiramisu: Boolean,
+) {
+
+    private val mutableShowAlarmTimePicker = Channel<Unit>()
+    val showAlarmTimePicker = mutableShowAlarmTimePicker
+        .receiveAsFlow()
+
+    private val mutableRequestPostNotificationsPermission = Channel<Unit>()
+    val requestPostNotificationsPermission = mutableRequestPostNotificationsPermission
+        .receiveAsFlow()
+
+    private val mutableNotificationsDisabled = Channel<Unit>()
+    val notificationsDisabled = mutableNotificationsDisabled
+        .receiveAsFlow()
+
+    fun addAlarmWithChecks() {
+        if (notificationHelper.notificationsEnabled) {
+            mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
+        } else {
+            // Check runtime version here because requesting the POST_NOTIFICATION permission
+            // before Android 13 (Tiramisu) has no effect nor error message.
+            when (runsAtLeastOnAndroidTiramisu) {
+                true -> mutableRequestPostNotificationsPermission.sendOneTimeEvent(Unit)
+                false -> mutableNotificationsDisabled.sendOneTimeEvent(Unit)
+            }
+        }
+    }
+
+    fun addAlarm(session: Session, alarmTimesIndex: Int) =
+        alarmServices.addSessionAlarm(session, alarmTimesIndex)
+
+    fun deleteAlarm(session: Session) = alarmServices.deleteSessionAlarm(session)
+
+    private fun <E> SendChannel<E>.sendOneTimeEvent(event: E) {
+        viewModelScope.launch {
+            send(event)
+        }
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
@@ -32,9 +32,19 @@ internal class SessionAlarmViewModelDelegate(
     val notificationsDisabled = mutableNotificationsDisabled
         .receiveAsFlow()
 
+    private val mutableRequestScheduleExactAlarmsPermission = Channel<Unit>()
+    val requestScheduleExactAlarmsPermission = mutableRequestScheduleExactAlarmsPermission
+        .receiveAsFlow()
+
+    fun canAddAlarms() = alarmServices.canScheduleExactAlarms
+
     fun addAlarmWithChecks() {
         if (notificationHelper.notificationsEnabled) {
-            mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
+            if (alarmServices.canScheduleExactAlarms) {
+                mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
+            } else {
+                mutableRequestScheduleExactAlarmsPermission.sendOneTimeEvent(Unit)
+            }
         } else {
             // Check runtime version here because requesting the POST_NOTIFICATION permission
             // before Android 13 (Tiramisu) has no effect nor error message.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -82,7 +82,7 @@ class SessionDetailsFragment : Fragment() {
         }
 
     }
-    private lateinit var permissionRequestLauncher: ActivityResultLauncher<String>
+    private lateinit var postNotificationsPermissionRequestLauncher: ActivityResultLauncher<String>
     private lateinit var appRepository: AppRepository
     private lateinit var alarmServices: AlarmServices
     private lateinit var notificationHelper: NotificationHelper
@@ -132,7 +132,7 @@ class SessionDetailsFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        permissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
+        postNotificationsPermissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
             if (isGranted) {
                 viewModel.setAlarm()
             } else {
@@ -212,7 +212,7 @@ class SessionDetailsFragment : Fragment() {
             }
         }
         viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
-            permissionRequestLauncher.launch(POST_NOTIFICATIONS)
+            postNotificationsPermissionRequestLauncher.launch(POST_NOTIFICATIONS)
         }
         viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
             showNotificationsDisabledError()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -3,10 +3,12 @@ package nerd.tuxmobil.fahrplan.congress.details
 import android.Manifest.permission.POST_NOTIFICATIONS
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
+import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -17,11 +19,13 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.annotation.MainThread
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -83,6 +87,7 @@ class SessionDetailsFragment : Fragment() {
 
     }
     private lateinit var postNotificationsPermissionRequestLauncher: ActivityResultLauncher<String>
+    private lateinit var scheduleExactAlarmsPermissionRequestLauncher: ActivityResultLauncher<Intent>
     private lateinit var appRepository: AppRepository
     private lateinit var alarmServices: AlarmServices
     private lateinit var notificationHelper: NotificationHelper
@@ -139,6 +144,24 @@ class SessionDetailsFragment : Fragment() {
                 showMissingPostNotificationsPermissionError()
             }
         }
+
+        scheduleExactAlarmsPermissionRequestLauncher =
+            registerForActivityResult(StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    // User granted the permission earlier.
+                    viewModel.addAlarmWithChecks()
+                } else {
+                    // User granted the permission for the first time.
+                    // Screen is resumed with RESULT_CANCELED, no indication
+                    // of whether the permission was granted or not.
+                    // Hence the following ugly view model bypass.
+                    if (viewModel.canAddAlarms()) {
+                        viewModel.addAlarmWithChecks()
+                    } else {
+                        showMissingScheduleExactAlarmsPermissionError()
+                    }
+                }
+            }
 
         setHasOptionsMenu(true)
     }
@@ -209,6 +232,11 @@ class SessionDetailsFragment : Fragment() {
         }
         viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
             showNotificationsDisabledError()
+        }
+        viewModel.requestScheduleExactAlarmsPermission.observe(viewLifecycleOwner) {
+            val intent = Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData("package:${BuildConfig.APPLICATION_ID}".toUri())
+            scheduleExactAlarmsPermissionRequestLauncher.launch(intent)
         }
     }
 
@@ -369,6 +397,10 @@ class SessionDetailsFragment : Fragment() {
 
     private fun showNotificationsDisabledError() {
         Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_are_disabled, Toast.LENGTH_LONG).show()
+    }
+
+    private fun showMissingScheduleExactAlarmsPermissionError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_schedule_exact_alarm_permission_missing, Toast.LENGTH_LONG).show()
     }
 
     private fun updateOptionsMenu() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -108,7 +108,7 @@ class SessionDetailsFragment : Fragment() {
         R.id.menu_item_add_to_calendar to { addToCalendar() },
         R.id.menu_item_flag_as_favorite to { favorSession() },
         R.id.menu_item_unflag_as_favorite to { unfavorSession() },
-        R.id.menu_item_set_alarm to { setAlarm() },
+        R.id.menu_item_set_alarm to { addAlarmWithChecks() },
         R.id.menu_item_delete_alarm to { deleteAlarm() },
         R.id.menu_item_close_session_details to { closeDetails() },
         R.id.menu_item_navigate to { navigateToRoom() },
@@ -134,7 +134,7 @@ class SessionDetailsFragment : Fragment() {
 
         postNotificationsPermissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
             if (isGranted) {
-                viewModel.setAlarm()
+                viewModel.addAlarmWithChecks()
             } else {
                 showMissingPostNotificationsPermissionError()
             }
@@ -192,7 +192,7 @@ class SessionDetailsFragment : Fragment() {
         viewModel.addToCalendar.observe(viewLifecycleOwner) { session ->
             CalendarSharing(requireContext()).addToCalendar(session)
         }
-        viewModel.setAlarm.observe(viewLifecycleOwner) {
+        viewModel.showAlarmTimePicker.observe(viewLifecycleOwner) {
             AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_KEY) { requestKey, result ->
                 if (requestKey == SESSION_DETAILS_FRAGMENT_REQUEST_KEY &&
                     result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -193,14 +193,7 @@ class SessionDetailsFragment : Fragment() {
             CalendarSharing(requireContext()).addToCalendar(session)
         }
         viewModel.showAlarmTimePicker.observe(viewLifecycleOwner) {
-            AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_KEY) { requestKey, result ->
-                if (requestKey == SESSION_DETAILS_FRAGMENT_REQUEST_KEY &&
-                    result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
-                ) {
-                    val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
-                    viewModel.addAlarm(alarmTimesIndex)
-                }
-            }
+            showAlarmTimePicker()
         }
         viewModel.navigateToRoom.observe(viewLifecycleOwner) { uri ->
             startActivity(Intent(Intent.ACTION_VIEW, uri))
@@ -357,6 +350,17 @@ class SessionDetailsFragment : Fragment() {
         this.setLinkTextColor(ContextCompat.getColor(context, R.color.text_link_on_light))
         this.movementMethod = LinkMovementMethodCompat.getInstance()
         this.isVisible = true
+    }
+
+    private fun showAlarmTimePicker() {
+        AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_KEY) { requestKey, result ->
+            if (requestKey == SESSION_DETAILS_FRAGMENT_REQUEST_KEY &&
+                result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+            ) {
+                val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                viewModel.addAlarm(alarmTimesIndex)
+            }
+        }
     }
 
     private fun showMissingPostNotificationsPermissionError() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -119,6 +119,9 @@ internal class SessionDetailsViewModel(
     val notificationsDisabled = sessionAlarmViewModelDelegate
         .notificationsDisabled
 
+    val requestScheduleExactAlarmsPermission = sessionAlarmViewModelDelegate
+        .requestScheduleExactAlarmsPermission
+
     val showAlarmTimePicker = sessionAlarmViewModelDelegate
         .showAlarmTimePicker
 
@@ -215,6 +218,10 @@ internal class SessionDetailsViewModel(
             }
             repository.updateHighlight(unfavoredSession)
         }
+    }
+
+    fun canAddAlarms(): Boolean {
+        return sessionAlarmViewModelDelegate.canAddAlarms()
     }
 
     fun addAlarmWithChecks() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.alarms.SessionAlarmViewModelDelegate
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toRoom
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.navigation.IndoorNavigation
@@ -34,8 +35,8 @@ internal class SessionDetailsViewModel(
 
     private val repository: AppRepository,
     private val executionContext: ExecutionContext,
-    private val alarmServices: AlarmServices,
-    private val notificationHelper: NotificationHelper,
+    alarmServices: AlarmServices,
+    notificationHelper: NotificationHelper,
     private val sessionFormatter: SessionFormatter,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
@@ -46,7 +47,7 @@ internal class SessionDetailsViewModel(
     private val formattingDelegate: FormattingDelegate = DateFormattingDelegate(),
     private val defaultEngelsystemRoomName: String,
     private val customEngelsystemRoomName: String,
-    private val runsAtLeastOnAndroidTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    runsAtLeastOnAndroidTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 
 ) : ViewModel() {
 
@@ -74,6 +75,14 @@ internal class SessionDetailsViewModel(
 
     }
 
+    private var sessionAlarmViewModelDelegate: SessionAlarmViewModelDelegate =
+        SessionAlarmViewModelDelegate(
+            viewModelScope,
+            notificationHelper,
+            alarmServices,
+            runsAtLeastOnAndroidTiramisu,
+        )
+
     val abstractFont = Font.Roboto.Bold
     val descriptionFont = Font.Roboto.Regular
     val linksFont = Font.Roboto.Regular
@@ -99,17 +108,19 @@ internal class SessionDetailsViewModel(
     val shareJson = mutableShareJson.receiveAsFlow()
     private val mutableAddToCalendar = Channel<Session>()
     val addToCalendar = mutableAddToCalendar.receiveAsFlow()
-    private val mutableShowAlarmTimePicker = Channel<Unit>()
-    val showAlarmTimePicker = mutableShowAlarmTimePicker.receiveAsFlow()
     private val mutableNavigateToRoom = Channel<Uri>()
     val navigateToRoom = mutableNavigateToRoom.receiveAsFlow()
     private val mutableCloseDetails = Channel<Unit>()
     val closeDetails = mutableCloseDetails.receiveAsFlow()
-    private val mutableRequestPostNotificationsPermission = Channel<Unit>()
-    val requestPostNotificationsPermission =
-        mutableRequestPostNotificationsPermission.receiveAsFlow()
-    private val mutableNotificationsDisabled = Channel<Unit>()
-    val notificationsDisabled = mutableNotificationsDisabled.receiveAsFlow()
+
+    val requestPostNotificationsPermission = sessionAlarmViewModelDelegate
+        .requestPostNotificationsPermission
+
+    val notificationsDisabled = sessionAlarmViewModelDelegate
+        .notificationsDisabled
+
+    val showAlarmTimePicker = sessionAlarmViewModelDelegate
+        .showAlarmTimePicker
 
     private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
         roomName = if (roomName == defaultEngelsystemRoomName) customEngelsystemRoomName else roomName
@@ -207,27 +218,18 @@ internal class SessionDetailsViewModel(
     }
 
     fun addAlarmWithChecks() {
-        if (notificationHelper.notificationsEnabled) {
-            mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
-        } else {
-            // Check runtime version here because requesting the POST_NOTIFICATION permission
-            // before Android 13 (Tiramisu) has no effect nor error message.
-            when (runsAtLeastOnAndroidTiramisu) {
-                true -> mutableRequestPostNotificationsPermission.sendOneTimeEvent(Unit)
-                false -> mutableNotificationsDisabled.sendOneTimeEvent(Unit)
-            }
-        }
+        sessionAlarmViewModelDelegate.addAlarmWithChecks()
     }
 
     fun addAlarm(alarmTimesIndex: Int) {
         loadSelectedSession { session ->
-            alarmServices.addSessionAlarm(session, alarmTimesIndex)
+            sessionAlarmViewModelDelegate.addAlarm(session, alarmTimesIndex)
         }
     }
 
     fun deleteAlarm() {
         loadSelectedSession { session ->
-            alarmServices.deleteSessionAlarm(session)
+            sessionAlarmViewModelDelegate.deleteAlarm(session)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -99,8 +99,8 @@ internal class SessionDetailsViewModel(
     val shareJson = mutableShareJson.receiveAsFlow()
     private val mutableAddToCalendar = Channel<Session>()
     val addToCalendar = mutableAddToCalendar.receiveAsFlow()
-    private val mutableSetAlarm = Channel<Unit>()
-    val setAlarm = mutableSetAlarm.receiveAsFlow()
+    private val mutableShowAlarmTimePicker = Channel<Unit>()
+    val showAlarmTimePicker = mutableShowAlarmTimePicker.receiveAsFlow()
     private val mutableNavigateToRoom = Channel<Uri>()
     val navigateToRoom = mutableNavigateToRoom.receiveAsFlow()
     private val mutableCloseDetails = Channel<Unit>()
@@ -206,9 +206,9 @@ internal class SessionDetailsViewModel(
         }
     }
 
-    fun setAlarm() {
+    fun addAlarmWithChecks() {
         if (notificationHelper.notificationsEnabled) {
-            mutableSetAlarm.sendOneTimeEvent(Unit)
+            mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
         } else {
             // Check runtime version here because requesting the POST_NOTIFICATION permission
             // before Android 13 (Tiramisu) has no effect nor error message.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -2,10 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import android.Manifest.permission.POST_NOTIFICATIONS
 import android.annotation.SuppressLint
+import android.app.Activity.RESULT_OK
 import android.content.Context
+import android.content.Intent
 import android.graphics.Typeface
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
 import android.text.TextUtils.TruncateAt
 import android.view.ContextMenu
 import android.view.ContextMenu.ContextMenuInfo
@@ -26,10 +29,12 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.ActionBar.NAVIGATION_MODE_LIST
 import androidx.appcompat.app.ActionBar.OnNavigationListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.view.updatePadding
 import androidx.core.widget.NestedScrollView
 import androidx.core.widget.NestedScrollView.OnScrollChangeListener
@@ -95,6 +100,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     }
 
     private lateinit var postNotificationsPermissionRequestLauncher: ActivityResultLauncher<String>
+    private lateinit var scheduleExactAlarmsPermissionRequestLauncher: ActivityResultLauncher<Intent>
     private lateinit var inflater: LayoutInflater
     private lateinit var sessionViewDrawer: SessionViewDrawer
     private lateinit var errorMessageFactory: ErrorMessage.Factory
@@ -147,6 +153,24 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 showMissingPostNotificationsPermissionError()
             }
         }
+
+        scheduleExactAlarmsPermissionRequestLauncher =
+            registerForActivityResult(StartActivityForResult()) { result ->
+                // User granted the permission earlier.
+                if (result.resultCode == RESULT_OK) {
+                    viewModel.addAlarmWithChecks()
+                } else {
+                    // User granted the permission for the first time.
+                    // Screen is resumed with RESULT_CANCELED, no indication
+                    // of whether the permission was granted or not.
+                    // Hence the following ugly view model bypass.
+                    if (viewModel.canAddAlarms()) {
+                        viewModel.addAlarmWithChecks()
+                    } else {
+                        showMissingScheduleExactAlarmsPermissionError()
+                    }
+                }
+            }
 
         setHasOptionsMenu(true)
         val context = requireContext()
@@ -218,6 +242,11 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         }
         viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
             showNotificationsDisabledError()
+        }
+        viewModel.requestScheduleExactAlarmsPermission.observe(viewLifecycleOwner) {
+            val intent = Intent(ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                .setData("package:${BuildConfig.APPLICATION_ID}".toUri())
+            scheduleExactAlarmsPermissionRequestLauncher.launch(intent)
         }
         viewModel.showAlarmTimePicker.observe(viewLifecycleOwner) {
             showAlarmTimePicker()
@@ -555,6 +584,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     private fun showNotificationsDisabledError() {
         Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_are_disabled, Toast.LENGTH_LONG).show()
+    }
+
+    private fun showMissingScheduleExactAlarmsPermissionError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_schedule_exact_alarm_permission_missing, Toast.LENGTH_LONG).show()
     }
 
     private inner class OnDaySelectedListener(private val numDays: Int) : OnNavigationListener {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -94,7 +94,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     }
 
-    private lateinit var permissionRequestLauncher: ActivityResultLauncher<String>
+    private lateinit var postNotificationsPermissionRequestLauncher: ActivityResultLauncher<String>
     private lateinit var inflater: LayoutInflater
     private lateinit var sessionViewDrawer: SessionViewDrawer
     private lateinit var errorMessageFactory: ErrorMessage.Factory
@@ -140,7 +140,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        permissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
+        postNotificationsPermissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
             if (isGranted) {
                 showAlarmTimePicker()
             } else {
@@ -214,7 +214,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             scrollTo(sessionId, verticalPosition, roomIndex)
         }
         viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
-            permissionRequestLauncher.launch(POST_NOTIFICATIONS)
+            postNotificationsPermissionRequestLauncher.launch(POST_NOTIFICATIONS)
         }
         viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
             showNotificationsDisabledError()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -481,7 +481,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 updateMenuItems()
             }
             CONTEXT_MENU_ITEM_ID_SET_ALARM -> {
-                viewModel.showAlarmTimePickerWithChecks()
+                viewModel.addAlarmWithChecks()
             }
             CONTEXT_MENU_ITEM_ID_DELETE_ALARM -> {
                 viewModel.deleteAlarm(session)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -142,7 +142,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
         postNotificationsPermissionRequestLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
             if (isGranted) {
-                showAlarmTimePicker()
+                viewModel.addAlarmWithChecks()
             } else {
                 showMissingPostNotificationsPermissionError()
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -97,6 +97,9 @@ internal class FahrplanViewModel(
     val notificationsDisabled = sessionAlarmViewModelDelegate
         .notificationsDisabled
 
+    val requestScheduleExactAlarmsPermission = sessionAlarmViewModelDelegate
+        .requestScheduleExactAlarmsPermission
+
     val showAlarmTimePicker = sessionAlarmViewModelDelegate
         .showAlarmTimePicker
 
@@ -244,6 +247,10 @@ internal class FahrplanViewModel(
         launch {
             repository.updateHighlight(session)
         }
+    }
+
+    fun canAddAlarms(): Boolean {
+        return sessionAlarmViewModelDelegate.canAddAlarms()
     }
 
     fun addAlarmWithChecks() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.alarms.SessionAlarmViewModelDelegate
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -36,21 +37,29 @@ internal class FahrplanViewModel(
     private val repository: AppRepository,
     private val executionContext: ExecutionContext,
     private val logging: Logging,
-    private val alarmServices: AlarmServices,
-    private val notificationHelper: NotificationHelper,
+    alarmServices: AlarmServices,
+    notificationHelper: NotificationHelper,
     private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
     private val scrollAmountCalculator: ScrollAmountCalculator,
     private val defaultEngelsystemRoomName: String,
     private val customEngelsystemRoomName: String,
-    private val runsAtLeastOnAndroidTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+    runsAtLeastOnAndroidTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 
 ) : ViewModel() {
 
     private companion object {
         const val LOG_TAG = "FahrplanViewModel"
     }
+
+    private var sessionAlarmViewModelDelegate: SessionAlarmViewModelDelegate =
+        SessionAlarmViewModelDelegate(
+            viewModelScope,
+            notificationHelper,
+            alarmServices,
+            runsAtLeastOnAndroidTiramisu,
+        )
 
     val fahrplanParameter = combine(
         repository.uncanceledSessionsForDayIndex.filter { it.allSessions.isNotEmpty() },
@@ -82,32 +91,19 @@ internal class FahrplanViewModel(
     private val mutableScrollToSessionParameter = Channel<ScrollToSessionParameter>()
     val scrollToSessionParameter = mutableScrollToSessionParameter.receiveAsFlow()
 
-    private val mutableRequestPostNotificationsPermission = Channel<Unit>()
-    val requestPostNotificationsPermission = mutableRequestPostNotificationsPermission.receiveAsFlow()
+    val requestPostNotificationsPermission = sessionAlarmViewModelDelegate
+        .requestPostNotificationsPermission
 
-    private val mutableNotificationsDisabled = Channel<Unit>()
-    val notificationsDisabled = mutableNotificationsDisabled.receiveAsFlow()
+    val notificationsDisabled = sessionAlarmViewModelDelegate
+        .notificationsDisabled
 
-    private val mutableShowAlarmTimePicker = Channel<Unit>()
-    val showAlarmTimePicker = mutableShowAlarmTimePicker.receiveAsFlow()
+    val showAlarmTimePicker = sessionAlarmViewModelDelegate
+        .showAlarmTimePicker
 
     var preserveVerticalScrollPosition: Boolean = false
 
     init {
         updateUncanceledSessions()
-    }
-
-    fun addAlarmWithChecks() {
-        if (notificationHelper.notificationsEnabled) {
-            mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
-        } else {
-            // Check runtime version here because requesting the POST_NOTIFICATION permission
-            // before Android 13 (Tiramisu) has no effect nor error message.
-            when (runsAtLeastOnAndroidTiramisu) {
-                true -> mutableRequestPostNotificationsPermission.sendOneTimeEvent(Unit)
-                false -> mutableNotificationsDisabled.sendOneTimeEvent(Unit)
-            }
-        }
     }
 
     private fun updateUncanceledSessions() {
@@ -250,15 +246,19 @@ internal class FahrplanViewModel(
         }
     }
 
+    fun addAlarmWithChecks() {
+        sessionAlarmViewModelDelegate.addAlarmWithChecks()
+    }
+
     fun addAlarm(session: Session, alarmTimesIndex: Int) {
         launch {
-            alarmServices.addSessionAlarm(session, alarmTimesIndex)
+            sessionAlarmViewModelDelegate.addAlarm(session, alarmTimesIndex)
         }
     }
 
     fun deleteAlarm(session: Session) {
         launch {
-            alarmServices.deleteSessionAlarm(session)
+            sessionAlarmViewModelDelegate.deleteAlarm(session)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -97,7 +97,7 @@ internal class FahrplanViewModel(
         updateUncanceledSessions()
     }
 
-    fun showAlarmTimePickerWithChecks() {
+    fun addAlarmWithChecks() {
         if (notificationHelper.notificationsEnabled) {
             mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
         } else {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -204,6 +204,7 @@
 
     <string name="alarms_disabled_notifications_permission_missing">Alarme sind deaktiviert. Bitte erteile die \"Benachrichtigungen\" Berechtigung.</string>
     <string name="alarms_disabled_notifications_are_disabled">Alarme sind deaktiviert. Bitte aktiviere Benachrichtigungen.</string>
+    <string name="alarms_disabled_schedule_exact_alarm_permission_missing">Alarme sind deaktiviert. Bitte \"Erlaube, Wecker &amp; Erinnerungen einzurichten\".</string>
 
     <!-- Session list item -->
     <string name="session_list_item_duration_text"><xliff:g example="45" id="duration">%d</xliff:g> min.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
 
     <string name="alarms_disabled_notifications_permission_missing">Alarms are disabled. Please grant the \"Notifications\" permission.</string>
     <string name="alarms_disabled_notifications_are_disabled">Alarms are disabled. Please enable notifications.</string>
+    <string name="alarms_disabled_schedule_exact_alarm_permission_missing">Alarms are disabled. Please \"Allow setting alarms &amp; reminders\".</string>
 
     <!-- Session list item -->
     <string name="session_list_item_duration_text"><xliff:g example="45" id="duration">%d</xliff:g> min.</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -125,6 +125,54 @@ class AlarmServicesTest {
     }
 
     @Test
+    fun `canScheduleExactAlarms returns true before SnowCone 1`() {
+        val alarmManager = mock<AlarmManager> {
+            on { canScheduleExactAlarms() } doReturn false // not relevant
+        }
+        val alarmServices = createAlarmServices(
+            alarmManager = alarmManager,
+            runsAtLeastOnAndroidSnowCone = false,
+        )
+        assertThat(alarmServices.canScheduleExactAlarms).isTrue()
+    }
+
+    @Test
+    fun `canScheduleExactAlarms returns true before SnowCone 2`() {
+        val alarmManager = mock<AlarmManager> {
+            on { canScheduleExactAlarms() } doReturn true // not relevant
+        }
+        val alarmServices = createAlarmServices(
+            alarmManager = alarmManager,
+            runsAtLeastOnAndroidSnowCone = false,
+        )
+        assertThat(alarmServices.canScheduleExactAlarms).isTrue()
+    }
+
+    @Test
+    fun `canScheduleExactAlarms returns false as of SnowCone and alarmManager returns false`() {
+        val alarmManager = mock<AlarmManager> {
+            on { canScheduleExactAlarms() } doReturn false
+        }
+        val alarmServices = createAlarmServices(
+            alarmManager = alarmManager,
+            runsAtLeastOnAndroidSnowCone = true,
+        )
+        assertThat(alarmServices.canScheduleExactAlarms).isFalse()
+    }
+
+    @Test
+    fun `canScheduleExactAlarms returns true as of SnowCone and alarmManager returns true`() {
+        val alarmManager = mock<AlarmManager> {
+            on { canScheduleExactAlarms() } doReturn true
+        }
+        val alarmServices = createAlarmServices(
+            alarmManager = alarmManager,
+            runsAtLeastOnAndroidSnowCone = true,
+        )
+        assertThat(alarmServices.canScheduleExactAlarms).isTrue()
+    }
+
+    @Test
     fun `scheduleSessionAlarm invokes cancel then set when discardExisting is true`() {
         val pendingIntent = mock<PendingIntent>()
         val pendingIntentDelegate = object : PendingIntentDelegate {
@@ -201,7 +249,9 @@ class AlarmServicesTest {
 
     private fun createAlarmServices(
         pendingIntentDelegate: PendingIntentDelegate = mock(),
-        formattingDelegate: FormattingDelegate = mock()
+        formattingDelegate: FormattingDelegate = mock(),
+        alarmManager: AlarmManager = this.alarmManager,
+        runsAtLeastOnAndroidSnowCone: Boolean = true,
     ) = AlarmServices(
         context = mockContext,
         repository = repository,
@@ -209,7 +259,8 @@ class AlarmServicesTest {
         alarmTimeValues = alarmTimesValues,
         logging = NoLogging,
         pendingIntentDelegate = pendingIntentDelegate,
-        formattingDelegate = formattingDelegate
+        formattingDelegate = formattingDelegate,
+        runsAtLeastOnAndroidSnowCone = runsAtLeastOnAndroidSnowCone,
     )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
@@ -39,13 +39,39 @@ class SessionAlarmViewModelDelegateTest {
     }
 
     @Test
+    fun `canAddAlarms() invokes canScheduleExactAlarms property`() = runTest {
+        val alarmServices = mock<AlarmServices>()
+        val delegate = createDelegate(alarmServices = alarmServices)
+        delegate.canAddAlarms()
+        verifyInvokedOnce(alarmServices).canScheduleExactAlarms
+    }
+
+    @Test
     fun `addAlarmWithChecks() posts to showAlarmTimePicker`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn true
         }
-        val delegate = createDelegate(notificationHelper)
+        val alarmServices = mock<AlarmServices> {
+            on { canScheduleExactAlarms } doReturn true
+        }
+        val delegate = createDelegate(notificationHelper, alarmServices)
         delegate.addAlarmWithChecks()
         delegate.showAlarmTimePicker.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `addAlarmWithChecks() posts to requestScheduleExactAlarmsPermission`() = runTest {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn true
+        }
+        val alarmServices = mock<AlarmServices> {
+            on { canScheduleExactAlarms } doReturn false
+        }
+        val delegate = createDelegate(notificationHelper, alarmServices)
+        delegate.addAlarmWithChecks()
+        delegate.requestScheduleExactAlarmsPermission.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
@@ -1,0 +1,94 @@
+package nerd.tuxmobil.fahrplan.congress.alarms
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+class SessionAlarmViewModelDelegateTest {
+
+    private companion object {
+        val SESSION = Session("session-23")
+    }
+
+    @get:Rule
+    val mainDispatcherTestRule = MainDispatcherTestRule()
+
+    @Test
+    fun `addAlarm() invokes addSessionAlarm() function`() = runTest {
+        val alarmServices = mock<AlarmServices>()
+        val delegate = createDelegate(alarmServices = alarmServices)
+        delegate.addAlarm(SESSION, alarmTimesIndex = 0)
+        verifyInvokedOnce(alarmServices).addSessionAlarm(SESSION, alarmTimesIndex = 0)
+    }
+
+    @Test
+    fun `deleteAlarm() invokes deleteSessionAlarm() function`() = runTest {
+        val alarmServices = mock<AlarmServices>()
+        val delegate = createDelegate(alarmServices = alarmServices)
+        delegate.deleteAlarm(SESSION)
+        verifyInvokedOnce(alarmServices).deleteSessionAlarm(SESSION)
+    }
+
+    @Test
+    fun `addAlarmWithChecks() posts to showAlarmTimePicker`() = runTest {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn true
+        }
+        val delegate = createDelegate(notificationHelper)
+        delegate.addAlarmWithChecks()
+        delegate.showAlarmTimePicker.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `addAlarmWithChecks() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn false
+        }
+        val delegate = createDelegate(
+            notificationHelper = notificationHelper,
+            runsAtLeastOnAndroidTiramisu = true,
+        )
+        delegate.addAlarmWithChecks()
+        delegate.requestPostNotificationsPermission.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `addAlarmWithChecks() posts to notificationsDisabled before Android 13`() = runTest {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn false
+        }
+        val delegate = createDelegate(
+            notificationHelper = notificationHelper,
+            runsAtLeastOnAndroidTiramisu = false,
+        )
+        delegate.addAlarmWithChecks()
+        delegate.notificationsDisabled.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    private fun TestScope.createDelegate(
+        notificationHelper: NotificationHelper = mock(),
+        alarmServices: AlarmServices = mock(),
+        runsAtLeastOnAndroidTiramisu: Boolean = true,
+    ) = SessionAlarmViewModelDelegate(
+        viewModelScope = this,
+        notificationHelper = notificationHelper,
+        alarmServices = alarmServices,
+        runsAtLeastOnAndroidTiramisu = runsAtLeastOnAndroidTiramisu,
+    )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -315,6 +315,7 @@ class SessionDetailsViewModelTest {
         viewModel.showAlarmTimePicker.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
+        verifyInvokedOnce(notificationHelper).notificationsEnabled
     }
 
     @Test
@@ -332,6 +333,7 @@ class SessionDetailsViewModelTest {
         viewModel.requestPostNotificationsPermission.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
+        verifyInvokedOnce(notificationHelper).notificationsEnabled
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -305,20 +305,20 @@ class SessionDetailsViewModelTest {
     }
 
     @Test
-    fun `setAlarm() posts to setAlarm`() = runTest {
+    fun `addAlarmWithChecks() posts to showAlarmTimePicker`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn true
         }
         val repository = createRepository()
         val viewModel = createViewModel(repository, notificationHelper = notificationHelper)
-        viewModel.setAlarm()
-        viewModel.setAlarm.test {
+        viewModel.addAlarmWithChecks()
+        viewModel.showAlarmTimePicker.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }
 
     @Test
-    fun `setAlarm() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
+    fun `addAlarmWithChecks() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -328,14 +328,14 @@ class SessionDetailsViewModelTest {
             notificationHelper = notificationHelper,
             runsAtLeastOnAndroidTiramisu = true
         )
-        viewModel.setAlarm()
+        viewModel.addAlarmWithChecks()
         viewModel.requestPostNotificationsPermission.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }
 
     @Test
-    fun `setAlarm() posts to notificationsDisabled before Android 13`() = runTest {
+    fun `addAlarmWithChecks() posts to notificationsDisabled before Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -345,7 +345,7 @@ class SessionDetailsViewModelTest {
             notificationHelper = notificationHelper,
             runsAtLeastOnAndroidTiramisu = false
         )
-        viewModel.setAlarm()
+        viewModel.addAlarmWithChecks()
         viewModel.notificationsDisabled.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -267,6 +267,7 @@ class FahrplanViewModelTest {
         viewModel.showAlarmTimePicker.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
+        verifyInvokedOnce(notificationHelper).notificationsEnabled
     }
 
     @Test
@@ -284,6 +285,7 @@ class FahrplanViewModelTest {
         viewModel.requestPostNotificationsPermission.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
+        verifyInvokedOnce(notificationHelper).notificationsEnabled
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -257,17 +257,58 @@ class FahrplanViewModelTest {
     }
 
     @Test
+    fun `canAddAlarms invokes canScheduleExactAlarms property`() {
+        val repository = createRepository()
+        val alarmServices = mock<AlarmServices>()
+        val viewModel = createViewModel(repository = repository, alarmServices = alarmServices)
+        viewModel.canAddAlarms()
+        verifyInvokedOnce(alarmServices).canScheduleExactAlarms
+    }
+
+    @Test
     fun `addAlarmWithChecks() posts to showAlarmTimePicker`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn true
         }
+        val alarmServices = mock<AlarmServices> {
+            on { canScheduleExactAlarms } doReturn true
+        }
         val repository = createRepository()
-        val viewModel = createViewModel(repository, notificationHelper = notificationHelper)
+        val viewModel = createViewModel(
+            repository = repository,
+            notificationHelper = notificationHelper,
+            alarmServices = alarmServices,
+            runsAtLeastOnAndroidTiramisu = true, // not relevant
+        )
         viewModel.addAlarmWithChecks()
         viewModel.showAlarmTimePicker.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
         verifyInvokedOnce(notificationHelper).notificationsEnabled
+        verifyInvokedOnce(alarmServices).canScheduleExactAlarms
+    }
+
+    @Test
+    fun `addAlarmWithChecks() posts to requestScheduleExactAlarmsPermission`() = runTest {
+        val notificationHelper = mock<NotificationHelper> {
+            on { notificationsEnabled } doReturn true
+        }
+        val alarmServices = mock<AlarmServices> {
+            on { canScheduleExactAlarms } doReturn false
+        }
+        val repository = createRepository()
+        val viewModel = createViewModel(
+            repository = repository,
+            notificationHelper = notificationHelper,
+            alarmServices = alarmServices,
+            runsAtLeastOnAndroidTiramisu = true, // not relevant
+        )
+        viewModel.addAlarmWithChecks()
+        viewModel.requestScheduleExactAlarmsPermission.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+        verifyInvokedOnce(notificationHelper).notificationsEnabled
+        verifyInvokedOnce(alarmServices).canScheduleExactAlarms
     }
 
     @Test
@@ -279,7 +320,7 @@ class FahrplanViewModelTest {
         val viewModel = createViewModel(
             repository = repository,
             notificationHelper = notificationHelper,
-            runsAtLeastOnAndroidTiramisu = true
+            runsAtLeastOnAndroidTiramisu = true,
         )
         viewModel.addAlarmWithChecks()
         viewModel.requestPostNotificationsPermission.test {
@@ -297,7 +338,7 @@ class FahrplanViewModelTest {
         val viewModel = createViewModel(
             repository = repository,
             notificationHelper = notificationHelper,
-            runsAtLeastOnAndroidTiramisu = false
+            runsAtLeastOnAndroidTiramisu = false,
         )
         viewModel.addAlarmWithChecks()
         viewModel.notificationsDisabled.test {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -257,20 +257,20 @@ class FahrplanViewModelTest {
     }
 
     @Test
-    fun `showAlarmTimePickerWithChecks() posts to showAlarmTimePicker`() = runTest {
+    fun `addAlarmWithChecks() posts to showAlarmTimePicker`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn true
         }
         val repository = createRepository()
         val viewModel = createViewModel(repository, notificationHelper = notificationHelper)
-        viewModel.showAlarmTimePickerWithChecks()
+        viewModel.addAlarmWithChecks()
         viewModel.showAlarmTimePicker.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }
 
     @Test
-    fun `showAlarmTimePickerWithChecks() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
+    fun `addAlarmWithChecks() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -280,14 +280,14 @@ class FahrplanViewModelTest {
             notificationHelper = notificationHelper,
             runsAtLeastOnAndroidTiramisu = true
         )
-        viewModel.showAlarmTimePickerWithChecks()
+        viewModel.addAlarmWithChecks()
         viewModel.requestPostNotificationsPermission.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }
 
     @Test
-    fun `showAlarmTimePickerWithChecks() posts to notificationsDisabled before Android 13`() = runTest {
+    fun `addAlarmWithChecks() posts to notificationsDisabled before Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -297,7 +297,7 @@ class FahrplanViewModelTest {
             notificationHelper = notificationHelper,
             runsAtLeastOnAndroidTiramisu = false
         )
-        viewModel.showAlarmTimePickerWithChecks()
+        viewModel.addAlarmWithChecks()
         viewModel.notificationsDisabled.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }


### PR DESCRIPTION
# Description
+ Add `android.permission.SCHEDULE_EXACT_ALARM`.
+ Extract common code into `SessionAlarmViewModelDelegate`.
+ Revise alarm related names, hence harmonize `SessionDetailsViewModel` & `FahrplanViewModel`.
+ This change does not affect alarms scheduled for loading schedule updates.

# Test scenarios
+ Add alarm via:
  + Main schedule grid screen: long press a session
  + Session details screen: toolbar item
+ Fresh install.
+ Disabling notifications.
+ Revoking schedule exact alarm permission.
+ Check correct error messages.
+ [Doze mode](https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze), successfully tested with Android 14 device
+ [App Standby mode](https://developer.android.com/training/monitoring-device-state/doze-standby#testing_your_app_with_app_standby), successfully tested with Android 14 device

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Pixel 6 emulator, Android 10 (API 29)
- :heavy_check_mark: Pixel 3a device, Android 12 (API 31)
- :heavy_check_mark: Pixel 4a emulator, Android 12L (API 32)
- :heavy_check_mark: Pixel 7 emulator, Android 13 (API 33)
- :heavy_check_mark: Pixel 6 device, Android 14 (API 34)

# Screenshots (Android 14)
![Notification permission dialog](https://github.com/EventFahrplan/EventFahrplan/assets/144518/3123dc4e-e5cd-43e7-ad16-2dd8b5046bf5) ![Allow setting alarms and reminders screen](https://github.com/EventFahrplan/EventFahrplan/assets/144518/959b13e8-fe5b-4360-90a4-2231f7ea7bda) ![setting alarms and reminders disabled error message](https://github.com/EventFahrplan/EventFahrplan/assets/144518/dd3ff388-14e6-4ce6-8913-5888e30f4fbe)


# Docs
+ https://developer.android.com/about/versions/12/behavior-changes-12#exact-alarm-permission
+ https://developer.android.com/about/versions/13/features#use-exact-alarm-permission
+ https://developer.android.com/about/versions/14/changes/schedule-exact-alarms
+ https://developer.android.com/reference/android/Manifest.permission#SCHEDULE_EXACT_ALARM
+ https://developer.android.com/reference/androidx/core/app/AlarmManagerCompat#setExactAndAllowWhileIdle(android.app.AlarmManager,int,long,android.app.PendingIntent)
+ https://developer.android.com/reference/android/app/AlarmManager#canScheduleExactAlarms()
+ https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze_and_app_standby

---

Resolves #612