### PR TITLE
Improve error message with disabled notifications on devices running older than Android 13 (Tiramisu).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -214,8 +214,8 @@ class SessionDetailsFragment : Fragment() {
         viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
             permissionRequestLauncher.launch(POST_NOTIFICATIONS)
         }
-        viewModel.missingPostNotificationsPermission.observe(viewLifecycleOwner) {
-            showMissingPostNotificationsPermissionError()
+        viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
+            showNotificationsDisabledError()
         }
     }
 
@@ -361,6 +361,10 @@ class SessionDetailsFragment : Fragment() {
 
     private fun showMissingPostNotificationsPermissionError() {
         Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
+    }
+
+    private fun showNotificationsDisabledError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_are_disabled, Toast.LENGTH_LONG).show()
     }
 
     private fun updateOptionsMenu() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -108,9 +108,8 @@ internal class SessionDetailsViewModel(
     private val mutableRequestPostNotificationsPermission = Channel<Unit>()
     val requestPostNotificationsPermission =
         mutableRequestPostNotificationsPermission.receiveAsFlow()
-    private val mutableMissingPostNotificationsPermission = Channel<Unit>()
-    val missingPostNotificationsPermission =
-        mutableMissingPostNotificationsPermission.receiveAsFlow()
+    private val mutableNotificationsDisabled = Channel<Unit>()
+    val notificationsDisabled = mutableNotificationsDisabled.receiveAsFlow()
 
     private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
         roomName = if (roomName == defaultEngelsystemRoomName) customEngelsystemRoomName else roomName
@@ -211,9 +210,11 @@ internal class SessionDetailsViewModel(
         if (notificationHelper.notificationsEnabled) {
             mutableSetAlarm.sendOneTimeEvent(Unit)
         } else {
+            // Check runtime version here because requesting the POST_NOTIFICATION permission
+            // before Android 13 (Tiramisu) has no effect nor error message.
             when (runsAtLeastOnAndroidTiramisu) {
                 true -> mutableRequestPostNotificationsPermission.sendOneTimeEvent(Unit)
-                false -> mutableMissingPostNotificationsPermission.sendOneTimeEvent(Unit)
+                false -> mutableNotificationsDisabled.sendOneTimeEvent(Unit)
             }
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -18,6 +18,11 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
         getNotificationManager()
     }
 
+    /**
+     * Returns `true` if notifications in general are enabled for the app.
+     * If individual channels are disabled, this method still returns `true`.
+     * Hence, firing an alarm for a disabled channel will not show a notification.
+     */
     val notificationsEnabled: Boolean
         get() = notificationManager.areNotificationsEnabled()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -216,8 +216,8 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
             permissionRequestLauncher.launch(POST_NOTIFICATIONS)
         }
-        viewModel.missingPostNotificationsPermission.observe(viewLifecycleOwner) {
-            showMissingPostNotificationsPermissionError()
+        viewModel.notificationsDisabled.observe(viewLifecycleOwner) {
+            showNotificationsDisabledError()
         }
         viewModel.showAlarmTimePicker.observe(viewLifecycleOwner) {
             showAlarmTimePicker()
@@ -551,6 +551,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
 
     private fun showMissingPostNotificationsPermissionError() {
         Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
+    }
+
+    private fun showNotificationsDisabledError() {
+        Toast.makeText(requireContext(), R.string.alarms_disabled_notifications_are_disabled, Toast.LENGTH_LONG).show()
     }
 
     private inner class OnDaySelectedListener(private val numDays: Int) : OnNavigationListener {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -85,8 +85,8 @@ internal class FahrplanViewModel(
     private val mutableRequestPostNotificationsPermission = Channel<Unit>()
     val requestPostNotificationsPermission = mutableRequestPostNotificationsPermission.receiveAsFlow()
 
-    private val mutableMissingPostNotificationsPermission = Channel<Unit>()
-    val missingPostNotificationsPermission = mutableMissingPostNotificationsPermission.receiveAsFlow()
+    private val mutableNotificationsDisabled = Channel<Unit>()
+    val notificationsDisabled = mutableNotificationsDisabled.receiveAsFlow()
 
     private val mutableShowAlarmTimePicker = Channel<Unit>()
     val showAlarmTimePicker = mutableShowAlarmTimePicker.receiveAsFlow()
@@ -101,9 +101,11 @@ internal class FahrplanViewModel(
         if (notificationHelper.notificationsEnabled) {
             mutableShowAlarmTimePicker.sendOneTimeEvent(Unit)
         } else {
+            // Check runtime version here because requesting the POST_NOTIFICATION permission
+            // before Android 13 (Tiramisu) has no effect nor error message.
             when (runsAtLeastOnAndroidTiramisu) {
                 true -> mutableRequestPostNotificationsPermission.sendOneTimeEvent(Unit)
-                false -> mutableMissingPostNotificationsPermission.sendOneTimeEvent(Unit)
+                false -> mutableNotificationsDisabled.sendOneTimeEvent(Unit)
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -203,6 +203,7 @@
     <string name="alarm_time_title_60_minutes_before">60 Minuten vorher</string>
 
     <string name="alarms_disabled_notifications_permission_missing">Alarme sind deaktiviert. Bitte erteile die \"Benachrichtigungen\" Berechtigung.</string>
+    <string name="alarms_disabled_notifications_are_disabled">Alarme sind deaktiviert. Bitte aktiviere Benachrichtigungen.</string>
 
     <!-- Session list item -->
     <string name="session_list_item_duration_text"><xliff:g example="45" id="duration">%d</xliff:g> min.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="alarm_time_title_60_minutes_before">60 minutes before</string>
 
     <string name="alarms_disabled_notifications_permission_missing">Alarms are disabled. Please grant the \"Notifications\" permission.</string>
+    <string name="alarms_disabled_notifications_are_disabled">Alarms are disabled. Please enable notifications.</string>
 
     <!-- Session list item -->
     <string name="session_list_item_duration_text"><xliff:g example="45" id="duration">%d</xliff:g> min.</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -318,7 +318,7 @@ class SessionDetailsViewModelTest {
     }
 
     @Test
-    fun `setAlarm() posts to requestPostNotificationsPermission`() = runTest {
+    fun `setAlarm() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -335,7 +335,7 @@ class SessionDetailsViewModelTest {
     }
 
     @Test
-    fun `setAlarm() posts to missingPostNotificationsPermission`() = runTest {
+    fun `setAlarm() posts to notificationsDisabled before Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -346,7 +346,7 @@ class SessionDetailsViewModelTest {
             runsAtLeastOnAndroidTiramisu = false
         )
         viewModel.setAlarm()
-        viewModel.missingPostNotificationsPermission.test {
+        viewModel.notificationsDisabled.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -270,7 +270,7 @@ class FahrplanViewModelTest {
     }
 
     @Test
-    fun `showAlarmTimePickerWithChecks() posts to requestPostNotificationsPermission`() = runTest {
+    fun `showAlarmTimePickerWithChecks() posts to requestPostNotificationsPermission as of Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -287,7 +287,7 @@ class FahrplanViewModelTest {
     }
 
     @Test
-    fun `showAlarmTimePickerWithChecks() posts to missingPostNotificationsPermission`() = runTest {
+    fun `showAlarmTimePickerWithChecks() posts to notificationsDisabled before Android 13`() = runTest {
         val notificationHelper = mock<NotificationHelper> {
             on { notificationsEnabled } doReturn false
         }
@@ -298,7 +298,7 @@ class FahrplanViewModelTest {
             runsAtLeastOnAndroidTiramisu = false
         )
         viewModel.showAlarmTimePickerWithChecks()
-        viewModel.missingPostNotificationsPermission.test {
+        viewModel.notificationsDisabled.test {
             assertThat(awaitItem()).isEqualTo(Unit)
         }
     }


### PR DESCRIPTION
# Description
+ Clarify, why the SDK check is needed: Check runtime version because requesting the `POST_NOTIFICATION` permission before Android 13 (Tiramisu) has no effect nor error message.
+ Enhance test descriptions.
+ Related: 63b57b53b279f7660c50e64e288001a9abc8c6aa.
+ Document alarm notification behavior with disabled notification channels.

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/516

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Pixel 4a emulator, Android 12L (API 32)
- :heavy_check_mark: Pixel 7 emulator, Android 13 (API 32)

# Docs
+ https://developer.android.com/develop/ui/views/notifications/notification-permission
+ https://developer.android.com/reference/androidx/core/app/NotificationManagerCompat#areNotificationsEnabled()