### PR TITLE
Update project setup (Compose compiler 1.5.9, kotlin 1.9.22, moshi 1.15.1, engelsystem 8.1.0, Gradle 7.6.4)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 21, 29 ]
+        api-level: [ 21 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -55,7 +55,7 @@ object Plugins {
 object Libs {
 
     private object Versions {
-        const val annotation = "1.7.0"
+        const val annotation = "1.7.1"
         const val appCompat = "1.6.1"
         const val assertjAndroid = "1.2.0"
         const val betterLinkMovementMethod = "2.2.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -72,7 +72,7 @@ object Libs {
         const val material = "1.9.0"
         const val mockito = "5.10.0"
         const val mockitoKotlin = "5.2.1"
-        const val moshi = "1.15.0"
+        const val moshi = "1.15.1"
         const val okhttp = "4.12.0"
         const val preference = "1.2.1"
         const val retrofit = "2.9.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -63,7 +63,7 @@ object Libs {
         const val coreKtx = "1.9.0"
         const val coreTesting = "2.2.0"
         const val emailIntentBuilder = "2.0.0"
-        const val engelsystem = "8.0.0"
+        const val engelsystem = "8.1.0"
         const val espresso = "3.5.1"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.7.3"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -81,7 +81,7 @@ object Libs {
         const val testExtJunit = "1.1.5"
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
-        const val truth = "1.2.0"
+        const val truth = "1.4.0"
         const val turbine = "1.0.0"
     }
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -67,7 +67,7 @@ object Libs {
         const val espresso = "3.5.1"
         const val junit = "4.13.2"
         const val kotlinCoroutines = "1.7.3"
-        const val lifecycle = "2.6.2"
+        const val lifecycle = "2.6.2" // compileSdk 34 is required as of 2.7.0
         const val markwon = "4.6.2"
         const val material = "1.9.0"
         const val mockito = "5.10.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -70,7 +70,7 @@ object Libs {
         const val lifecycle = "2.6.2"
         const val markwon = "4.6.2"
         const val material = "1.9.0"
-        const val mockito = "5.9.0"
+        const val mockito = "5.10.0"
         const val mockitoKotlin = "5.2.1"
         const val moshi = "1.15.0"
         const val okhttp = "4.12.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -39,7 +39,7 @@ object Plugins {
         const val ksp = "1.9.22-1.0.17"
         const val sonarQube = "4.4.1.3373"
         const val unMock = "0.7.9"
-        const val versions = "0.50.0"
+        const val versions = "0.51.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -19,7 +19,7 @@ object Compose {
 
     object Versions {
         internal const val bom = "2023.06.01" // compileSdk 34 is required as of 2023.08.00
-        const val compiler = "1.5.6"
+        const val compiler = "1.5.9"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"
@@ -35,8 +35,8 @@ object Plugins {
         const val android = "7.4.2"
         const val androidJunitJacoco = "0.16.0"
         const val dexcount = "4.0.0"
-        const val kotlin = "1.9.21"
-        const val ksp = "1.9.21-1.0.15"
+        const val kotlin = "1.9.22"
+        const val ksp = "1.9.22-1.0.17"
         const val sonarQube = "4.4.1.3373"
         const val unMock = "0.7.9"
         const val versions = "0.50.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Description
+ Use Jetpack Compose compiler v.1.5.9 & kotlin v.1.9.22 & ksp v.1.9.22-1.0.17.
+ Use gradle-versions-plugin v.0.51.0.
+ Use truth v.1.4.0.
+ Use mockito v.5.10.0.
+ Use annotation v.1.7.1.
+ Use moshi v.1.15.1.
+ Document compileSdk requirement for lifecycle.
+ Use Gradle wrapper v.7.6.4.
+ Use engelsystem v.8.1.0.
+ Avoid timeout by not running instrumentation tests on Android 10 (Quince Tart).

# Successfully tested on
with `ccc37c3` flavor, `release` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)
- :heavy_check_mark: Pixel 6 device, Android 14 (API 34)