### PR TITLE
Update GitHub actions setup

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
+          check_name: Test results (test)
           files: |
             build/test-results/**/*.xml
             */build/test-results/**/*.xml
@@ -52,5 +53,6 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@v1
         if: always()
         with:
+          check_name: Test results (androidTest)
           files: |
             **/androidTest-results/**/*.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,9 @@ jobs:
 
   android_tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        api-level: [ 21 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,6 +46,28 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Gradle cache
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: AVD cache
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-${{ matrix.api-level }}
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
@@ -52,7 +77,10 @@ jobs:
       - name: Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 21
+          api-level: ${{ matrix.api-level }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew :database:connectedAndroidTest
 
       - name: Publish unit-test results

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
           java-version: '11'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 21
-          script: ./gradlew connectedCcc37c3DebugAndroidTest
+          script: ./gradlew :database:connectedAndroidTest
 
       - name: Publish unit-test results
         uses: EnricoMi/publish-unit-test-result-action/composite@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 21 ]
+        api-level: [ 21, 29 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -87,6 +87,6 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()
         with:
-          check_name: Test results (androidTest)
+          check_name: Test results (androidTest), API level ${{ matrix.api-level }}
           files: |
             **/androidTest-results/**/*.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,12 +32,16 @@ jobs:
             */build/test-results/**/*.xml
 
   android_tests:
-    # see https://github.com/reactivecircus/android-emulator-runner,
-    # needs to run on macos as only there virtualization is available!
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,4 @@ jobs:
         if: always()
         with:
           files: |
-            build/test-results/**/*.xml
-            */build/test-results/**/*.xml
-            */build/outputs/androidTest-results/connected/*.xml
+            **/androidTest-results/**/*.xml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
           script: ./gradlew testDebug :engelsystem:test testCcc37c3DebugUnitTest assembleCcc37c3Debug lintAnalyzeCcc37c3Debug
 
       - name: Publish unit-test results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           check_name: Test results (test)
@@ -50,7 +50,7 @@ jobs:
           script: ./gradlew :database:connectedAndroidTest
 
       - name: Publish unit-test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()
         with:
           check_name: Test results (androidTest)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -35,7 +35,7 @@ jobs:
     # needs to run on macos as only there virtualization is available!
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -35,7 +36,8 @@ jobs:
     # needs to run on macos as only there virtualization is available!
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up JDK
         uses: actions/setup-java@v4


### PR DESCRIPTION
# Description
- Fix running instrumentation tests (`androidTest` source set). Broken since: 4f328f90b1a24343fd6e228ca048742ee9f44696.
- Fix publishing instrumentation test (`androidTest` source set) results.
- Prevent earlier test results being overwritten by later ones.
- Use `EnricoMi/publish-unit-test-result-action/composite@v2`.
- Use `actions/setup-java@v4`.
- Use `actions/checkout@v4`.
- Run instrumentation tests with `ubuntu-latest`.
- Reduce emulator startup time by setting up AVD snapshot caching.
- Run instrumentation tests on Android 10 (Quince Tart), too.