### PR TITLE
Modernize testing infrastructure: Migrate from JUnit 4 to JUnit 5.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -254,6 +254,8 @@ dependencies {
     }
     testImplementation Libs.coreTesting
     testImplementation Libs.junit
+    testImplementation Libs.junitJupiterApi
+    testRuntimeOnly Libs.junitJupiterEngine
     testImplementation(Libs.kotlinCoroutinesTest) {
         // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -253,9 +253,9 @@ dependencies {
         exclude group: "com.android.support", module: "support-annotations"
     }
     testImplementation Libs.coreTesting
-    testImplementation Libs.junit
     testImplementation Libs.junitJupiterApi
     testRuntimeOnly Libs.junitJupiterEngine
+    testImplementation Libs.junitJupiterParams
     testImplementation(Libs.kotlinCoroutinesTest) {
         // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/MyAppTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MyAppTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -20,8 +20,8 @@ import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -9,8 +9,8 @@ import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConferenceTimeFrame
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -57,7 +57,7 @@ class AlarmUpdaterTest {
     private lateinit var alarmUpdater: AlarmUpdater
     private val mockListener = mock<OnAlarmUpdateListener>()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         alarmUpdater = AlarmUpdater(conferenceTimeFrame, mockListener, testableAppRepository, NoLogging)
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -4,7 +4,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
@@ -20,13 +20,14 @@ import nerd.tuxmobil.fahrplan.congress.commons.ScreenNavigation
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class AlarmsViewModelTest {
 
     private companion object {
@@ -37,9 +38,6 @@ class AlarmsViewModelTest {
         val ALARM_STARTS_AT = SESSION_STARTS_AT.minusMinutes(ALARM_TIME_IN_MIN.toLong())
 
     }
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     @Test
     fun `alarmsState emits Loading`() = runTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
@@ -2,25 +2,23 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class SessionAlarmViewModelDelegateTest {
 
     private companion object {
         val SESSION = Session("session-23")
     }
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     @Test
     fun `addAlarm() invokes addSessionAlarm() function`() = runTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Covers [CalendarDescriptionComposer.getCalendarDescription].

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -6,8 +6,8 @@ import android.os.Bundle
 import android.provider.CalendarContract
 import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.After
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatcher
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.mock
@@ -32,7 +32,7 @@ class CalendarSharingTest {
         verify(onFailure, never()).invoke()
     }
 
-    @After
+    @AfterEach
     fun validate() {
         validateMockitoUsage()
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.changes
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
@@ -14,15 +14,13 @@ import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
 import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class ChangeListViewModelTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     @Test
     fun `changeListParameter emits null`() = runTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatisticTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatisticTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.changes
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ChangeStatisticTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import info.metadude.android.eventfahrplan.database.models.Alarm as AlarmDatabaseModel
 
 class AlarmExtensionsTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/FetchScheduleResultExtensionsTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import info.metadude.android.eventfahrplan.network.models.HttpHeader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import info.metadude.android.eventfahrplan.network.fetching.FetchScheduleResult as NetworkFetchScheduleResult
 import info.metadude.android.eventfahrplan.network.fetching.HttpStatus as NetworkHttpStatus
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult as AppFetchScheduleResult

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HighlightExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/HighlightExtensionsTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import nerd.tuxmobil.fahrplan.congress.models.Highlight
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import info.metadude.android.eventfahrplan.database.models.Highlight as HighlightDatabaseModel
 
 class HighlightExtensionsTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/MetaExtensionsTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneId
 import info.metadude.android.eventfahrplan.database.models.HttpHeader as HttpHeaderDatabaseModel
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -6,7 +6,7 @@ import info.metadude.android.eventfahrplan.database.models.Session.Companion.REC
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Covers [SessionsExtensions.toVirtualDays][toVirtualDays].

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensionsTest.kt
@@ -5,7 +5,7 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.kotlin.library.engelsystem.models.Shift
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftsExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftsExtensionsTest.kt
@@ -4,8 +4,8 @@ import info.metadude.android.eventfahrplan.commons.temporal.DayRange
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.kotlin.library.engelsystem.models.Shift
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 
@@ -15,7 +15,7 @@ class ShiftsExtensionsTest {
     private lateinit var endsAt: ZonedDateTime
     private lateinit var dayRanges: List<DayRange>
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val day = Moment.parseDate("2019-08-23")
         startsAt = day.toZonedDateTime(ZoneOffset.UTC)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -4,7 +4,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
@@ -26,17 +26,15 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class SessionDetailsViewModelTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private companion object {
         val NO_TIME_ZONE_ID = null

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionFormatterTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.details
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SessionFormatterTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/extensions/TextViewExtensionsTest.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import androidx.core.text.set
 import androidx.core.text.toSpannable
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.favorites
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
@@ -16,17 +16,15 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class StarredListViewModelTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private val simpleSessionFormat = mock<SimpleSessionFormat>()
     private val jsonSessionFormat = mock<JsonSessionFormat>()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/DateInfoTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/DateInfoTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.models
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DateInfoTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/DayRangeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/DayRangeTest.kt
@@ -3,8 +3,8 @@ package nerd.tuxmobil.fahrplan.congress.models
 import info.metadude.android.eventfahrplan.commons.temporal.DayRange
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
 
@@ -12,7 +12,7 @@ class DayRangeTest {
 
     private lateinit var dayRange: DayRange
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val day1 = Moment.parseDate("2019-12-27")
         val day2 = Moment.parseDate("2019-12-30")

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleDataTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleDataTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.models
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ScheduleDataTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.models
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 private typealias SessionModification = Session.() -> Unit
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.models
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class VirtualDayTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navGetUriTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navGetUriTest.kt
@@ -4,10 +4,8 @@ import android.net.Uri
 import androidx.core.net.toUri
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Room
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -15,13 +13,7 @@ import org.mockito.kotlin.mock
 /**
  * Covers [C3nav.getUri].
  */
-@RunWith(Parameterized::class)
-class C3navGetUriTest(
-    private val baseUrl: String,
-    private val room: Room,
-    private val convertedName: String,
-    private val uri: Uri,
-) {
+class C3navGetUriTest {
 
     companion object {
 
@@ -33,7 +25,6 @@ class C3navGetUriTest(
             arrayOf(baseUrl, room, convertedName, uri)
 
         @JvmStatic
-        @Parameters(name = "{index}: baseUrl = \"{0}\", \"{1}\", convertedName = \"{2}\" -> isSupported = \"{3}\"")
         fun data() = listOf(
             scenarioOf(
                 VALID_BASE_URL,
@@ -69,8 +60,14 @@ class C3navGetUriTest(
 
     }
 
-    @Test
-    fun getUri() {
+    @ParameterizedTest(name = """{index}: baseUrl = "{0}", "{1}", convertedName = "{2}" -> isSupported = "{3}"""")
+    @MethodSource("data")
+    fun getUri(
+        baseUrl: String,
+        room: Room,
+        convertedName: String,
+        uri: Uri,
+    ) {
         val nameConverter = mock<RoomForC3NavConverter> {
             on { convert(anyOrNull()) } doReturn convertedName
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navIsSupportedTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/C3navIsSupportedTest.kt
@@ -2,10 +2,9 @@ package nerd.tuxmobil.fahrplan.congress.navigation
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Room
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -13,13 +12,7 @@ import org.mockito.kotlin.mock
 /**
  * Covers [C3nav.isSupported].
  */
-@RunWith(Parameterized::class)
-class C3navIsSupportedTest(
-    private val baseUrl: String,
-    private val room: Room,
-    private val convertedName: String,
-    private val isSupported: Boolean,
-) {
+class C3navIsSupportedTest {
 
     companion object {
 
@@ -36,7 +29,6 @@ class C3navIsSupportedTest(
             arrayOf(baseUrl, room, convertedName, isSupported)
 
         @JvmStatic
-        @Parameters(name = "{index}: baseUrl = \"{0}\", \"{1}\", convertedName = \"{2}\" -> isSupported = \"{3}\"")
         fun data() = listOf(
             scenarioOf(
                 VALID_BASE_URL,
@@ -72,8 +64,14 @@ class C3navIsSupportedTest(
 
     }
 
-    @Test
-    fun isSupported() {
+    @ParameterizedTest(name = """{index}: baseUrl = "{0}", "{1}", convertedName = "{2}" -> isSupported = "{3}"""")
+    @MethodSource("data")
+    fun isSupported(
+        baseUrl: String,
+        room: Room,
+        convertedName: String,
+        isSupported: Boolean,
+    ) {
         val nameConverter = mock<RoomForC3NavConverter> {
             on { convert(anyOrNull()) } doReturn convertedName
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/navigation/RoomForC3NavConverterTest.kt
@@ -1,18 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.navigation
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
-@RunWith(Parameterized::class)
-class RoomForC3NavConverterTest(
-
-        private val roomName: String?,
-        private val expectedText: String
-
-) {
+class RoomForC3NavConverterTest {
 
     companion object {
 
@@ -20,7 +12,6 @@ class RoomForC3NavConverterTest(
                 arrayOf(roomName, expectedText)
 
         @JvmStatic
-        @Parameters(name = "{index}: room = \"{0}\" -> expectedText = \"{1}\"")
         fun data() = listOf(
                 scenarioOf(roomName = "Ada", expectedText = "hall-a"),
                 scenarioOf(roomName = "Borg", expectedText = "hall-b"),
@@ -33,8 +24,12 @@ class RoomForC3NavConverterTest(
         )
     }
 
-    @Test
-    fun convert() {
+    @ParameterizedTest(name = """{index}: room = "{0}" -> expectedText = "{1}"""")
+    @MethodSource("data")
+    fun convert(
+        roomName: String?,
+        expectedText: String,
+    ) {
         assertThat(RoomForC3NavConverter().convert(roomName)).isEqualTo(expectedText)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseRepository
@@ -28,8 +28,8 @@ import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseFailu
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseSuccess
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
 import okhttp3.OkHttpClient
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -60,6 +60,7 @@ private typealias OnFetchScheduleFinished = (fetchScheduleResult: NetworkFetchSc
  * - [AppRepository.selectedSession]
  * - [AppRepository.uncanceledSessionsForDayIndex]
  */
+@ExtendWith(MainDispatcherTestExtension::class)
 class AppRepositoryLoadAndParseScheduleTest {
 
     private companion object {
@@ -67,9 +68,6 @@ class AppRepositoryLoadAndParseScheduleTest {
         const val SCHEDULE_URL = "https://example.com/schedule.xml"
         const val EMPTY_ENGELSYSTEM_URL = ""
     }
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private val alarmsDatabaseRepository = mock<AlarmsDatabaseRepository>()
     private val highlightsDatabaseRepository = mock<HighlightsDatabaseRepository>()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -2,15 +2,15 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
 import kotlinx.coroutines.test.runTest
 import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSessionsDatabaseModel
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -19,10 +19,8 @@ import org.mockito.kotlin.whenever
 /**
  * Test class to deal with sessions which interact with the [SessionsDatabaseRepository].
  */
+@ExtendWith(MainDispatcherTestExtension::class)
 class AppRepositorySessionsTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private val sessionsDatabaseRepository = mock<SessionsDatabaseRepository>()
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/NetworkScopeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/NetworkScopeTest.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
 import nerd.tuxmobil.fahrplan.congress.exceptions.ExceptionHandling
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import kotlin.coroutines.CoroutineContext
 
 @ExperimentalCoroutinesApi

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.repositories
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SessionsTransformerTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 
 class ConferenceTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedNever
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
@@ -30,9 +30,9 @@ import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToSessionParam
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
-import org.junit.Ignore
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
@@ -41,10 +41,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.threeten.bp.ZoneOffset
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class FahrplanViewModelTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private val simpleSessionFormat = mock<SimpleSessionFormat>()
     private val jsonSessionFormat = mock<JsonSessionFormat>()
@@ -429,7 +427,7 @@ class FahrplanViewModelTest {
         }
     }
 
-    @Ignore("Flaky, see https://github.com/EventFahrplan/EventFahrplan/issues/526")
+    @Disabled("Flaky, see https://github.com/EventFahrplan/EventFahrplan/issues/526")
     @Test
     fun `scrollToCurrentSession posts to scrollToCurrentSessionParameter property when session is present and day indices match`() = runTest {
         val scheduleData = createScheduleData(Session("session-31"), dayIndex = 3)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollStateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollStateTest.kt
@@ -5,7 +5,7 @@ import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollState.Companion.SCROLL_THRESHOLD_FACTOR
 import nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView.Companion.SWIPE_MIN_DISTANCE
 import nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView.Companion.SWIPE_THRESHOLD_VELOCITY
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class HorizontalSnapScrollStateTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollViewCalculateDisplayColumnCountTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollViewCalculateDisplayColumnCountTest.kt
@@ -2,23 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.R
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 /**
  * Parameterized unit test for [HorizontalSnapScrollView.calculateDisplayColumnCount].
  */
-@RunWith(Parameterized::class)
-class HorizontalSnapScrollViewCalculateDisplayColumnCountTest(
-        private val availablePixels: Int,
-        private val totalColumnCount: Int,
-        private val maxColumnCountForLayout: Int,
-        private val densityScaleFactor: Float,
-        private val minColumnWidthDip: Int,
-        private val calculatedColumnCount: Int,
-        @Suppress("unused") private val testDescription: String
-) {
+class HorizontalSnapScrollViewCalculateDisplayColumnCountTest {
 
     companion object {
 
@@ -137,7 +127,6 @@ class HorizontalSnapScrollViewCalculateDisplayColumnCountTest(
         )
 
         @JvmStatic
-        @Parameterized.Parameters(name = "{index}: \"{6}\"")
         fun data() = listOf(
                 // Pixel 2 portrait (maxColumnCountForLayout=1)
                 pixel2Portrait(totalColumnCount = 1, calculatedColumnCount = 1),
@@ -201,8 +190,17 @@ class HorizontalSnapScrollViewCalculateDisplayColumnCountTest(
         )
     }
 
-    @Test
-    fun calculateDisplayColumnCount() {
+    @ParameterizedTest(name = """{index}: "{6}"""")
+    @MethodSource("data")
+    fun calculateDisplayColumnCount(
+        availablePixels: Int,
+        totalColumnCount: Int,
+        maxColumnCountForLayout: Int,
+        densityScaleFactor: Float,
+        minColumnWidthDip: Int,
+        calculatedColumnCount: Int,
+        @Suppress("UNUSED_PARAMETER") testDescription: String
+    ) {
         assertThat(HorizontalSnapScrollView.calculateDisplayColumnCount(
                 availablePixels,
                 totalColumnCount,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -6,7 +6,7 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class LayoutCalculatorTest {
     private val conferenceDate = "2020-03-30"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestRule
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -29,16 +29,14 @@ import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseSucce
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.LoadScheduleUiState
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScheduleChangesParameter
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
+@ExtendWith(MainDispatcherTestExtension::class)
 class MainViewModelTest {
-
-    @get:Rule
-    val mainDispatcherTestRule = MainDispatcherTestRule()
 
     private val logging = NoLogging
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -4,8 +4,8 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 
 class NavigationMenuEntriesGeneratorTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -8,7 +8,7 @@ import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 
 class ScrollAmountCalculatorTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
@@ -6,24 +6,15 @@ import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
 import info.metadude.android.eventfahrplan.network.temporal.DateParser
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.threeten.bp.ZoneOffset
 
 /**
  * Covers ScrollAmountCalculator.calculateScrollAmount(Conference, Session, int).
  * Ensures correct behavior with different time zone offsets.
  */
-@RunWith(Parameterized::class)
-class ScrollAmountCalculatorTimeZoneOffsetTest(
-
-        private val deviceTimeZoneId: String,
-        private val sessionStartsAtDateTimeIso8601: String,
-        private val conferenceStartedHoursAgo: Int,
-        private val expectedScrollAmount: Int
-
-) {
+class ScrollAmountCalculatorTimeZoneOffsetTest {
 
     companion object {
 
@@ -48,15 +39,20 @@ class ScrollAmountCalculatorTimeZoneOffsetTest(
                 scenarioOf(deviceTimeZoneId, "2021-03-28T06:00:00+02:00", startedHoursAgo = 7, expectedScrollAmount = 2856)
 
         @JvmStatic
-        @Parameterized.Parameters(name = "{index}: device = {0}, sessionStartsAt = {1}, conferenceStartedHoursAgo = {2} -> scrollAmount = {3}")
         fun data() = timeZoneOffsets.map { startsNowScenarioOf(deviceTimeZoneId = "GMT$it") } +
                 timeZoneOffsets.map { startedBeforeScenarioOf(deviceTimeZoneId = "GMT$it") } +
                 timeZoneOffsets.map { winterSummerScenarioOf(deviceTimeZoneId = "GMT$it") }
 
     }
 
-    @Test
-    fun calculateScrollAmount() {
+    @ParameterizedTest(name = "{index}: device = {0}, sessionStartsAt = {1}, conferenceStartedHoursAgo = {2} -> scrollAmount = {3}")
+    @MethodSource("data")
+    fun calculateScrollAmount(
+        deviceTimeZoneId: String,
+        sessionStartsAtDateTimeIso8601: String,
+        conferenceStartedHoursAgo: Int,
+        expectedScrollAmount: Int
+    ) {
         withTimeZone(deviceTimeZoneId) {
             val targetSessionStartsAtDateTime = DateParser.getDateTime(sessionStartsAtDateTimeIso8601)
             val targetSessionStartsAt = Moment.ofEpochMilli(targetSessionStartsAtDateTime)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentFormattedTextTest.kt
@@ -2,19 +2,12 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.threeten.bp.OffsetDateTime
 import java.util.TimeZone
 
-@RunWith(Parameterized::class)
-class TimeSegmentFormattedTextTest(
-
-        private val minutesOfTheDay: Int,
-        private val expectedFormattedText: String
-
-) {
+class TimeSegmentFormattedTextTest {
 
     companion object {
 
@@ -24,7 +17,6 @@ class TimeSegmentFormattedTextTest(
                 arrayOf(minutesOfTheDay, expectedFormattedText)
 
         @JvmStatic
-        @Parameterized.Parameters(name = "{index}: minutes = {0} -> formattedText = {1}")
         fun data() = listOf(
                 scenarioOf(minutesOfTheDay = 0, expectedFormattedText = "01:00"),
                 scenarioOf(minutesOfTheDay = 1, expectedFormattedText = "01:00"),
@@ -43,8 +35,12 @@ class TimeSegmentFormattedTextTest(
         )
     }
 
-    @Test
-    fun formattedText() {
+    @ParameterizedTest(name = "{index}: minutes = {0} -> formattedText = {1}")
+    @MethodSource("data")
+    fun formattedText(
+        minutesOfTheDay: Int,
+        expectedFormattedText: String
+    ) {
         TimeZone.setDefault(DEFAULT_TIME_ZONE)
         val zoneOffsetNow = OffsetDateTime.now().offset
         val moment = Moment.now().startOfDay().plusMinutes(minutesOfTheDay.toLong())

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TimeSegmentTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -6,9 +6,9 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.schedule.Conference
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 import java.util.Locale
 import java.util.TimeZone
@@ -22,13 +22,13 @@ class TimeTextViewParameterTest {
     private val systemTimezone = TimeZone.getDefault()
     private val systemLocale = Locale.getDefault()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         Locale.setDefault(Locale("de", "DE"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
     }
 
-    @After
+    @AfterEach
     fun resetSystemDefaults() {
         Locale.setDefault(systemLocale)
         TimeZone.setDefault(systemTimezone)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.serialization
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.Companion.computeSessionsWithChangeFlags
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 
 class ScheduleChangesTest {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/JsonSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/JsonSessionFormatTest.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.sharing
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class JsonSessionFormatTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -5,9 +5,9 @@ import info.metadude.android.eventfahrplan.commons.temporal.DateParser
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneId
 import java.util.Locale
 import java.util.TimeZone
@@ -63,13 +63,13 @@ class SimpleSessionFormatTest {
         slug = "U9SD23"
     }
 
-    @Before
+    @BeforeEach
     fun setUp() {
         Locale.setDefault(Locale("de", "DE"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
     }
 
-    @After
+    @AfterEach
     fun cleanUp() {
         Locale.setDefault(systemLocale)
         TimeZone.setDefault(systemTimezone)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ConferenceTimeFrameTest.kt
@@ -2,9 +2,9 @@ package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import org.junit.Assert.fail
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 class ConferenceTimeFrameTest {
 
@@ -18,7 +18,7 @@ class ConferenceTimeFrameTest {
 
     private lateinit var conference: ConferenceTimeFrame
 
-    @Before
+    @BeforeEach
     fun setUp() {
         conference = ConferenceTimeFrame(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EngelsystemUrlValidatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/EngelsystemUrlValidatorTest.kt
@@ -1,18 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
-@RunWith(Parameterized::class)
-class EngelsystemUrlValidatorTest(
-
-        private val url: String,
-        private val isValid: Boolean
-
-) {
+class EngelsystemUrlValidatorTest {
 
     companion object {
 
@@ -20,7 +12,6 @@ class EngelsystemUrlValidatorTest(
                 arrayOf(url, isValid)
 
         @JvmStatic
-        @Parameters(name = "{index}: url = {0} -> isValid = {1}")
         fun data() = listOf(
                 scenarioOf(url = "https", isValid = false),
                 scenarioOf(url = "https://", isValid = false),
@@ -34,8 +25,12 @@ class EngelsystemUrlValidatorTest(
         )
     }
 
-    @Test
-    fun isValid() {
+    @ParameterizedTest(name = "{index}: url = {0} -> isValid = {1}")
+    @MethodSource("data")
+    fun isValid(
+        url: String,
+        isValid: Boolean
+    ) {
         assertThat(EngelsystemUrlValidator(url).isValid()).isEqualTo(isValid)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FahrplanMiscTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.DateInfos
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FahrplanMiscTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.utils
 import nerd.tuxmobil.fahrplan.congress.extensions.WIKI_SESSION_TRACK_NAME
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FeedbackUrlComposerTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/MarkdownConverterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/MarkdownConverterTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MarkdownConverterTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.utils
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SessionUrlComposerTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/UrlValidatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/UrlValidatorTest.kt
@@ -1,18 +1,10 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
-import org.junit.runners.Parameterized.Parameters
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
-@RunWith(Parameterized::class)
-class UrlValidatorTest(
-
-        private val url: String,
-        private val isValid: Boolean
-
-) {
+class UrlValidatorTest {
 
     companion object {
 
@@ -20,7 +12,6 @@ class UrlValidatorTest(
                 arrayOf(url, isValid)
 
         @JvmStatic
-        @Parameters(name = "{index}: url = {0} -> isValid = {1}")
         fun data() = listOf(
                 scenarioOf(url = "https", isValid = false),
                 scenarioOf(url = "https://", isValid = false),
@@ -31,8 +22,12 @@ class UrlValidatorTest(
         )
     }
 
-    @Test
-    fun isValid() {
+    @ParameterizedTest(name = "{index}: url = {0} -> isValid = {1}")
+    @MethodSource("data")
+    fun isValid(
+        url: String,
+        isValid: Boolean
+    ) {
         assertThat(UrlValidator(url).isValid()).isEqualTo(isValid)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidationTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/validation/MetaValidationTest.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.validation
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.network.models.Meta
 import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MetaValidationTest {
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/wiki/WikiSessionUtilsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/wiki/WikiSessionUtilsTest.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.wiki
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class WikiSessionUtilsTest {
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ allprojects {
 
 subprojects {
     tasks.withType(Test).configureEach {
+        useJUnitPlatform()
         testLogging {
             events TestLogEvent.FAILED,
                     TestLogEvent.PASSED,

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -66,6 +66,7 @@ object Libs {
         const val engelsystem = "8.1.0"
         const val espresso = "3.5.1"
         const val junit = "4.13.2"
+        const val junitJupiter = "5.10.2"
         const val kotlinCoroutines = "1.7.3"
         const val lifecycle = "2.6.2" // compileSdk 34 is required as of 2.7.0
         const val markwon = "4.6.2"
@@ -96,6 +97,8 @@ object Libs {
     const val engelsystem = "info.metadude.kotlin.library.engelsystem:engelsystem-base:${Versions.engelsystem}"
     const val espresso = "androidx.test.espresso:espresso-core:${Versions.espresso}"
     const val junit = "junit:junit:${Versions.junit}"
+    const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitJupiter}"
+    const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitJupiter}"
     const val kotlinCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -65,7 +65,6 @@ object Libs {
         const val coreTesting = "2.2.0"
         const val emailIntentBuilder = "2.0.0"
         const val engelsystem = "8.1.0"
-        const val junit = "4.13.2"
         const val junitJupiter = "5.10.2"
         const val kotlinCoroutines = "1.7.3"
         const val lifecycle = "2.6.2" // compileSdk 34 is required as of 2.7.0
@@ -96,9 +95,9 @@ object Libs {
     const val coreTesting = "androidx.arch.core:core-testing:${Versions.coreTesting}"
     const val emailIntentBuilder = "de.cketti.mailto:email-intent-builder:${Versions.emailIntentBuilder}"
     const val engelsystem = "info.metadude.kotlin.library.engelsystem:engelsystem-base:${Versions.engelsystem}"
-    const val junit = "junit:junit:${Versions.junit}"
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitJupiter}"
     const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitJupiter}"
+    const val junitJupiterParams = "org.junit.jupiter:junit-jupiter-params:${Versions.junitJupiter}"
     const val kotlinCoroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}"
     const val kotlinCoroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.kotlinCoroutines}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -55,6 +55,7 @@ object Plugins {
 object Libs {
 
     private object Versions {
+        const val androidTest = "1.4.0"
         const val annotation = "1.7.1"
         const val appCompat = "1.6.1"
         const val assertjAndroid = "1.2.0"
@@ -64,7 +65,6 @@ object Libs {
         const val coreTesting = "2.2.0"
         const val emailIntentBuilder = "2.0.0"
         const val engelsystem = "8.1.0"
-        const val espresso = "3.5.1"
         const val junit = "4.13.2"
         const val junitJupiter = "5.10.2"
         const val kotlinCoroutines = "1.7.3"
@@ -79,13 +79,14 @@ object Libs {
         const val retrofit = "2.9.0"
         const val robolectric = "4.3_r2-robolectric-0"
         const val snackengage = "0.30"
-        const val testExtJunit = "1.1.5"
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
         const val truth = "1.4.0"
         const val turbine = "1.0.0"
     }
 
+    const val androidTestCore = "de.mannodermaus.junit5:android-test-core:${Versions.androidTest}"
+    const val androidTestRunner = "de.mannodermaus.junit5:android-test-runner:${Versions.androidTest}"
     const val annotation = "androidx.annotation:annotation:${Versions.annotation}"
     const val appCompat = "androidx.appcompat:appcompat:${Versions.appCompat}"
     const val assertjAndroid = "com.squareup.assertj:assertj-android:${Versions.assertjAndroid}"
@@ -95,7 +96,6 @@ object Libs {
     const val coreTesting = "androidx.arch.core:core-testing:${Versions.coreTesting}"
     const val emailIntentBuilder = "de.cketti.mailto:email-intent-builder:${Versions.emailIntentBuilder}"
     const val engelsystem = "info.metadude.kotlin.library.engelsystem:engelsystem-base:${Versions.engelsystem}"
-    const val espresso = "androidx.test.espresso:espresso-core:${Versions.espresso}"
     const val junit = "junit:junit:${Versions.junit}"
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:${Versions.junitJupiter}"
     const val junitJupiterEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitJupiter}"
@@ -119,7 +119,6 @@ object Libs {
     const val retrofitConverterMoshi = "com.squareup.retrofit2:converter-moshi:${Versions.retrofit}"
     const val robolectric = "org.robolectric:android-all:${Versions.robolectric}"
     const val snackengagePlayrate = "com.github.ligi.snackengage:snackengage-playrate:${Versions.snackengage}"
-    const val testExtJunit = "androidx.test.ext:junit:${Versions.testExtJunit}"
     const val threeTenBp = "org.threeten:threetenbp:${Versions.threeTenBp}"
     const val tracedroid = "com.github.ligi:tracedroid:${Versions.tracedroid}"
     const val truth = "com.google.truth:truth:${Versions.truth}"

--- a/commons-testing/build.gradle
+++ b/commons-testing/build.gradle
@@ -30,7 +30,7 @@ android {
 
 dependencies {
 
-    implementation Libs.junit
+    implementation Libs.junitJupiterApi
     implementation (Libs.kotlinCoroutinesTest) {
         // workaround for https://github.com/Kotlin/kotlinx.coroutines/issues/2023
         exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"

--- a/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/MainDispatcherTestExtension.kt
+++ b/commons-testing/src/main/java/info/metadude/android/eventfahrplan/commons/testing/MainDispatcherTestExtension.kt
@@ -6,28 +6,24 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.rules.TestWatcher
-import org.junit.runner.Description
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
 
 /**
  * Sets the given [dispatcher] as an underlying dispatcher of [Dispatchers.Main].
  * All consecutive usages of [Dispatchers.Main] will use the given [dispatcher] under the hood.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-class MainDispatcherTestRule(
-
+class MainDispatcherTestExtension(
     private val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : BeforeEachCallback, AfterEachCallback {
 
-) : TestWatcher() {
-
-    override fun starting(description: Description) {
-        super.starting(description)
+    override fun beforeEach(context: ExtensionContext?) {
         Dispatchers.setMain(dispatcher)
     }
 
-    override fun finished(description: Description) {
-        super.finished(description)
+    override fun afterEach(context: ExtensionContext?) {
         Dispatchers.resetMain()
     }
-
 }

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 
     testImplementation project(":commons-testing")
     testImplementation Libs.junit
+    testImplementation Libs.junitJupiterApi
+    testRuntimeOnly Libs.junitJupiterEngine
     testImplementation(Libs.assertjAndroid) {
         exclude group: "com.android.support", module: "support-annotations"
     }

--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -32,9 +32,9 @@ dependencies {
     api Libs.threeTenBp
 
     testImplementation project(":commons-testing")
-    testImplementation Libs.junit
     testImplementation Libs.junitJupiterApi
     testRuntimeOnly Libs.junitJupiterEngine
+    testImplementation Libs.junitJupiterParams
     testImplementation(Libs.assertjAndroid) {
         exclude group: "com.android.support", module: "support-annotations"
     }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensionsTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/extensions/StandardExtensionsTest.kt
@@ -1,7 +1,7 @@
 package info.metadude.android.eventfahrplan.commons.extensions
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class StandardExtensionsTest {
 

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterFormattedTime24HourTest.kt
@@ -3,9 +3,8 @@ package info.metadude.android.eventfahrplan.commons.temporal
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatterFormattedTime24HourTest.TestParameter.Companion.parse
 import info.metadude.android.eventfahrplan.commons.testing.withTimeZone
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.threeten.bp.ZoneOffset
 
 /**
@@ -19,25 +18,20 @@ import org.threeten.bp.ZoneOffset
  *
  * TODO: TechDebt: Once the app offers an option to render sessions in the device time zone this test must be adapted.
  */
-@RunWith(Parameterized::class)
-class DateFormatterFormattedTime24HourTest(
-
-    private val timeZoneId: String
-
-) {
+class DateFormatterFormattedTime24HourTest {
 
     companion object {
 
         private val timeZoneOffsets = -12..14
 
         @JvmStatic
-        @Parameterized.Parameters(name = "{index}: timeZoneId = {0}")
         fun data() = timeZoneOffsets.map { arrayOf("GMT$it") }
 
     }
 
-    @Test
-    fun `getFormattedTime24Hour 2021-03-27`() = testEach(listOf(
+    @ParameterizedTest(name = "{index}: timeZoneId = {0}")
+    @MethodSource("data")
+    fun `getFormattedTime24Hour 2021-03-27`(timeZoneId: String) = testEach(timeZoneId, listOf(
         "2021-03-27T00:01:00+01:00" to "00:01",
         "2021-03-27T01:00:00+01:00" to "01:00",
         "2021-03-27T02:00:00+01:00" to "02:00",
@@ -65,8 +59,9 @@ class DateFormatterFormattedTime24HourTest(
         "2021-03-27T23:59:00+01:00" to "23:59",
     ))
 
-    @Test
-    fun `getFormattedTime24Hour 2021-03-28`() = testEach(listOf(
+    @ParameterizedTest(name = "{index}: timeZoneId = {0}")
+    @MethodSource("data")
+    fun `getFormattedTime24Hour 2021-03-28`(timeZoneId: String) = testEach(timeZoneId, listOf(
         "2021-03-28T00:01:00+02:00" to "00:01",
         "2021-03-28T01:00:00+02:00" to "01:00",
         "2021-03-28T02:00:00+02:00" to "02:00", // TechDebt: Daylight saving time is ignored here.
@@ -94,7 +89,7 @@ class DateFormatterFormattedTime24HourTest(
         "2021-03-28T23:59:00+02:00" to "23:59",
     ))
 
-    private fun testEach(pairs: List<Pair<String, String>>) {
+    private fun testEach(timeZoneId: String, pairs: List<Pair<String, String>>) {
         pairs.forEach { (dateTime, expectedFormattedTime) ->
             val (moment, offset) = parse(dateTime)
             withTimeZone(timeZoneId) {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -1,9 +1,9 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.threeten.bp.OffsetDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
@@ -22,12 +22,12 @@ class DateFormatterTest {
     private val moment = Moment.parseDate("2019-01-22")
     private val timestamp = moment.toMilliseconds()
 
-    @Before
+    @BeforeEach
     fun resetTimeZone() {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
     }
 
-    @After
+    @AfterEach
     fun resetSystemDefaults() {
         Locale.setDefault(systemLocale)
         TimeZone.setDefault(systemTimezone)

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
@@ -1,8 +1,8 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import org.threeten.bp.DateTimeException
 import org.threeten.bp.format.DateTimeParseException
 

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -7,7 +7,7 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MIL
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MINUTES_OF_ONE_DAY
 import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.toMoment
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.threeten.bp.LocalDate
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -14,7 +14,8 @@ android {
     defaultConfig {
         minSdk Android.minSdkVersion
         targetSdk Android.targetSdkVersion
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArgument("runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder")
     }
 
     compileOptions {
@@ -25,6 +26,15 @@ android {
     kotlinOptions {
         jvmTarget = Config.compatibleJavaVersion
     }
+    packagingOptions {
+        resources {
+            excludes += [
+                    "META-INF/LICENSE.md",
+                    "META-INF/LICENSE-notice.md",
+            ]
+        }
+    }
+
 }
 
 dependencies {
@@ -36,6 +46,7 @@ dependencies {
     androidTestImplementation(Libs.assertjAndroid) {
         exclude group: "com.android.support", module: "support-annotations"
     }
-    androidTestImplementation Libs.espresso
-    androidTestImplementation Libs.testExtJunit
+    androidTestImplementation Libs.androidTestCore
+    androidTestRuntimeOnly Libs.androidTestRunner
+    androidTestImplementation Libs.junitJupiterApi
 }

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
@@ -1,6 +1,5 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
@@ -10,10 +9,8 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Al
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
 import info.metadude.android.eventfahrplan.database.models.Alarm
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
 class AlarmExtensionsTest {
 
     @Test

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
@@ -1,14 +1,11 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.HIGHLIGHT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.models.Highlight
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
 class HighlightExtensionsTest {
 
     @Test

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/MetaExtensionsTest.kt
@@ -1,6 +1,5 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SCHEDULE_LAST_MODIFIED
@@ -11,10 +10,8 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Me
 import info.metadude.android.eventfahrplan.database.models.HttpHeader
 import info.metadude.android.eventfahrplan.database.models.Meta
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
 class MetaExtensionsTest {
 
     @Test

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
@@ -1,6 +1,5 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ABSTRACT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_DURATION
@@ -39,10 +38,8 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.URL
 import info.metadude.android.eventfahrplan.database.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
 class SessionExtensionsTest {
 
     @Test

--- a/engelsystem/build.gradle
+++ b/engelsystem/build.gradle
@@ -11,7 +11,8 @@ dependencies {
         exclude group: "com.squareup.okio", module: "okio"
     }
 
-    testImplementation Libs.junit
+    testImplementation Libs.junitJupiterApi
+    testRuntimeOnly Libs.junitJupiterEngine
     testImplementation Libs.kotlinCoroutinesTest
     testImplementation Libs.mockitoCore
     testImplementation Libs.okhttpMockWebServer

--- a/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
+++ b/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/EngelsystemNetworkRepositoryTest.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
@@ -83,12 +83,12 @@ class EngelsystemNetworkRepositoryTest {
     private val okHttpClient = mock<OkHttpClient>()
     private val repository = createRepository()
 
-    @Before
+    @BeforeEach
     fun setUp() {
         mockWebServer.start()
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
         mockWebServer.shutdown()
     }

--- a/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/utils/UriParserTest.kt
+++ b/engelsystem/src/test/kotlin/info/metadude/android/eventfahrplan/engelsystem/utils/UriParserTest.kt
@@ -2,8 +2,8 @@ package info.metadude.android.eventfahrplan.engelsystem.utils
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.engelsystem.models.EngelsystemUri
-import org.junit.Assert.fail
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
 import java.net.URISyntaxException
 
 class UriParserTest {
@@ -71,7 +71,7 @@ class UriParserTest {
     }
 
     private fun failExpectingUriSyntaxException() {
-        fail("Expect a URISyntaxException to be thrown.")
+        fail<Unit>("Expect a URISyntaxException to be thrown.")
     }
 
     @Test

--- a/network/build.gradle
+++ b/network/build.gradle
@@ -32,7 +32,8 @@ dependencies {
     implementation Libs.annotation
     implementation Libs.okhttp
 
-    testImplementation Libs.junit
+    testImplementation Libs.junitJupiterApi
+    testRuntimeOnly Libs.junitJupiterEngine
     testImplementation(Libs.assertjAndroid) {
         exclude group: "com.android.support", module: "support-annotations"
     }

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DateParserTest.kt
@@ -1,7 +1,7 @@
 package info.metadude.android.eventfahrplan.network.temporal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DateParserTest {
 

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DurationParserTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/temporal/DurationParserTest.kt
@@ -1,7 +1,7 @@
 package info.metadude.android.eventfahrplan.network.temporal
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DurationParserTest {
     @Test

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidationTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidationTest.kt
@@ -4,7 +4,7 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import info.metadude.android.eventfahrplan.network.models.Session
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class DateFieldValidationTest {
 


### PR DESCRIPTION
# Description
- Migrate primitive unit tests.
- Migrate unit tests with `MainDispatcherTestRule` to `MainDispatcherTestExtension`.
- Migrate instrumentation tests utilizing `de.mannodermaus.junit5:android-test-*`.
- Migrate parameterized tests.
- Remove JUnit 4 dependencies from all modules.
- Remove unused `androidx.text.ext:junit` and `espresso-core` dependencies.

# Verification
- Verified number of tests before and after the migration match (aka. all are still executed).
- Verified JaCoCo test report still works.
- Verified GitHub action still collects unit test results.

# Related
- [mannodermaus/android-junit5: Question: Should I use this project?](https://github.com/mannodermaus/android-junit5/issues/236)