### PR TITLE
Speed up CI by not starting an emulator for unit tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,10 +17,7 @@ jobs:
         run: ./gradlew assembleCcc37c3
 
       - name: Unit Tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 21
-          script: ./gradlew testDebug :engelsystem:test testCcc37c3DebugUnitTest assembleCcc37c3Debug lintAnalyzeCcc37c3Debug
+        run: ./gradlew testDebug :engelsystem:test testCcc37c3DebugUnitTest assembleCcc37c3Debug lintAnalyzeCcc37c3Debug
 
       - name: Publish unit-test results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [ ] I have read the recent version of the [contribution guide](
  https://github.com/EventFahrplan/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [ ] I have checked a few other pull requests to see how they are written.
* [ ] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [ ] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [ ] I can help myself to get this feature implemented or know someone who wants to do it.

# Description
<!--
- Short summary of what you are trying to accomplish.
- Link to the associated issue if applicable.
- Link to an external bug tracker if applicable.
- Which device/emulator and Android version did you test on?
-->

# Before
![image](https://github.com/EventFahrplan/EventFahrplan/assets/2906988/0ca7ed74-c3a0-4cb9-a746-ff25403bbf3e)

# After
Not approved yet.
Estimated saving: 2.5 minutes per build.

Edit:

![image](https://github.com/EventFahrplan/EventFahrplan/assets/144518/2ebafcc9-3b84-4a27-a49c-8c6328c7c621)