### PR TITLE
Continue to display parsing error when schedule data cannot be parsed.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -362,10 +362,10 @@ object AppRepository {
                 val parsingStatus = if (meta.numDays == 0) InitialParsing else Parsing
                 mutableLoadScheduleState.tryEmit(parsingStatus)
                 parseSchedule(
-                        fetchScheduleResult.scheduleXml,
-                        fetchScheduleResult.httpHeader,
-                        onParsingDone,
-                        onLoadingShiftsDone
+                    scheduleXml = fetchScheduleResult.scheduleXml,
+                    httpHeader = fetchScheduleResult.httpHeader,
+                    onParsingDone = onParsingDone,
+                    onLoadingShiftsDone = onLoadingShiftsDone
                 )
             } else if (fetchResult.isNotModified) {
                 loadShifts(onLoadingShiftsDone)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -391,9 +391,9 @@ object AppRepository {
                     val validMeta = meta.validate()
                     updateMeta(validMeta)
                 },
-                onParsingDone = { result: Boolean, version: String ->
-                    val parseResult = ParseScheduleResult(result, version)
-                    val parseScheduleStatus = if (result) ParseSuccess else ParseFailure(parseResult)
+                onParsingDone = { isSuccess: Boolean, version: String ->
+                    val parseResult = ParseScheduleResult(isSuccess, version)
+                    val parseScheduleStatus = if (isSuccess) ParseSuccess else ParseFailure(parseResult)
                     mutableLoadScheduleState.tryEmit(parseScheduleStatus)
                     onParsingDone(parseResult)
                     loadShifts(onLoadingShiftsDone)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -364,6 +364,7 @@ object AppRepository {
                 parseSchedule(
                     scheduleXml = fetchScheduleResult.scheduleXml,
                     httpHeader = fetchScheduleResult.httpHeader,
+                    oldMeta = meta,
                     onParsingDone = onParsingDone,
                     onLoadingShiftsDone = onLoadingShiftsDone
                 )
@@ -375,6 +376,7 @@ object AppRepository {
 
     private fun parseSchedule(scheduleXml: String,
                               httpHeader: HttpHeader,
+                              oldMeta: Meta,
                               onParsingDone: (parseScheduleResult: ParseResult) -> Unit,
                               onLoadingShiftsDone: (loadShiftsResult: LoadShiftsResult) -> Unit) {
         scheduleNetworkRepository.parseSchedule(scheduleXml, httpHeader,
@@ -392,6 +394,9 @@ object AppRepository {
                     updateMeta(validMeta)
                 },
                 onParsingDone = { isSuccess: Boolean, version: String ->
+                    if (!isSuccess) {
+                        updateMeta(oldMeta.copy(httpHeader = HttpHeader(eTag = "", lastModified = "")))
+                    }
                     val parseResult = ParseScheduleResult(isSuccess, version)
                     val parseScheduleStatus = if (isSuccess) ParseSuccess else ParseFailure(parseResult)
                     mutableLoadScheduleState.tryEmit(parseScheduleStatus)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -351,7 +351,7 @@ class AppRepositoryLoadAndParseScheduleTest {
             httpHeader: HttpHeader,
             onUpdateSessions: (sessions: List<NetworkSession>) -> Unit,
             onUpdateMeta: (meta: NetworkMeta) -> Unit,
-            onParsingDone: (result: Boolean, version: String) -> Unit
+            onParsingDone: (isSuccess: Boolean, version: String) -> Unit
         ) {
             this.onUpdateSessions = onUpdateSessions
             this.onUpdateMeta = onUpdateMeta

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -298,6 +298,29 @@ class AppRepositoryLoadAndParseScheduleTest {
             testableAppRepository.loadScheduleState.test {
                 assertThat(awaitItem()).isEqualTo(ParseFailure(ParseScheduleResult(false, "1.0.0")))
             }
+            // Reset ETag &b Last-Modified if parsing failed
+            verify(metaDatabaseRepository, times(2)).insert(any())
+        }
+
+    @Test
+    fun `loadScheduleState emits ParseFailure when initial parsing finished with an error`() =
+        runTest {
+            whenever(metaDatabaseRepository.query()) doReturn DatabaseMeta(numDays = 0)
+            val success = createFetchScheduleResult(NetworkHttpStatus.HTTP_OK)
+            val onParsingDone: OnParsingDone = { result ->
+                assertThat(result).isEqualTo(ParseScheduleResult(isSuccess = false, "1.0.0"))
+            }
+            testableAppRepository.loadSchedule(isUserRequest = false, onParsingDone = onParsingDone)
+            scheduleNetworkRepository.onFetchScheduleFinished(success)
+
+            // onParsingDone
+            whenever(sharedPreferencesRepository.getEngelsystemShiftsUrl()) doReturn EMPTY_ENGELSYSTEM_URL // early exit to bypass here
+            scheduleNetworkRepository.onParsingDone(false, "1.0.0")
+            testableAppRepository.loadScheduleState.test {
+                assertThat(awaitItem()).isEqualTo(ParseFailure(ParseScheduleResult(false, "1.0.0")))
+            }
+            // Reset ETag &b Last-Modified if parsing failed
+            verify(metaDatabaseRepository, times(2)).insert(any())
         }
 
     private fun createFetchScheduleResult(httpStatus: NetworkHttpStatus) =

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/RealScheduleNetworkRepository.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/RealScheduleNetworkRepository.kt
@@ -30,11 +30,11 @@ class RealScheduleNetworkRepository(
                                httpHeader: HttpHeader,
                                onUpdateSessions: (sessions: List<Session>) -> Unit,
                                onUpdateMeta: (meta: Meta) -> Unit,
-                               onParsingDone: (result: Boolean, version: String) -> Unit) {
+                               onParsingDone: (isSuccess: Boolean, version: String) -> Unit) {
         parser.setListener(object : FahrplanParser.OnParseCompleteListener {
             override fun onUpdateSessions(sessions: List<Session>) = onUpdateSessions.invoke(sessions)
             override fun onUpdateMeta(meta: Meta) = onUpdateMeta.invoke(meta)
-            override fun onParseDone(result: Boolean, version: String) = onParsingDone.invoke(result, version)
+            override fun onParseDone(isSuccess: Boolean, version: String) = onParsingDone.invoke(isSuccess, version)
         })
         parser.parse(scheduleXml, httpHeader)
     }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/ScheduleNetworkRepository.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/repositories/ScheduleNetworkRepository.kt
@@ -17,6 +17,6 @@ interface ScheduleNetworkRepository {
                       httpHeader: HttpHeader,
                       onUpdateSessions: (sessions: List<Session>) -> Unit,
                       onUpdateMeta: (meta: Meta) -> Unit,
-                      onParsingDone: (result: Boolean, version: String) -> Unit)
+                      onParsingDone: (isSuccess: Boolean, version: String) -> Unit)
 
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -33,7 +33,7 @@ public class FahrplanParser {
 
         void onUpdateMeta(@NonNull Meta meta);
 
-        void onParseDone(Boolean result, String version);
+        void onParseDone(Boolean isSuccess, String version);
     }
 
     @NonNull
@@ -80,7 +80,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
 
     private boolean completed;
 
-    private boolean result;
+    private boolean isSuccess;
 
     ParserTask(@NonNull Logging logging, FahrplanParser.OnParseCompleteListener listener) {
         this.logging = logging;
@@ -109,17 +109,17 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
     }
 
     private void notifyActivity() {
-        if (result) {
+        if (isSuccess) {
             listener.onUpdateMeta(meta);
             listener.onUpdateSessions(sessions);
         }
-        listener.onParseDone(result, meta.getVersion());
+        listener.onParseDone(isSuccess, meta.getVersion());
         completed = false;
     }
 
-    protected void onPostExecute(Boolean result) {
+    protected void onPostExecute(Boolean isSuccess) {
         completed = true;
-        this.result = result;
+        this.isSuccess = isSuccess;
 
         if (listener != null) {
             notifyActivity();


### PR DESCRIPTION
# Description
+ Previously, loading malformed schedule data would result in an error message shown once. Each subsequent failed load would not be shown as an error message, but as `Schedule is up to date`. This happened because the `ETag` or `Last-Modified` header from the HTTP response remained in the database.
+ Now the `ETag` and `Last-Modified` headers are cleared when the parsing fails.

# Initial installation: Before & after
Up to date message shown although loading fails
![parser-error-initial-missing](https://github.com/EventFahrplan/EventFahrplan/assets/144518/783f2281-b5db-461a-ac7f-d309daae8310)
Error message shown when parsing failed
![parser-error-initial](https://github.com/EventFahrplan/EventFahrplan/assets/144518/3eaaef53-1e97-433f-87c0-50957a8d557a)

# Schedule update with existing locally stored data: Before & after
Up to date message shown although loading fails
![parser-error-missing](https://github.com/EventFahrplan/EventFahrplan/assets/144518/8c4b8922-89ca-41b8-99f2-10c8f75a7837)
Error message shown when parsing failed
![parser-error-missings](https://github.com/EventFahrplan/EventFahrplan/assets/144518/8f3ce2dc-5685-4a0e-9606-fef8e77782b7)

# Successfully tested on
with `fossgis2024` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 13 (API 33)

# Related
+ https://github.com/pretalx/pretalx/issues/1685
