### PR TITLE
Allow to customize the color of list items.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -71,6 +71,17 @@ class SessionDetailsFragment : Fragment() {
             }
         }
 
+        // Custom list items.
+        // Docs: https://noties.io/Markwon/docs/v4/core/theme.html#list
+        private fun createListItemsPlugin(context: Context) = object : AbstractMarkwonPlugin() {
+            override fun configureTheme(builder: MarkwonTheme.Builder) {
+                val itemColor = ContextCompat.getColor(context, R.color.session_details_list_item)
+                builder
+                    .bulletWidth(16)
+                    .listItemColor(itemColor)
+            }
+        }
+
         @JvmStatic
         fun replaceAtBackStack(fragmentManager: FragmentManager, @IdRes containerViewId: Int, sidePane: Boolean) {
             val fragment = SessionDetailsFragment().withArguments(
@@ -128,6 +139,7 @@ class SessionDetailsFragment : Fragment() {
         notificationHelper = NotificationHelper(context)
         markwon = Markwon.builder(requireContext())
             .usePlugin(HEADINGS_PLUGIN)
+            .usePlugin(createListItemsPlugin(context))
             .usePlugin(LinkifyPlugin.create())
             .build()
     }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -74,6 +74,7 @@
     <!-- Session details -->
     <color name="session_details_background">@color/session_background</color>
     <color name="session_details_text">@android:color/black</color>
+    <color name="session_details_list_item">@color/text_primary</color>
     <color name="session_detailbar_background">#eee</color>
     <color name="session_detailbar_text">#999</color>
     <color name="session_detailbar_icon">@color/colorAccent</color>


### PR DESCRIPTION
# Description
+ Allow to customize the color of list items.
+ Decrease overall bullet item size.

# Before & after
![bullets1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/e21153f3-8b02-49f4-a6da-dff18706aa28) ![bullets2](https://github.com/EventFahrplan/EventFahrplan/assets/144518/2a45ae92-3c29-426f-be4a-dbe0aaf5089d)

# Successfully tested on
with `fossgis2024` flavor, `debug` build
- :heavy_check_mark: Pixel 6 device, Android 14 (API 34)