### PR TITLE
Migrate Session class from Java to Kotlin (part 1)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -123,7 +123,7 @@ class AlarmServices @VisibleForTesting constructor(
         val alarmTimeInMin = alarmTimes[alarmTimesIndex]
         val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
         val timeText = formattingDelegate.getFormattedDateTimeShort(useDeviceTimeZone, alarmTime, session.timeZoneOffset)
-        val day = session.day
+        val day = session.dayIndex
         val alarm = Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText)
         val schedulableAlarm = alarm.toSchedulableAlarm()
         scheduleSessionAlarm(schedulableAlarm, true)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -108,7 +108,7 @@ internal class AlarmsViewModel(
                                 firesAt = alarm.startTime,
                                 firesAtText = firesAtText,
                                 firesAtContentDescription = firesAtContentDescription,
-                                dayIndex = found.day
+                                dayIndex = found.dayIndex
                             )
                         }
                 },

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -155,7 +155,7 @@ abstract class SessionsAdapter protected constructor(
         val daySeparator = context.getString(R.string.day_separator)
         for (index in list.indices) {
             val session = list[index]
-            day = session.day
+            day = session.dayIndex
             val formattedDate = DateFormatter.newInstance(useDeviceTimeZone)
                 .getFormattedDate(session.dateUTC, session.timeZoneOffset)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.calendar
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
@@ -15,6 +16,7 @@ import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 class CalendarDescriptionComposer(
 
     private val sessionOnlineText: String,
+    private val sessionPropertiesFormatter: SessionPropertiesFormatter = SessionPropertiesFormatter(),
     private val markdownConversion: MarkdownConversion = MarkdownConverter,
     private val sessionUrlComposition: SessionUrlComposition = SessionUrlComposer()
 
@@ -44,7 +46,7 @@ class CalendarDescriptionComposer(
     }
 
     private fun StringBuilder.appendSpeakers(session: Session) {
-        appendParagraphIfNotEmpty(session.formattedSpeakers)
+        appendParagraphIfNotEmpty(sessionPropertiesFormatter.getFormattedSpeakers(session))
     }
 
     private fun StringBuilder.appendAbstract(session: Session) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -11,6 +11,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class ChangeListAdapter internal constructor(
@@ -20,6 +21,7 @@ class ChangeListAdapter internal constructor(
         numDays: Int,
         useDeviceTimeZone: Boolean,
         private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+        private val contentDescriptionFormatter: ContentDescriptionFormatter,
 
 ) : SessionsAdapter(
 
@@ -52,26 +54,32 @@ class ChangeListAdapter internal constructor(
         with(viewHolder) {
             title.textOrHide = session.title
             subtitle.textOrHide = session.subtitle
-            subtitle.contentDescription = Session.getSubtitleContentDescription(subtitle.context, session.subtitle)
+            subtitle.contentDescription = contentDescriptionFormatter
+                .getSubtitleContentDescription(session.subtitle)
 
             val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
             speakers.textOrHide = speakerNames
-            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, speakerNames)
+            speakers.contentDescription = contentDescriptionFormatter
+                .getSpeakersContentDescription(session.speakers.size, speakerNames)
             val languageText = sessionPropertiesFormatter.getLanguageText(session)
             lang.textOrHide = languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, languageText)
+            lang.contentDescription = contentDescriptionFormatter
+                .getLanguageContentDescription(languageText)
 
             val dayText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(session.dateUTC, session.timeZoneOffset)
             day.textOrHide = dayText
             val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
-            time.contentDescription = Session.getStartTimeContentDescription(time.context, timeText)
+            time.contentDescription = contentDescriptionFormatter
+                .getStartTimeContentDescription(timeText)
 
             room.textOrHide = session.roomName
-            room.contentDescription = Session.getRoomNameContentDescription(room.context, session.roomName)
+            room.contentDescription = contentDescriptionFormatter
+                .getRoomNameContentDescription(session.roomName)
             val durationText = duration.context.getString(R.string.session_list_item_duration_text, session.duration)
             duration.textOrHide = durationText
-            duration.contentDescription = Session.getDurationContentDescription(duration.context, session.duration)
+            duration.contentDescription = contentDescriptionFormatter
+                .getDurationContentDescription(session.duration)
 
             video.isVisible = false
             noVideo.isVisible = false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -117,7 +117,7 @@ class ChangeListAdapter internal constructor(
                         lang.contentDescription = lang.context.getText(R.string.session_list_item_language_removed_content_description)
                     }
                 }
-                if (session.changedDay) {
+                if (session.changedDayIndex) {
                     day.setTextStyleChanged()
                 }
                 if (session.changedTime) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -11,13 +11,15 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class ChangeListAdapter internal constructor(
 
         context: Context,
         list: List<Session>,
         numDays: Int,
-        useDeviceTimeZone: Boolean
+        useDeviceTimeZone: Boolean,
+        private val sessionPropertiesFormatter: SessionPropertiesFormatter,
 
 ) : SessionsAdapter(
 
@@ -52,10 +54,12 @@ class ChangeListAdapter internal constructor(
             subtitle.textOrHide = session.subtitle
             subtitle.contentDescription = Session.getSubtitleContentDescription(subtitle.context, session.subtitle)
 
-            speakers.textOrHide = session.formattedSpeakers
-            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
-            lang.textOrHide = session.languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.languageText)
+            val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+            speakers.textOrHide = speakerNames
+            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, speakerNames)
+            val languageText = sessionPropertiesFormatter.getLanguageText(session)
+            lang.textOrHide = languageText
+            lang.contentDescription = Session.getLanguageContentDescription(lang.context, languageText)
 
             val dayText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedDate(session.dateUTC, session.timeZoneOffset)
             day.textOrHide = dayText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -120,7 +120,7 @@ class ChangeListAdapter internal constructor(
                 if (session.changedDayIndex) {
                     day.setTextStyleChanged()
                 }
-                if (session.changedTime) {
+                if (session.changedStartTime) {
                     time.setTextStyleChanged()
                 }
                 if (session.changedRoomName) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListAdapter.kt
@@ -112,7 +112,7 @@ class ChangeListAdapter internal constructor(
                 }
                 if (session.changedLanguage) {
                     lang.setTextStyleChanged()
-                    if (session.lang.isEmpty()) {
+                    if (session.language.isEmpty()) {
                         lang.text = lang.context.getText(R.string.dash)
                         lang.contentDescription = lang.context.getText(R.string.session_list_item_language_removed_content_description)
                     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -22,6 +22,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 /**
@@ -91,6 +92,7 @@ class ChangeListFragment : AbstractListFragment() {
                 numDays = numDays,
                 useDeviceTimeZone = useDeviceTimeZone,
                 sessionPropertiesFormatter = SessionPropertiesFormatter(),
+                contentDescriptionFormatter = ContentDescriptionFormatter(requireContext())
             )
             currentListView.adapter = adapter
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -22,6 +22,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 /**
  * A fragment representing a list of Items.
@@ -84,7 +85,13 @@ class ChangeListFragment : AbstractListFragment() {
 
     private fun observeViewModel() {
         viewModel.changeListParameter.observe(this) { (sessions, numDays, useDeviceTimeZone) ->
-            val adapter = ChangeListAdapter(requireContext(), sessions, numDays, useDeviceTimeZone)
+            val adapter = ChangeListAdapter(
+                context = requireContext(),
+                list = sessions,
+                numDays = numDays,
+                useDeviceTimeZone = useDeviceTimeZone,
+                sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            )
             currentListView.adapter = adapter
         }
         viewModel.scheduleChangesSeen.observe(viewLifecycleOwner) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -21,7 +21,7 @@ fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
 
 fun Session.toRoom() = Room(identifier = roomIdentifier, name = roomName)
 
-fun Session.toDateInfo(): DateInfo = DateInfo(dayIndex, Moment.parseDate(date))
+fun Session.toDateInfo(): DateInfo = DateInfo(dayIndex, Moment.parseDate(dateText))
 
 fun Session.toHighlightDatabaseModel() = HighlightDatabaseModel(
         sessionId = Integer.parseInt(sessionId),
@@ -31,7 +31,7 @@ fun Session.toHighlightDatabaseModel() = HighlightDatabaseModel(
 fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         sessionId = sessionId,
         abstractt = abstractt,
-        date = date,
+        date = dateText,
         dateUTC = dateUTC,
         dayIndex = dayIndex,
         description = description,
@@ -75,7 +75,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     val session = Session(sessionId)
 
     session.abstractt = abstractt
-    session.date = date
+    session.dateText = date
     session.dateUTC = dateUTC
     session.dayIndex = dayIndex
     session.description = description
@@ -121,7 +121,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     val session = Session(sessionId)
 
     session.abstractt = abstractt
-    session.date = date
+    session.dateText = date
     session.dateUTC = dateUTC
     session.dayIndex = dayIndex
     session.description = description

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -66,7 +66,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         changedRoomName = changedRoomName,
         changedSpeakers = changedSpeakers,
         changedSubtitle = changedSubtitle,
-        changedTime = changedTime,
+        changedTime = changedStartTime,
         changedTitle = changedTitle,
         changedTrack = changedTrack
 )
@@ -110,7 +110,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.changedRoomName = changedRoomName
     session.changedSpeakers = changedSpeakers
     session.changedSubtitle = changedSubtitle
-    session.changedTime = changedTime
+    session.changedStartTime = changedTime
     session.changedTitle = changedTitle
     session.changedTrack = changedTrack
 
@@ -156,7 +156,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.changedRoomName = changedRoomName
     session.changedSpeakers = changedSpeakers
     session.changedSubtitle = changedSubtitle
-    session.changedTime = changedStartTime
+    session.changedStartTime = changedStartTime
     session.changedTitle = changedTitle
     session.changedTrack = changedTrack
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -57,7 +57,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         type = type,
         url = url,
 
-        changedDay = changedDay,
+        changedDay = changedDayIndex,
         changedDuration = changedDuration,
         changedIsCanceled = changedIsCanceled,
         changedIsNew = changedIsNew,
@@ -101,7 +101,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.type = type
     session.url = url
 
-    session.changedDay = changedDay
+    session.changedDayIndex = changedDay
     session.changedDuration = changedDuration
     session.changedIsCanceled = changedIsCanceled
     session.changedIsNew = changedIsNew
@@ -147,7 +147,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.type = type
     session.url = url
 
-    session.changedDay = changedDayIndex
+    session.changedDayIndex = changedDayIndex
     session.changedDuration = changedDuration
     session.changedIsCanceled = changedIsCanceled
     session.changedIsNew = changedIsNew

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -13,7 +13,7 @@ import info.metadude.android.eventfahrplan.database.models.Session as SessionDat
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
 
 fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
-    if (day in dayIndices) {
+    if (dayIndex in dayIndices) {
         shiftRoomIndexBy(1)
     }
     return this
@@ -21,7 +21,7 @@ fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
 
 fun Session.toRoom() = Room(identifier = roomIdentifier, name = roomName)
 
-fun Session.toDateInfo(): DateInfo = DateInfo(day, Moment.parseDate(date))
+fun Session.toDateInfo(): DateInfo = DateInfo(dayIndex, Moment.parseDate(date))
 
 fun Session.toHighlightDatabaseModel() = HighlightDatabaseModel(
         sessionId = Integer.parseInt(sessionId),
@@ -33,7 +33,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         abstractt = abstractt,
         date = date,
         dateUTC = dateUTC,
-        dayIndex = day,
+        dayIndex = dayIndex,
         description = description,
         duration = duration, // minutes
         feedbackUrl = feedbackUrl,
@@ -77,7 +77,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.abstractt = abstractt
     session.date = date
     session.dateUTC = dateUTC
-    session.day = dayIndex
+    session.dayIndex = dayIndex
     session.description = description
     session.duration = duration // minutes
     session.feedbackUrl = feedbackUrl
@@ -123,7 +123,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.abstractt = abstractt
     session.date = date
     session.dateUTC = dateUTC
-    session.day = dayIndex
+    session.dayIndex = dayIndex
     session.description = description
     session.duration = duration // minutes
     session.feedbackUrl = feedbackUrl

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -38,7 +38,7 @@ fun Session.toSessionDatabaseModel() = SessionDatabaseModel(
         duration = duration, // minutes
         feedbackUrl = feedbackUrl,
         hasAlarm = hasAlarm,
-        language = lang,
+        language = language,
         links = links,
         isHighlight = highlight,
         recordingLicense = recordingLicense,
@@ -82,7 +82,7 @@ fun SessionDatabaseModel.toSessionAppModel(): Session {
     session.duration = duration // minutes
     session.feedbackUrl = feedbackUrl
     session.hasAlarm = hasAlarm
-    session.lang = language
+    session.language = language
     session.links = links
     session.highlight = isHighlight
     session.recordingLicense = recordingLicense
@@ -128,7 +128,7 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     session.duration = duration // minutes
     session.feedbackUrl = feedbackUrl
     session.hasAlarm = hasAlarm
-    session.lang = language
+    session.language = language
     session.links = links
     session.highlight = isHighlight
     session.recordingLicense = recordingLicense
@@ -181,8 +181,8 @@ fun Session.sanitize(): Session {
         description = abstractt
         abstractt = ""
     }
-    if (!lang.isNullOrEmpty()) {
-        lang = lang.lowercase()
+    if (!language.isNullOrEmpty()) {
+        language = language.lowercase()
     }
     if (("Sendezentrum-Bühne" == track || "Sendezentrum Bühne" == track || "xHain Berlin" == track) && !type.isNullOrEmpty()) {
         track = type

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -13,7 +13,7 @@ import info.metadude.android.eventfahrplan.database.models.Session as SessionDat
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
 
 fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
-    if (dayIndices.contains(day)) {
+    if (day in dayIndices) {
         shiftRoomIndexBy(1)
     }
     return this

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
@@ -20,12 +20,12 @@ fun List<Session>.toDayIndices(): Set<Int> {
 }
 
 /**
- * Splits the given sessions into [VirtualDay]s. The [Session.date] field is used to separate them.
+ * Splits the given sessions into [VirtualDay]s. The [Session.dateText] field is used to separate them.
  * This field is unique for a virtual day, even for sessions after midnight.
  */
 fun List<Session>.toVirtualDays(): List<VirtualDay> {
     var index = 0
-    return groupBy { it.date }
+    return groupBy { it.dateText }
         .map { (_, sessions) ->
             val sorted = sessions.sortedBy { it.dateUTC }
             VirtualDay(++index, sorted)
@@ -39,7 +39,7 @@ fun List<Session>.toSessionsDatabaseModel() = map(Session::toSessionDatabaseMode
 fun List<Session>.toDayRanges(): List<DayRange> {
     val ranges = mutableSetOf<DayRange>()
     forEach {
-        val day = Moment.parseDate(it.date)
+        val day = Moment.parseDate(it.dateText)
         val dayRange = DayRange(day)
         ranges.add(dayRange)
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
@@ -14,7 +14,7 @@ fun List<Session>.shiftRoomIndicesOfMainSchedule(dayIndices: Set<Int>) = map {
 fun List<Session>.toDayIndices(): Set<Int> {
     val dayIndices = HashSet<Int>()
     forEach {
-        dayIndices.add(it.day)
+        dayIndices.add(it.dayIndex)
     }
     return dayIndices
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -22,7 +22,7 @@ fun Shift.toSessionAppModel(
 
 ) = Session("${SHIFT_ID_OFFSET + sID}").apply {
     abstractt = ""
-    date = startsAtLocalDateString
+    dateText = startsAtLocalDateString
     dateUTC = dateUtcMs
     dayIndex = oneBasedDayIndex(logging, dayRanges)
     description = descriptionText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -24,7 +24,7 @@ fun Shift.toSessionAppModel(
     abstractt = ""
     date = startsAtLocalDateString
     dateUTC = dateUtcMs
-    day = oneBasedDayIndex(logging, dayRanges)
+    dayIndex = oneBasedDayIndex(logging, dayRanges)
     description = descriptionText
     duration = shiftDuration // minutes
     relStartTime = minuteOfDay

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -46,11 +46,11 @@ import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.startActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
-import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -112,6 +112,7 @@ class SessionDetailsFragment : Fragment() {
         )
     }
     private lateinit var model: SelectedSessionParameter
+    private lateinit var contentDescriptionFormatter: ContentDescriptionFormatter
     private lateinit var markwon: Markwon
     private var sidePane = false
     private var hasArguments = false
@@ -137,7 +138,8 @@ class SessionDetailsFragment : Fragment() {
         appRepository = AppRepository
         alarmServices = AlarmServices.newInstance(context, appRepository)
         notificationHelper = NotificationHelper(context)
-        markwon = Markwon.builder(requireContext())
+        contentDescriptionFormatter = ContentDescriptionFormatter(context)
+        markwon = Markwon.builder(context)
             .usePlugin(HEADINGS_PLUGIN)
             .usePlugin(createListItemsPlugin(context))
             .usePlugin(LinkifyPlugin.create())
@@ -261,12 +263,14 @@ class SessionDetailsFragment : Fragment() {
         var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
         textView.text = if (model.hasDateUtc) model.formattedZonedDateTimeShort else ""
         if (model.hasDateUtc) {
-            textView.contentDescription = Session.getStartTimeContentDescription(textView.context, model.formattedZonedDateTimeLong)
+            textView.contentDescription = contentDescriptionFormatter
+                .getStartTimeContentDescription(model.formattedZonedDateTimeLong)
         }
 
         textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
         textView.text = model.roomName
-        textView.contentDescription = Session.getRoomNameContentDescription(textView.context, model.roomName)
+        textView.contentDescription = contentDescriptionFormatter
+            .getRoomNameContentDescription(model.roomName)
         textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
         textView.text = if (model.sessionId.isEmpty()) "" else textView.context.getString(R.string.session_details_session_id, model.sessionId)
 
@@ -281,7 +285,8 @@ class SessionDetailsFragment : Fragment() {
             textView.isVisible = false
         } else {
             typeface = typefaceFactory.getTypeface(viewModel.subtitleFont)
-            textView.applyText(typeface, model.subtitle, Session.getSubtitleContentDescription(textView.context, model.subtitle))
+            textView.applyText(typeface, model.subtitle, contentDescriptionFormatter
+                .getSubtitleContentDescription(model.subtitle))
         }
 
         // Speakers
@@ -290,7 +295,8 @@ class SessionDetailsFragment : Fragment() {
             textView.isVisible = false
         } else {
             typeface = typefaceFactory.getTypeface(viewModel.speakersFont)
-            val speakerNamesContentDescription = Session.getSpeakersContentDescription(textView.context, model.speakersCount, model.speakerNames)
+            val speakerNamesContentDescription = contentDescriptionFormatter
+                .getSpeakersContentDescription(model.speakersCount, model.speakerNames)
             textView.applyText(typeface, model.speakerNames, speakerNamesContentDescription)
         }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -27,6 +27,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 import org.threeten.bp.ZoneOffset
@@ -38,6 +39,7 @@ internal class SessionDetailsViewModel(
     alarmServices: AlarmServices,
     notificationHelper: NotificationHelper,
     private val sessionFormatter: SessionFormatter,
+    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
     private val feedbackUrlComposer: FeedbackUrlComposer,
@@ -152,7 +154,7 @@ internal class SessionDetailsViewModel(
             formattedZonedDateTimeLong = formattedZonedDateTimeLong,
             title = title.orEmpty(),
             subtitle = subtitle.orEmpty(),
-            speakerNames = formattedSpeakers,
+            speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(this),
             speakersCount = speakers.size,
             abstract = abstractt.orEmpty(),
             formattedAbstract = formattedAbstract,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -13,6 +13,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 
 internal class SessionDetailsViewModelFactory(
@@ -33,6 +34,7 @@ internal class SessionDetailsViewModelFactory(
             alarmServices = alarmServices,
             notificationHelper = notificationHelper,
             sessionFormatter = SessionFormatter(),
+            sessionPropertiesFormatter = SessionPropertiesFormatter(),
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),
             feedbackUrlComposer = FeedbackUrlComposer(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -11,6 +11,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class StarredListAdapter internal constructor(
@@ -20,6 +21,7 @@ class StarredListAdapter internal constructor(
         numDays: Int,
         useDeviceTimeZone: Boolean,
         private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+        private val contentDescriptionFormatter: ContentDescriptionFormatter,
 
 ) : SessionsAdapter(
 
@@ -53,25 +55,31 @@ class StarredListAdapter internal constructor(
 
             title.textOrHide = session.title
             subtitle.textOrHide = session.subtitle
-            subtitle.contentDescription = Session.getSubtitleContentDescription(subtitle.context, session.subtitle)
+            subtitle.contentDescription = contentDescriptionFormatter
+                .getSubtitleContentDescription(session.subtitle)
 
             val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
             speakers.textOrHide = speakerNames
-            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, speakerNames)
+            speakers.contentDescription = contentDescriptionFormatter
+                .getSpeakersContentDescription(session.speakers.size, speakerNames)
             val languageText = sessionPropertiesFormatter.getLanguageText(session)
             lang.textOrHide = languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, languageText)
+            lang.contentDescription = contentDescriptionFormatter
+                .getLanguageContentDescription(languageText)
 
             day.isVisible = false
             val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
-            time.contentDescription = Session.getStartTimeContentDescription(time.context, timeText)
+            time.contentDescription = contentDescriptionFormatter
+                .getStartTimeContentDescription(timeText)
 
             room.textOrHide = session.roomName
-            room.contentDescription = Session.getRoomNameContentDescription(room.context, session.roomName)
+            room.contentDescription = contentDescriptionFormatter
+                .getRoomNameContentDescription(session.roomName)
             val durationText = duration.context.getString(R.string.session_list_item_duration_text, session.duration)
             duration.textOrHide = durationText
-            duration.contentDescription = Session.getDurationContentDescription(duration.context, session.duration)
+            duration.contentDescription = contentDescriptionFormatter
+                .getDurationContentDescription(session.duration)
 
             video.isVisible = false
             noVideo.isVisible = false

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -11,13 +11,15 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class StarredListAdapter internal constructor(
 
         context: Context,
         list: List<Session>,
         numDays: Int,
-        useDeviceTimeZone: Boolean
+        useDeviceTimeZone: Boolean,
+        private val sessionPropertiesFormatter: SessionPropertiesFormatter,
 
 ) : SessionsAdapter(
 
@@ -53,10 +55,12 @@ class StarredListAdapter internal constructor(
             subtitle.textOrHide = session.subtitle
             subtitle.contentDescription = Session.getSubtitleContentDescription(subtitle.context, session.subtitle)
 
-            speakers.textOrHide = session.formattedSpeakers
-            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, session.formattedSpeakers)
-            lang.textOrHide = session.languageText
-            lang.contentDescription = Session.getLanguageContentDescription(lang.context, session.languageText)
+            val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+            speakers.textOrHide = speakerNames
+            speakers.contentDescription = Session.getSpeakersContentDescription(speakers.context, session.speakers.size, speakerNames)
+            val languageText = sessionPropertiesFormatter.getLanguageText(session)
+            lang.textOrHide = languageText
+            lang.contentDescription = Session.getLanguageContentDescription(lang.context, languageText)
 
             day.isVisible = false
             val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -36,6 +36,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper.navigateUp
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 /**
@@ -139,6 +140,7 @@ class StarredListFragment :
                 numDays = numDays,
                 useDeviceTimeZone = useDeviceTimeZone,
                 sessionPropertiesFormatter = SessionPropertiesFormatter(),
+                contentDescriptionFormatter = ContentDescriptionFormatter(activity),
             )
             currentListView.adapter = adapter
             activity.invalidateOptionsMenu()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -169,7 +169,7 @@ class StarredListFragment :
         while (i < starredList.size) {
             val session = starredList[i]
             if (session.endsAt.isAfter(now)) {
-                numSeparators = session.day
+                numSeparators = session.dayIndex
                 break
             }
             i++

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -36,6 +36,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper.navigateUp
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 /**
  * A fragment representing a list of Items.
@@ -132,7 +133,13 @@ class StarredListFragment :
         viewModel.starredListParameter.observe(this) { (sessions, numDays, useDeviceTimeZone) ->
             starredList = sessions
             val activity = requireActivity()
-            val adapter = StarredListAdapter(activity, sessions, numDays, useDeviceTimeZone)
+            val adapter = StarredListAdapter(
+                context = activity,
+                list = sessions,
+                numDays = numDays,
+                useDeviceTimeZone = useDeviceTimeZone,
+                sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            )
             currentListView.adapter = adapter
             activity.invalidateOptionsMenu()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -75,7 +75,7 @@ public class Session {
     public boolean changedSubtitle;
     public boolean changedRoomName;
     public boolean changedDayIndex;
-    public boolean changedTime;
+    public boolean changedStartTime;
     public boolean changedDuration;
     public boolean changedSpeakers;
     public boolean changedRecordingOptOut;
@@ -123,7 +123,7 @@ public class Session {
         changedLanguage = false;
         changedTrack = false;
         changedIsNew = false;
-        changedTime = false;
+        changedStartTime = false;
         changedDuration = false;
         changedIsCanceled = false;
     }
@@ -161,7 +161,7 @@ public class Session {
         this.changedSubtitle = session.changedSubtitle;
         this.changedRoomName = session.changedRoomName;
         this.changedDayIndex = session.changedDayIndex;
-        this.changedTime = session.changedTime;
+        this.changedStartTime = session.changedStartTime;
         this.changedDuration = session.changedDuration;
         this.changedSpeakers = session.changedSpeakers;
         this.changedRecordingOptOut = session.changedRecordingOptOut;
@@ -261,7 +261,7 @@ public class Session {
         changedLanguage = false;
         changedTrack = false;
         changedIsNew = false;
-        changedTime = false;
+        changedStartTime = false;
         changedDuration = false;
     }
 
@@ -270,7 +270,7 @@ public class Session {
         return changedDayIndex || changedDuration ||
                 changedLanguage || changedRecordingOptOut ||
                 changedRoomName || changedSpeakers || changedSubtitle ||
-                changedTime || changedTitle || changedTrack;
+                changedStartTime || changedTitle || changedTrack;
     }
 
     @NonNull

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -3,9 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.models;
 import static java.util.Collections.emptyList;
 import static info.metadude.android.eventfahrplan.commons.temporal.Moment.MILLISECONDS_OF_ONE_MINUTE;
 
-import android.content.Context;
-import android.text.TextUtils;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.util.ObjectsCompat;
@@ -14,10 +11,8 @@ import org.threeten.bp.ZoneOffset;
 
 import java.util.List;
 
-import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter;
 import info.metadude.android.eventfahrplan.commons.temporal.Moment;
 import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser;
-import nerd.tuxmobil.fahrplan.congress.R;
 import nerd.tuxmobil.fahrplan.congress.repositories.SessionsTransformer;
 import nerd.tuxmobil.fahrplan.congress.schedule.Conference;
 
@@ -271,83 +266,6 @@ public class Session {
                 changedLanguage || changedRecordingOptOut ||
                 changedRoomName || changedSpeakers || changedSubtitle ||
                 changedStartTime || changedTitle || changedTrack;
-    }
-
-    @NonNull
-    public static String getDurationContentDescription(@NonNull Context context, int duration) {
-        return context.getString(R.string.session_list_item_duration_content_description, duration);
-    }
-
-    @NonNull
-    public static String getTitleContentDescription(@NonNull Context context, @NonNull String title) {
-        return TextUtils.isEmpty(title) ? "" : context.getString(R.string.session_list_item_title_content_description, title);
-    }
-
-    @NonNull
-    public static String getSubtitleContentDescription(@NonNull Context context, @NonNull String subtitle) {
-        return TextUtils.isEmpty(subtitle) ? "" : context.getString(R.string.session_list_item_subtitle_content_description, subtitle);
-    }
-
-    @NonNull
-    public static String getRoomNameContentDescription(@NonNull Context context, @NonNull String roomName) {
-        return context.getString(R.string.session_list_item_room_content_description, roomName);
-    }
-
-    @NonNull
-    public static String getSpeakersContentDescription(@NonNull Context context, int speakersCount, @NonNull String formattedSpeakerNames) {
-        return context.getResources().getQuantityString(R.plurals.session_list_item_speakers_content_description, speakersCount, formattedSpeakerNames);
-    }
-
-    @NonNull
-    public static String getFormattedTrackContentDescription(@NonNull Context context, @NonNull String trackName, @NonNull String languageCode) {
-        StringBuilder builder = new StringBuilder();
-        builder.append(context.getString(R.string.session_list_item_track_content_description, trackName));
-        if (!TextUtils.isEmpty(languageCode)) {
-            builder.append("; ").append(getLanguageContentDescription(context, languageCode));
-        }
-        return builder.toString();
-    }
-
-    @NonNull
-    public static String getLanguageContentDescription(@NonNull Context context, @NonNull String languageCode) {
-        if (TextUtils.isEmpty(languageCode)) {
-            return context.getString(R.string.session_list_item_language_unknown_content_description);
-        }
-        String languageName;
-        switch (languageCode) {
-            case "en":
-                languageName = context.getString(R.string.session_list_item_language_english_content_description);
-                break;
-            case "de":
-                languageName = context.getString(R.string.session_list_item_language_german_content_description);
-                break;
-            case "pt":
-                languageName = context.getString(R.string.session_list_item_language_portuguese_content_description);
-                break;
-            default:
-                languageName = languageCode;
-        }
-        return context.getString(R.string.session_list_item_language_content_description, languageName);
-    }
-
-    @NonNull
-    public static String getStartTimeContentDescription(@NonNull Context context, @NonNull String startTimeText) {
-        return context.getString(R.string.session_list_item_start_time_content_description, startTimeText);
-    }
-
-    @NonNull
-    public static String getHighlightContentDescription(@NonNull Context context, boolean isHighlighted) {
-        int stringResource = isHighlighted ? R.string.session_list_item_favored_content_description : R.string.session_list_item_not_favored_content_description;
-        return context.getString(stringResource);
-    }
-
-    @NonNull
-    public static String getStateContentDescription(@NonNull Context context, @NonNull Session session, Boolean useDeviceTimeZone) {
-        String roomNameContentDescription = getRoomNameContentDescription(context, session.roomName);
-        String startsAtText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset);
-        String startsAtContentDescription = getStartTimeContentDescription(context, startsAtText);
-        String isHighlightContentDescription = getHighlightContentDescription(context, session.highlight);
-        return isHighlightContentDescription + ", " + startsAtContentDescription + ", " + roomNameContentDescription;
     }
 
     public void shiftRoomIndexBy(int amount) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -74,7 +74,7 @@ public class Session {
     public boolean changedTitle;
     public boolean changedSubtitle;
     public boolean changedRoomName;
-    public boolean changedDay;
+    public boolean changedDayIndex;
     public boolean changedTime;
     public boolean changedDuration;
     public boolean changedSpeakers;
@@ -117,7 +117,7 @@ public class Session {
         changedTitle = false;
         changedSubtitle = false;
         changedRoomName = false;
-        changedDay = false;
+        changedDayIndex = false;
         changedSpeakers = false;
         changedRecordingOptOut = false;
         changedLanguage = false;
@@ -160,7 +160,7 @@ public class Session {
         this.changedTitle = session.changedTitle;
         this.changedSubtitle = session.changedSubtitle;
         this.changedRoomName = session.changedRoomName;
-        this.changedDay = session.changedDay;
+        this.changedDayIndex = session.changedDayIndex;
         this.changedTime = session.changedTime;
         this.changedDuration = session.changedDuration;
         this.changedSpeakers = session.changedSpeakers;
@@ -255,7 +255,7 @@ public class Session {
         changedTitle = false;
         changedSubtitle = false;
         changedRoomName = false;
-        changedDay = false;
+        changedDayIndex = false;
         changedSpeakers = false;
         changedRecordingOptOut = false;
         changedLanguage = false;
@@ -267,7 +267,7 @@ public class Session {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isChanged() {
-        return changedDay || changedDuration ||
+        return changedDayIndex || changedDuration ||
                 changedLanguage || changedRecordingOptOut ||
                 changedRoomName || changedSpeakers || changedSubtitle ||
                 changedTime || changedTitle || changedTrack;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -265,23 +265,6 @@ public class Session {
         changedDuration = false;
     }
 
-    public String getChangedStateString() {
-        return "Session{" +
-                "changedTitle=" + changedTitle +
-                ", changedSubtitle=" + changedSubtitle +
-                ", changedRoomName=" + changedRoomName +
-                ", changedDay=" + changedDay +
-                ", changedTime=" + changedTime +
-                ", changedDuration=" + changedDuration +
-                ", changedSpeakers=" + changedSpeakers +
-                ", changedRecordingOptOut=" + changedRecordingOptOut +
-                ", changedLanguage=" + changedLanguage +
-                ", changedTrack=" + changedTrack +
-                ", changedIsNew=" + changedIsNew +
-                ", changedIsCanceled=" + changedIsCanceled +
-                '}';
-    }
-
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isChanged() {
         return changedDay || changedDuration ||

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -55,7 +55,7 @@ public class Session {
     public String track;
     public String sessionId;
     public String type;
-    public String lang;
+    public String language;
     public String slug;
     public String abstractt;
     public String description;
@@ -100,7 +100,7 @@ public class Session {
         speakers = emptyList();
         track = "";
         type = "";
-        lang = "";
+        language = "";
         abstractt = "";
         description = "";
         relStartTime = 0;
@@ -147,7 +147,7 @@ public class Session {
         this.track = session.track;
         this.sessionId = session.sessionId;
         this.type = session.type;
-        this.lang = session.lang;
+        this.language = session.language;
         this.slug = session.slug;
         this.abstractt = session.abstractt;
         this.description = session.description;
@@ -211,7 +211,7 @@ public class Session {
         if (recordingOptOut != session.recordingOptOut) return false;
         if (startTime != session.startTime) return false;
         if (!ObjectsCompat.equals(date, session.date)) return false;
-        if (!ObjectsCompat.equals(lang, session.lang)) return false;
+        if (!ObjectsCompat.equals(language, session.language)) return false;
         if (!sessionId.equals(session.sessionId)) return false;
         if (!ObjectsCompat.equals(recordingLicense, session.recordingLicense)) return false;
         if (!ObjectsCompat.equals(roomName, session.roomName)) return false;
@@ -241,7 +241,7 @@ public class Session {
         result = 31 * result + ObjectsCompat.hashCode(track);
         result = 31 * result + sessionId.hashCode();
         result = 31 * result + ObjectsCompat.hashCode(type);
-        result = 31 * result + ObjectsCompat.hashCode(lang);
+        result = 31 * result + ObjectsCompat.hashCode(language);
         result = 31 * result + ObjectsCompat.hashCode(date);
         result = 31 * result + ObjectsCompat.hashCode(recordingLicense);
         result = 31 * result + (recordingOptOut ? 1 : 0);
@@ -295,10 +295,10 @@ public class Session {
 
     @NonNull
     public String getLanguageText() {
-        if (TextUtils.isEmpty(lang)) {
+        if (TextUtils.isEmpty(language)) {
             return "";
         } else {
-            return lang
+            return language
                     .replace("-formal", "")
                     .replace("German", "de")
                     .replace("german", "de")
@@ -315,7 +315,7 @@ public class Session {
     public String getFormattedTrackLanguageText() {
         StringBuilder builder = new StringBuilder();
         builder.append(track);
-        if (!TextUtils.isEmpty(lang)) {
+        if (!TextUtils.isEmpty(language)) {
             String language = getLanguageText();
             builder.append(" [").append(language).append("]");
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -32,7 +32,7 @@ public class Session {
     public String feedbackUrl;          // URL to Frab/Pretalx feedback system, e.g. feedbackUrl = "https://talks.event.net/2023/talk/V8LUNA/feedback"
     public String url;
     public int dayIndex;                // XML values start with 1
-    public String date;                 // YYYY-MM-DD
+    public String dateText;             // YYYY-MM-DD
     public long dateUTC;                // milliseconds
     @Nullable
     public ZoneOffset timeZoneOffset;
@@ -105,7 +105,7 @@ public class Session {
         description = "";
         relStartTime = 0;
         links = "";
-        date = "";
+        dateText = "";
         this.sessionId = sessionId;
         highlight = false;
         hasAlarm = false;
@@ -134,7 +134,7 @@ public class Session {
         this.feedbackUrl = session.feedbackUrl;
         this.url = session.url;
         this.dayIndex = session.dayIndex;
-        this.date = session.date;
+        this.dateText = session.dateText;
         this.dateUTC = session.dateUTC;
         this.timeZoneOffset = session.timeZoneOffset;
         this.startTime = session.startTime;
@@ -210,7 +210,7 @@ public class Session {
         if (duration != session.duration) return false;
         if (recordingOptOut != session.recordingOptOut) return false;
         if (startTime != session.startTime) return false;
-        if (!ObjectsCompat.equals(date, session.date)) return false;
+        if (!ObjectsCompat.equals(dateText, session.dateText)) return false;
         if (!ObjectsCompat.equals(language, session.language)) return false;
         if (!sessionId.equals(session.sessionId)) return false;
         if (!ObjectsCompat.equals(recordingLicense, session.recordingLicense)) return false;
@@ -242,7 +242,7 @@ public class Session {
         result = 31 * result + sessionId.hashCode();
         result = 31 * result + ObjectsCompat.hashCode(type);
         result = 31 * result + ObjectsCompat.hashCode(language);
-        result = 31 * result + ObjectsCompat.hashCode(date);
+        result = 31 * result + ObjectsCompat.hashCode(dateText);
         result = 31 * result + ObjectsCompat.hashCode(recordingLicense);
         result = 31 * result + (recordingOptOut ? 1 : 0);
         result = 31 * result + (int) dateUTC;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -289,40 +289,6 @@ public class Session {
     }
 
     @NonNull
-    public String getFormattedSpeakers() {
-        return speakers == null ? "" : TextUtils.join(", ", speakers);
-    }
-
-    @NonNull
-    public String getLanguageText() {
-        if (TextUtils.isEmpty(language)) {
-            return "";
-        } else {
-            return language
-                    .replace("-formal", "")
-                    .replace("German", "de")
-                    .replace("german", "de")
-                    .replace("Deutsch", "de")
-                    .replace("deutsch", "de")
-                    .replace("English", "en")
-                    .replace("english", "en")
-                    .replace("Englisch", "en")
-                    .replace("englisch", "en")
-                    ;
-        }
-    }
-
-    public String getFormattedTrackLanguageText() {
-        StringBuilder builder = new StringBuilder();
-        builder.append(track);
-        if (!TextUtils.isEmpty(language)) {
-            String language = getLanguageText();
-            builder.append(" [").append(language).append("]");
-        }
-        return builder.toString();
-    }
-
-    @NonNull
     public static String getRoomNameContentDescription(@NonNull Context context, @NonNull String roomName) {
         return context.getString(R.string.session_list_item_room_content_description, roomName);
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -31,7 +31,7 @@ public class Session {
     @Nullable
     public String feedbackUrl;          // URL to Frab/Pretalx feedback system, e.g. feedbackUrl = "https://talks.event.net/2023/talk/V8LUNA/feedback"
     public String url;
-    public int day;                     // XML values start with 1
+    public int dayIndex;                // XML values start with 1
     public String date;                 // YYYY-MM-DD
     public long dateUTC;                // milliseconds
     @Nullable
@@ -91,7 +91,7 @@ public class Session {
         subtitle = "";
         feedbackUrl = null;
         url = "";
-        day = 0;
+        dayIndex = 0;
         roomName = "";
         roomIdentifier = "";
         slug = "";
@@ -133,7 +133,7 @@ public class Session {
         this.subtitle = session.subtitle;
         this.feedbackUrl = session.feedbackUrl;
         this.url = session.url;
-        this.day = session.day;
+        this.dayIndex = session.dayIndex;
         this.date = session.date;
         this.dateUTC = session.dateUTC;
         this.timeZoneOffset = session.timeZoneOffset;
@@ -206,7 +206,7 @@ public class Session {
         Session session = (Session) o;
 
         if (!ObjectsCompat.equals(feedbackUrl, session.feedbackUrl)) return false;
-        if (day != session.day) return false;
+        if (dayIndex != session.dayIndex) return false;
         if (duration != session.duration) return false;
         if (recordingOptOut != session.recordingOptOut) return false;
         if (startTime != session.startTime) return false;
@@ -232,7 +232,7 @@ public class Session {
         int result = title.hashCode();
         result = 31 * result + ObjectsCompat.hashCode(subtitle);
         result = 31 * result + ObjectsCompat.hashCode(feedbackUrl);
-        result = 31 * result + day;
+        result = 31 * result + dayIndex;
         result = 31 * result + ObjectsCompat.hashCode(roomName);
         result = 31 * result + ObjectsCompat.hashCode(roomIdentifier);
         result = 31 * result + startTime;

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -585,7 +585,7 @@ object AppRepository {
      * To exclude Engelsystem shifts pass false to [includeEngelsystemShifts].
      */
     private fun loadSessionsForDayIndex(dayIndex: Int, includeEngelsystemShifts: Boolean): List<Session> {
-        var sessions = if (dayIndex == ALL_DAYS) {
+        val sessions = if (dayIndex == ALL_DAYS) {
             logging.d(LOG_TAG, "Loading sessions for all days.")
             if (includeEngelsystemShifts) {
                 readSessionsOrderedByDateUtc()
@@ -598,24 +598,30 @@ object AppRepository {
         }
         logging.d(LOG_TAG, "Got ${sessions.size} rows.")
 
-        val highlights = readHighlights()
-        for (highlight in highlights) {
-            logging.d(LOG_TAG, "$highlight")
-            sessions = sessions.map { session ->
-                if (session.sessionId == "${highlight.sessionId}") {
-                    Session(session).apply { this.highlight = highlight.isHighlight }
-                } else {
-                    session
-                }
+        val highlightedSessionIds = readHighlights()
+            .asSequence()
+            .filter { it.isHighlight }
+            .map { it.sessionId.toString() }
+            .toSet()
+
+        val highlightedSessions = sessions.map { session ->
+            if (session.sessionId in highlightedSessionIds) {
+                Session(session).apply { highlight = true }
+            } else {
+                session
             }
         }
 
         val alarmSessionIds = readAlarmSessionIds()
-        sessions = sessions.map { session ->
-            Session(session).apply { this.hasAlarm = session.sessionId in alarmSessionIds }
+        val sessionsWithAlarms = highlightedSessions.map { session ->
+            if (session.sessionId in alarmSessionIds) {
+                Session(session).apply { hasAlarm = true }
+            } else {
+                session
+            }
         }
 
-        return sessions.toList()
+        return sessionsWithAlarms
     }
 
     @WorkerThread
@@ -681,19 +687,26 @@ object AppRepository {
     }
 
     private fun readSessionBySessionId(sessionId: String): Session {
-        var session = sessionsDatabaseRepository.querySessionBySessionId(sessionId).toSessionAppModel()
+        val session = sessionsDatabaseRepository
+            .querySessionBySessionId(sessionId)
+            .toSessionAppModel()
 
-        val highlight = highlightsDatabaseRepository.queryBySessionId(sessionId.toInt())
-        if (highlight != null) {
-            session = Session(session).apply { this.highlight = highlight.isHighlight }
+        val isHighlighted = highlightsDatabaseRepository
+            .queryBySessionId(sessionId.toInt())
+            ?.isHighlight ?: false
+
+        val hasAlarm = alarmsDatabaseRepository
+            .query(sessionId)
+            .isNotEmpty()
+
+        return if (isHighlighted || hasAlarm) {
+            Session(session).apply {
+                this.highlight = isHighlighted
+                this.hasAlarm = hasAlarm
+            }
+        } else {
+            session
         }
-
-        val alarms = alarmsDatabaseRepository.query(sessionId)
-        if (alarms.isNotEmpty()) {
-            session = Session(session).apply { this.hasAlarm = true }
-        }
-
-        return session
     }
 
     private fun readSessionsForDayIndexOrderedByDateUtc(dayIndex: Int) =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformer.kt
@@ -80,7 +80,7 @@ private fun List<RoomData>.sortWithDeprioritizedRooms(deprioritizedRooms: List<S
     if (deprioritizedRooms.isEmpty()) {
         return this
     }
-    val (tail, head) = partition { deprioritizedRooms.contains(it.roomName) }
+    val (tail, head) = partition { it.roomName in deprioritizedRooms }
     val sortedTail = deprioritizedRooms.mapNotNull { roomName ->
         tail.firstOrNull { roomName == it.roomName }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -66,6 +66,7 @@ import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.utils.Font
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
 class FahrplanFragment : Fragment(), SessionViewEventsHandler {
@@ -175,7 +176,11 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         setHasOptionsMenu(true)
         val context = requireContext()
         roomTitleTypeFace = TypefaceFactory.getNewInstance(context).getTypeface(Font.Roboto.Light)
-        sessionViewDrawer = SessionViewDrawer(context, { sessionPadding })
+        sessionViewDrawer = SessionViewDrawer(
+            context = context,
+            sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            getSessionPadding = { sessionPadding },
+        )
         errorMessageFactory = ErrorMessage.Factory(context)
         connectivityObserver = ConnectivityObserver(context, onConnectionAvailable = {
             logging.d(LOG_TAG, "Network is available.")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -65,6 +65,7 @@ import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.TimeTextViewParameter
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -179,6 +180,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         sessionViewDrawer = SessionViewDrawer(
             context = context,
             sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            contentDescriptionFormatter = ContentDescriptionFormatter(context),
             getSessionPadding = { sessionPadding },
         )
         errorMessageFactory = ErrorMessage.Factory(context)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -14,11 +14,13 @@ import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.Font
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
 internal class SessionViewDrawer @JvmOverloads constructor(
 
         context: Context,
+        private val sessionPropertiesFormatter: SessionPropertiesFormatter,
         private val getSessionPadding: () -> Int,
         private val isAlternativeHighlightingEnabled: () -> Boolean = {
             // Must load the latest alternative highlighting value every time a session is redrawn.
@@ -51,11 +53,13 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         textView.text = session.subtitle
         textView.contentDescription = Session.getSubtitleContentDescription(sessionView.context, session.subtitle)
         textView = sessionView.requireViewByIdCompat(R.id.session_speakers_view)
-        textView.text = session.formattedSpeakers
-        textView.contentDescription = Session.getSpeakersContentDescription(sessionView.context, session.speakers.size, session.formattedSpeakers)
+        val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+        textView.text = speakerNames
+        textView.contentDescription = Session.getSpeakersContentDescription(sessionView.context, session.speakers.size, speakerNames)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
-        textView.text = session.formattedTrackLanguageText
-        textView.contentDescription = Session.getFormattedTrackContentDescription(sessionView.context, session.track, session.languageText)
+        val languageText = sessionPropertiesFormatter.getFormattedTrackLanguageText(session)
+        textView.text = languageText
+        textView.contentDescription = Session.getFormattedTrackContentDescription(sessionView.context, session.track, languageText)
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -13,6 +13,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -21,6 +22,7 @@ internal class SessionViewDrawer @JvmOverloads constructor(
 
         context: Context,
         private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+        private val contentDescriptionFormatter: ContentDescriptionFormatter,
         private val getSessionPadding: () -> Int,
         private val isAlternativeHighlightingEnabled: () -> Boolean = {
             // Must load the latest alternative highlighting value every time a session is redrawn.
@@ -48,23 +50,27 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         var textView = sessionView.requireViewByIdCompat<TextView>(R.id.session_title_view)
         textView.typeface = boldCondensed
         textView.text = session.title
-        textView.contentDescription = Session.getTitleContentDescription(sessionView.context, session.title)
+        textView.contentDescription = contentDescriptionFormatter
+            .getTitleContentDescription(session.title)
         textView = sessionView.requireViewByIdCompat(R.id.session_subtitle_view)
         textView.text = session.subtitle
-        textView.contentDescription = Session.getSubtitleContentDescription(sessionView.context, session.subtitle)
+        textView.contentDescription = contentDescriptionFormatter
+            .getSubtitleContentDescription(session.subtitle)
         textView = sessionView.requireViewByIdCompat(R.id.session_speakers_view)
         val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
         textView.text = speakerNames
-        textView.contentDescription = Session.getSpeakersContentDescription(sessionView.context, session.speakers.size, speakerNames)
+        textView.contentDescription = contentDescriptionFormatter
+            .getSpeakersContentDescription(session.speakers.size, speakerNames)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
-        val languageText = sessionPropertiesFormatter.getFormattedTrackLanguageText(session)
-        textView.text = languageText
-        textView.contentDescription = Session.getFormattedTrackContentDescription(sessionView.context, session.track, languageText)
+        textView.text = sessionPropertiesFormatter.getFormattedTrackLanguageText(session)
+        textView.contentDescription = contentDescriptionFormatter
+            .getFormattedTrackContentDescription(session.track, sessionPropertiesFormatter.getLanguageText(session))
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut
         }
-        ViewCompat.setStateDescription(sessionView, Session.getStateContentDescription(sessionView.context, session, useDeviceTimeZone))
+        ViewCompat.setStateDescription(sessionView, contentDescriptionFormatter
+            .getStateContentDescription(session, useDeviceTimeZone))
         setSessionBackground(session, sessionView)
         setSessionTextColor(session, sessionView)
         sessionView.tag = session

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -115,7 +115,7 @@ data class ScheduleChanges private constructor(
                     changedRoomName = sessionChange.changedRoom
                     changedTrack = sessionChange.changedTrack
                     changedRecordingOptOut = sessionChange.changedRecordingOptOut
-                    changedDay = sessionChange.changedDayIndex
+                    changedDayIndex = sessionChange.changedDayIndex
                     changedTime = sessionChange.changedStartTime
                     changedDuration = sessionChange.changedDuration
                 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -116,7 +116,7 @@ data class ScheduleChanges private constructor(
                     changedTrack = sessionChange.changedTrack
                     changedRecordingOptOut = sessionChange.changedRecordingOptOut
                     changedDayIndex = sessionChange.changedDayIndex
-                    changedTime = sessionChange.changedStartTime
+                    changedStartTime = sessionChange.changedStartTime
                     changedDuration = sessionChange.changedDuration
                 }
                 oldNotCanceledSessions -= oldSession

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -79,7 +79,7 @@ data class ScheduleChanges private constructor(
                     sessionChange.changedSpeakers = true
                     foundNoteworthyChanges = true
                 }
-                if (newSession.lang != oldSession.lang) {
+                if (newSession.language != oldSession.language) {
                     sessionChange.changedLanguage = true
                     foundNoteworthyChanges = true
                 }
@@ -157,7 +157,7 @@ data class ScheduleChanges private constructor(
             return title == session.title &&
                     subtitle == session.subtitle &&
                     speakers == session.speakers &&
-                    lang == session.lang &&
+                    language == session.language &&
                     roomName == session.roomName &&
                     track == session.track &&
                     recordingOptOut == session.recordingOptOut &&

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -95,7 +95,7 @@ data class ScheduleChanges private constructor(
                     sessionChange.changedRecordingOptOut = true
                     foundNoteworthyChanges = true
                 }
-                if (newSession.day != oldSession.day) {
+                if (newSession.dayIndex != oldSession.dayIndex) {
                     sessionChange.changedDayIndex = true
                     foundNoteworthyChanges = true
                 }
@@ -161,7 +161,7 @@ data class ScheduleChanges private constructor(
                     roomName == session.roomName &&
                     track == session.track &&
                     recordingOptOut == session.recordingOptOut &&
-                    day == session.day &&
+                    dayIndex == session.dayIndex &&
                     startTime == session.startTime &&
                     duration == session.duration
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -177,7 +177,7 @@ data class ScheduleChanges private constructor(
         private fun SessionAppModel.equalsContentWise(session: SessionAppModel): Boolean {
             return equalsInNoteworthyProperties(session) &&
                     url == session.url &&
-                    date == session.date &&
+                    dateText == session.dateText &&
                     dateUTC == session.dateUTC &&
                     timeZoneOffset == session.timeZoneOffset &&
                     relStartTime == session.relStartTime &&

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
@@ -36,7 +36,7 @@ data class SessionExport(
             speakers = session.speakers.joinToString(";"),
             track = session.track,
             type = session.type,
-            lang = session.lang,
+            lang = session.language,
             abstract = session.abstractt,
             description = session.description,
             links = session.links,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
@@ -29,7 +29,7 @@ data class SessionExport(
             sessionId = session.sessionId,
             title = session.title,
             subtitle = session.subtitle,
-            day = session.day,
+            day = session.dayIndex,
             room = session.roomName,
             slug = session.slug,
             url = session.url,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -1,0 +1,85 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import android.content.Context
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+class ContentDescriptionFormatter(val context: Context) {
+
+    fun getDurationContentDescription(duration: Int) =
+        context.getString(R.string.session_list_item_duration_content_description, duration)
+
+    fun getTitleContentDescription(title: String) =
+        if (title.isEmpty()) "" else context.getString(
+            R.string.session_list_item_title_content_description, title
+        )
+
+    fun getSubtitleContentDescription(subtitle: String): String =
+        if (subtitle.isEmpty()) "" else context.getString(
+            R.string.session_list_item_subtitle_content_description, subtitle
+        )
+
+    fun getRoomNameContentDescription(roomName: String): String {
+        return context.getString(R.string.session_list_item_room_content_description, roomName)
+    }
+
+    fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String) =
+        context.resources.getQuantityString(
+            R.plurals.session_list_item_speakers_content_description,
+            speakersCount,
+            formattedSpeakerNames
+        )
+
+    fun getFormattedTrackContentDescription(trackName: String, languageCode: String) =
+        buildString {
+            append(
+                context.getString(
+                    R.string.session_list_item_track_content_description,
+                    trackName
+                )
+            )
+            if (languageCode.isNotEmpty()) {
+                append("; ")
+                append(getLanguageContentDescription(languageCode))
+            }
+        }
+
+    fun getLanguageContentDescription(languageCode: String): String {
+        if (languageCode.isEmpty()) {
+            return context.getString(R.string.session_list_item_language_unknown_content_description)
+        }
+        val languageName = when (languageCode) {
+            "en" -> context.getString(R.string.session_list_item_language_english_content_description)
+            "de" -> context.getString(R.string.session_list_item_language_german_content_description)
+            "pt" -> context.getString(R.string.session_list_item_language_portuguese_content_description)
+            else -> languageCode
+        }
+        return context.getString(
+            R.string.session_list_item_language_content_description,
+            languageName
+        )
+    }
+
+    fun getStartTimeContentDescription(startTimeText: String) =
+        context.getString(R.string.session_list_item_start_time_content_description, startTimeText)
+
+    private fun getHighlightContentDescription(isHighlighted: Boolean): String {
+        val stringResource = if (isHighlighted)
+            R.string.session_list_item_favored_content_description
+        else
+            R.string.session_list_item_not_favored_content_description
+        return context.getString(stringResource)
+    }
+
+    fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean): String {
+        val roomNameContentDescription: String = getRoomNameContentDescription(session.roomName)
+        val startsAtText = DateFormatter
+            .newInstance(useDeviceTimeZone)
+            .getFormattedTime(session.dateUTC, session.timeZoneOffset)
+        val startsAtContentDescription = getStartTimeContentDescription(startsAtText)
+        val isHighlightContentDescription = getHighlightContentDescription(session.highlight)
+        return "$isHighlightContentDescription, $startsAtContentDescription, $roomNameContentDescription"
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/MarkdownConverter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/MarkdownConverter.kt
@@ -8,7 +8,7 @@ object MarkdownConverter : MarkdownConversion {
     // language=regex
     private const val MARKDOWN_LINK_REGEX = """\[(.*?)\]\(([^ \)]+).*?\)"""
     private const val HTML_LINK_TEMPLATE = """<a href="$2">$1</a>"""
-    private const val PlAIN_LINK_TEMPLATE = """$1 ($2)"""
+    private const val PLAIN_LINK_TEMPLATE = """$1 ($2)"""
 
     /**
      * Converts Markdown formatted links in the given [markdown] text
@@ -23,7 +23,7 @@ object MarkdownConverter : MarkdownConversion {
      * into plain text links and return the text as a string.
      */
     override fun markdownLinksToPlainTextLinks(markdown: String): String {
-        return markdown.replace(MARKDOWN_LINK_REGEX.toRegex(), PlAIN_LINK_TEMPLATE)
+        return markdown.replace(MARKDOWN_LINK_REGEX.toRegex(), PLAIN_LINK_TEMPLATE)
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
@@ -1,0 +1,39 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+class SessionPropertiesFormatter {
+
+    fun getFormattedSpeakers(session: Session) =
+        session.speakers?.joinToString(", ").orEmpty()
+
+    fun getFormattedTrackLanguageText(session: Session) =
+        buildString {
+            append(session.track)
+            if (session.track.isNotEmpty() && session.language.isNotEmpty()) {
+                append(" ")
+            }
+            if (session.language.isNotEmpty()) {
+                append("[")
+                append(getLanguageText(session))
+                append("]")
+            }
+        }
+
+    fun getLanguageText(session: Session) =
+        if (session.language.isEmpty()) {
+            ""
+        } else {
+            session.language
+                .replace("-formal", "")
+                .replace("German", "de")
+                .replace("german", "de")
+                .replace("Deutsch", "de")
+                .replace("deutsch", "de")
+                .replace("English", "en")
+                .replace("english", "en")
+                .replace("Englisch", "en")
+                .replace("englisch", "en")
+        }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -31,7 +31,7 @@ class SessionUrlComposer @JvmOverloads constructor(
     override fun getSessionUrl(session: Session): String = when (serverBackEndType) {
             PENTABARF.name -> getComposedSessionUrl(session.slug)
             else -> if (session.url.isNullOrEmpty()) {
-                if (specialRoomNames.contains(session.roomName)) {
+                if (session.roomName in specialRoomNames) {
                     NO_URL
                 } else {
                     getComposedSessionUrl(session.sessionId)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/TypefaceFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/TypefaceFactory.kt
@@ -24,7 +24,7 @@ class TypefaceFactory private constructor(
     private val typefaceByFont = mutableMapOf<Font, Typeface>()
 
     fun getTypeface(font: Font): Typeface {
-        return if (typefaceByFont.contains(font)) {
+        return if (font in typefaceByFont) {
             typefaceByFont[font]!!
         } else {
             val typeface = Typeface.createFromAsset(assetManager, font.fileName)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -56,7 +56,7 @@ class AlarmServicesTest {
         whenever(repository.readUseDeviceTimeZoneEnabled()) doReturn true
         whenever(formattingDelegate.getFormattedDateTimeShort(any(), any(), any())) doReturn "not relevant"
         val session = Session("S1").apply {
-            day = 1
+            dayIndex = 1
             hasAlarm = false
             title = "Title"
             dateUTC = 1536332400000L // 2018-09-07T17:00:00+02:00

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -107,7 +107,7 @@ class SessionExtensionsTest {
         )
         val sessionAppModel = SessionAppModel("7331").apply {
             abstractt = "Lorem ipsum"
-            day = 3
+            dayIndex = 3
             date = "2015-08-13"
             dateUTC = 1439478900000L
             description = "Lorem ipsum dolor sit amet"
@@ -153,7 +153,7 @@ class SessionExtensionsTest {
     fun `toDateInfo returns a DateInfo object derived from a session`() {
         val session = Session("")
         session.date = "2015-08-13"
-        session.day = 3
+        session.dayIndex = 3
         val dateInfo = DateInfo(3, Moment.parseDate("2015-08-13"))
         assertThat(session.toDateInfo()).isEqualTo(dateInfo)
     }
@@ -162,15 +162,15 @@ class SessionExtensionsTest {
     fun `toDayRanges returns a list of day ranges derived from a list of sessions`() {
         val session0 = Session("")
         session0.date = "2019-08-02"
-        session0.day = 2
+        session0.dayIndex = 2
 
         val session1 = Session("")
         session1.date = "2019-08-01"
-        session1.day = 1
+        session1.dayIndex = 1
 
         val session1Copy = Session("")
         session1Copy.date = "2019-08-01"
-        session1Copy.day = 1
+        session1Copy.dayIndex = 1
 
         val sessions = listOf(session0, session1, session1Copy)
         val dayRanges = sessions.toDayRanges()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -108,7 +108,7 @@ class SessionExtensionsTest {
         val sessionAppModel = SessionAppModel("7331").apply {
             abstractt = "Lorem ipsum"
             dayIndex = 3
-            date = "2015-08-13"
+            dateText = "2015-08-13"
             dateUTC = 1439478900000L
             description = "Lorem ipsum dolor sit amet"
             duration = 45
@@ -152,7 +152,7 @@ class SessionExtensionsTest {
     @Test
     fun `toDateInfo returns a DateInfo object derived from a session`() {
         val session = Session("")
-        session.date = "2015-08-13"
+        session.dateText = "2015-08-13"
         session.dayIndex = 3
         val dateInfo = DateInfo(3, Moment.parseDate("2015-08-13"))
         assertThat(session.toDateInfo()).isEqualTo(dateInfo)
@@ -161,15 +161,15 @@ class SessionExtensionsTest {
     @Test
     fun `toDayRanges returns a list of day ranges derived from a list of sessions`() {
         val session0 = Session("")
-        session0.date = "2019-08-02"
+        session0.dateText = "2019-08-02"
         session0.dayIndex = 2
 
         val session1 = Session("")
-        session1.date = "2019-08-01"
+        session1.dateText = "2019-08-01"
         session1.dayIndex = 1
 
         val session1Copy = Session("")
-        session1Copy.date = "2019-08-01"
+        session1Copy.dateText = "2019-08-01"
         session1Copy.dayIndex = 1
 
         val sessions = listOf(session0, session1, session1Copy)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -142,7 +142,7 @@ class SessionExtensionsTest {
             changedRoomName = true
             changedSpeakers = true
             changedSubtitle = true
-            changedTime = true
+            changedStartTime = true
             changedTitle = true
             changedTrack = true
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -115,7 +115,7 @@ class SessionExtensionsTest {
             feedbackUrl = "https://talks.mrmcd.net/2018/talk/V3FUNG/feedback"
             hasAlarm = true
             highlight = true
-            lang = "en"
+            language = "en"
             links = "[Website](https://www.example.com/path)"
             relStartTime = 1035
             recordingLicense = "CC 0"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -133,7 +133,7 @@ class SessionExtensionsTest {
             type = "tutorial"
             url = "https://talks.mrmcd.net/2018/talk/V3FUNG"
 
-            changedDay = true
+            changedDayIndex = true
             changedDuration = true
             changedIsCanceled = true
             changedIsNew = true

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -38,7 +38,7 @@ class SessionsExtensionsToVirtualDaysTest {
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) =
         Session("").apply {
-            this.date = dateText
+            this.dateText = dateText
             this.dateUTC = startsAt
             this.duration = duration
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -25,6 +25,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -503,6 +504,7 @@ class SessionDetailsViewModelTest {
         alarmServices: AlarmServices = mock(),
         notificationHelper: NotificationHelper = mock(),
         sessionFormatter: SessionFormatter = mock(),
+        sessionPropertiesFormatter: SessionPropertiesFormatter = SessionPropertiesFormatter(),
         simpleSessionFormat: SimpleSessionFormat = mock(),
         jsonSessionFormat: JsonSessionFormat = mock(),
         feedbackUrlComposer: FeedbackUrlComposer = mock(),
@@ -519,6 +521,7 @@ class SessionDetailsViewModelTest {
         alarmServices = alarmServices,
         notificationHelper = notificationHelper,
         sessionFormatter = sessionFormatter,
+        sessionPropertiesFormatter = sessionPropertiesFormatter,
         simpleSessionFormat = simpleSessionFormat,
         jsonSessionFormat = jsonSessionFormat,
         feedbackUrlComposer = feedbackUrlComposer,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -25,7 +25,7 @@ class SessionTest {
             speakers = listOf("Janet")
             track = "science"
             type = "workshop"
-            lang = "cz"
+            language = "cz"
             recordingLicense = "CC-0"
             recordingOptOut = true
 
@@ -238,7 +238,7 @@ class SessionTest {
 
     @Test
     fun `equals evaluates false and hashCode differ for sessions with odd lang`() {
-        val session2Modification: SessionModification = { lang = "Odd language" }
+        val session2Modification: SessionModification = { language = "Odd language" }
         assertOddSessionsAreNotEqual { session2Modification() }
         assertOddSessionsHaveOddHashCodes { session2Modification() }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -45,7 +45,7 @@ class SessionTest {
             changedSubtitle = true
             changedRoomName = true
             changedDayIndex = true
-            changedTime = true
+            changedStartTime = true
             changedDuration = true
             changedSpeakers = true
             changedRecordingOptOut = true
@@ -70,7 +70,7 @@ class SessionTest {
             changedSubtitle = false
             changedRoomName = false
             changedDayIndex = false
-            changedTime = false
+            changedStartTime = false
             changedDuration = false
             changedSpeakers = false
             changedRecordingOptOut = false
@@ -278,7 +278,7 @@ class SessionTest {
             changedSubtitle = true
             changedRoomName = true
             changedDayIndex = true
-            changedTime = true
+            changedStartTime = true
             changedDuration = true
             changedSpeakers = true
             changedRecordingOptOut = true
@@ -292,7 +292,7 @@ class SessionTest {
             changedSubtitle = false
             changedRoomName = false
             changedDayIndex = false
-            changedTime = false
+            changedStartTime = false
             changedDuration = false
             changedSpeakers = false
             changedRecordingOptOut = false

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -44,7 +44,7 @@ class SessionTest {
             changedTitle = true
             changedSubtitle = true
             changedRoomName = true
-            changedDay = true
+            changedDayIndex = true
             changedTime = true
             changedDuration = true
             changedSpeakers = true
@@ -69,7 +69,7 @@ class SessionTest {
             changedTitle = false
             changedSubtitle = false
             changedRoomName = false
-            changedDay = false
+            changedDayIndex = false
             changedTime = false
             changedDuration = false
             changedSpeakers = false
@@ -277,7 +277,7 @@ class SessionTest {
             changedTitle = true
             changedSubtitle = true
             changedRoomName = true
-            changedDay = true
+            changedDayIndex = true
             changedTime = true
             changedDuration = true
             changedSpeakers = true
@@ -291,7 +291,7 @@ class SessionTest {
             changedTitle = false
             changedSubtitle = false
             changedRoomName = false
-            changedDay = false
+            changedDayIndex = false
             changedTime = false
             changedDuration = false
             changedSpeakers = false

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -16,7 +16,7 @@ class SessionTest {
             subtitle = "Gravida arcu ac tortor"
             feedbackUrl = "https://example.com/feedback"
             dayIndex = 3
-            date = "2020-02-29"
+            dateText = "2020-02-29"
             dateUTC = 1439478900000L
             startTime = 1125
             duration = 60
@@ -175,7 +175,7 @@ class SessionTest {
 
     @Test
     fun `equals evaluates false and hashCode differ for sessions with odd date`() {
-        val session2Modification: SessionModification = { date = "1999-12-23" }
+        val session2Modification: SessionModification = { dateText = "1999-12-23" }
         assertOddSessionsAreNotEqual { session2Modification() }
         assertOddSessionsHaveOddHashCodes { session2Modification() }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -15,7 +15,7 @@ class SessionTest {
             title = "Lorem ipsum"
             subtitle = "Gravida arcu ac tortor"
             feedbackUrl = "https://example.com/feedback"
-            day = 3
+            dayIndex = 3
             date = "2020-02-29"
             dateUTC = 1439478900000L
             startTime = 1125
@@ -168,7 +168,7 @@ class SessionTest {
 
     @Test
     fun `equals evaluates false and hashCode differ for sessions with odd day`() {
-        val session2Modification: SessionModification = { day = 2 }
+        val session2Modification: SessionModification = { dayIndex = 2 }
         assertOddSessionsAreNotEqual { session2Modification() }
         assertOddSessionsHaveOddHashCodes { session2Modification() }
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -63,7 +63,7 @@ class VirtualDayTest {
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) =
         Session("").apply {
-            this.date = dateText
+            this.dateText = dateText
             this.dateUTC = startsAt
             this.duration = duration
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -173,7 +173,7 @@ class NavigationMenuEntriesGeneratorTest {
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) =
         Session("").apply {
-            this.date = dateText
+            this.dateText = dateText
             this.dateUTC = startsAt
             this.duration = duration
         }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -107,7 +107,7 @@ class ScrollAmountCalculatorTest {
         val roomData = RoomData(roomName = session.roomName, sessions = sessions)
         val scheduleData = ScheduleData(dayIndex = session.dayIndex, roomDataList = listOf(roomData))
         val conference = Conference.ofSessions(sessions)
-        val dateInfo = DateInfo(dayIndex = session.dayIndex, date = Moment.parseDate(session.date))
+        val dateInfo = DateInfo(dayIndex = session.dayIndex, date = Moment.parseDate(session.dateText))
         val dateInfos = DateInfos().apply { add(dateInfo) }
         return ScrollAmountCalculator(NoLogging).calculateScrollAmount(conference, dateInfos, scheduleData, nowMoment, currentDayIndex, BOX_HEIGHT, columnIndex)
     }
@@ -122,7 +122,7 @@ class ScrollAmountCalculatorTest {
 
     private fun createBaseSession(sessionId: String, moment: Moment) = Session(sessionId).apply {
         dayIndex = 0
-        date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
+        dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay
         duration = 60

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -24,7 +24,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.startsAt,
-                currentDayIndex = session.day,
+                currentDayIndex = session.dayIndex,
                 columnIndex = -1
         )
         assertThat(scrollAmount).isEqualTo(0)
@@ -36,7 +36,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.startsAt,
-                currentDayIndex = session.day,
+                currentDayIndex = session.dayIndex,
                 columnIndex = COLUMN_INDEX + 1
         )
         assertThat(scrollAmount).isEqualTo(0)
@@ -48,7 +48,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.startsAt.minusMinutes(1),
-                currentDayIndex = session.day
+                currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(0)
     }
@@ -59,7 +59,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.startsAt,
-                currentDayIndex = session.day
+                currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(0)
     }
@@ -70,7 +70,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.endsAt.minusMinutes(1),
-                currentDayIndex = session.day
+                currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(0)
     }
@@ -81,7 +81,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.endsAt,
-                currentDayIndex = session.day
+                currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(408)
     }
@@ -92,7 +92,7 @@ class ScrollAmountCalculatorTest {
         val scrollAmount = calculateScrollAmount(
                 session = session,
                 nowMoment = session.endsAt,
-                currentDayIndex = session.day
+                currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(408)
     }
@@ -105,9 +105,9 @@ class ScrollAmountCalculatorTest {
     ): Int {
         val sessions = listOf(session)
         val roomData = RoomData(roomName = session.roomName, sessions = sessions)
-        val scheduleData = ScheduleData(dayIndex = session.day, roomDataList = listOf(roomData))
+        val scheduleData = ScheduleData(dayIndex = session.dayIndex, roomDataList = listOf(roomData))
         val conference = Conference.ofSessions(sessions)
-        val dateInfo = DateInfo(dayIndex = session.day, date = Moment.parseDate(session.date))
+        val dateInfo = DateInfo(dayIndex = session.dayIndex, date = Moment.parseDate(session.date))
         val dateInfos = DateInfos().apply { add(dateInfo) }
         return ScrollAmountCalculator(NoLogging).calculateScrollAmount(conference, dateInfos, scheduleData, nowMoment, currentDayIndex, BOX_HEIGHT, columnIndex)
     }
@@ -121,7 +121,7 @@ class ScrollAmountCalculatorTest {
     )
 
     private fun createBaseSession(sessionId: String, moment: Moment) = Session(sessionId).apply {
-        day = 0
+        dayIndex = 0
         date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
@@ -74,7 +74,7 @@ class ScrollAmountCalculatorTimeZoneOffsetTest {
 
     private fun createBaseSession(sessionId: String, moment: Moment) = Session(sessionId).apply {
         dayIndex = 0
-        date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
+        dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay
         relStartTime = moment.minuteOfDay // This might now always be the case, see ParserTask.parseFahrplan

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
@@ -73,7 +73,7 @@ class ScrollAmountCalculatorTimeZoneOffsetTest {
     }
 
     private fun createBaseSession(sessionId: String, moment: Moment) = Session(sessionId).apply {
-        day = 0
+        dayIndex = 0
         date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -143,7 +143,7 @@ class TimeTextViewParameterTest {
 
     private fun createSession(moment: Moment, duration: Int = 60) = Session("s1").apply {
         dayIndex = 0
-        date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
+        dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay
         this.duration = duration

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -142,7 +142,7 @@ class TimeTextViewParameterTest {
     }
 
     private fun createSession(moment: Moment, duration: Int = 60) = Session("s1").apply {
-        day = 0
+        dayIndex = 0
         date = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString()
         dateUTC = moment.toMilliseconds()
         startTime = moment.minuteOfDay

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -44,7 +44,7 @@ class ScheduleChangesTest {
             title = "title"
             subtitle = "subtitle"
             speakers = listOf("speakers")
-            lang = "language"
+            language = "language"
             roomName = "room"
             recordingOptOut = true
             dayIndex = 3
@@ -114,11 +114,11 @@ class ScheduleChangesTest {
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and foundNoteworthyChanges = true if language has changed`() {
-        val oldSessions = listOf(createSession { lang = "Old language" })
-        val newSessions = listOf(createSession { lang = "New language" })
+        val oldSessions = listOf(createSession { language = "Old language" })
+        val newSessions = listOf(createSession { language = "New language" })
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
-            lang = "New language"
+            language = "New language"
             changedLanguage = true
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
@@ -222,7 +222,7 @@ class ScheduleChangesTest {
             title = "Old title"
             subtitle = "Old subtitle"
             speakers = listOf("Old speakers")
-            lang = "Old language"
+            language = "Old language"
             roomName = "Old room"
             dayIndex = 2
             track = "Old track"
@@ -245,7 +245,7 @@ class ScheduleChangesTest {
             title = "New title"
             subtitle = "New subtitle"
             speakers = listOf("New speakers")
-            lang = "New language"
+            language = "New language"
             roomName = "New room"
             dayIndex = 3
             track = "New track"
@@ -268,7 +268,7 @@ class ScheduleChangesTest {
             title = "New title"
             subtitle = "New subtitle"
             speakers = listOf("New speakers")
-            lang = "New language"
+            language = "New language"
             roomName = "New room"
             dayIndex = 3
             track = "New track"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -47,7 +47,7 @@ class ScheduleChangesTest {
             lang = "language"
             roomName = "room"
             recordingOptOut = true
-            day = 3
+            dayIndex = 3
             startTime = 200
             duration = 90
         })
@@ -166,11 +166,11 @@ class ScheduleChangesTest {
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions and foundNoteworthyChanges = true if dayIndex has changed`() {
-        val oldSessions = listOf(createSession { day = 1 })
-        val newSessions = listOf(createSession { day = 2 })
+        val oldSessions = listOf(createSession { dayIndex = 1 })
+        val newSessions = listOf(createSession { dayIndex = 2 })
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
-            day = 2
+            dayIndex = 2
             changedDay = true
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
@@ -224,7 +224,7 @@ class ScheduleChangesTest {
             speakers = listOf("Old speakers")
             lang = "Old language"
             roomName = "Old room"
-            day = 2
+            dayIndex = 2
             track = "Old track"
             recordingOptOut = false
             startTime = 200
@@ -247,7 +247,7 @@ class ScheduleChangesTest {
             speakers = listOf("New speakers")
             lang = "New language"
             roomName = "New room"
-            day = 3
+            dayIndex = 3
             track = "New track"
             recordingOptOut = true
             startTime = 300
@@ -270,7 +270,7 @@ class ScheduleChangesTest {
             speakers = listOf("New speakers")
             lang = "New language"
             roomName = "New room"
-            day = 3
+            dayIndex = 3
             track = "New track"
             recordingOptOut = true
             startTime = 300

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -184,7 +184,7 @@ class ScheduleChangesTest {
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             startTime = 200
-            changedTime = true
+            changedStartTime = true
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundNoteworthyChanges).isTrue()
@@ -237,7 +237,7 @@ class ScheduleChangesTest {
             changedDayIndex = false
             changedTrack = false
             changedRecordingOptOut = false
-            changedTime = false
+            changedStartTime = false
             changedDuration = false
 
         })
@@ -260,7 +260,7 @@ class ScheduleChangesTest {
             changedDayIndex = false
             changedTrack = false
             changedRecordingOptOut = false
-            changedTime = false
+            changedStartTime = false
             changedDuration = false
         })
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
@@ -283,7 +283,7 @@ class ScheduleChangesTest {
             changedDayIndex = true
             changedTrack = true
             changedRecordingOptOut = true
-            changedTime = true
+            changedStartTime = true
             changedDuration = true
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -305,11 +305,11 @@ class ScheduleChangesTest {
 
     @Test
     fun `computeSessionsWithChangeFlags flags and returns new sessions, foundNoteworthyChanges = false and foundChanges = true if date has changed`() {
-        val oldSessions = listOf(createSession { date = "2023-08-01" })
-        val newSessions = listOf(createSession { date = "2023-08-02" })
+        val oldSessions = listOf(createSession { dateText = "2023-08-01" })
+        val newSessions = listOf(createSession { dateText = "2023-08-02" })
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
-            date = "2023-08-02"
+            dateText = "2023-08-02"
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundNoteworthyChanges).isFalse()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -171,7 +171,7 @@ class ScheduleChangesTest {
         val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
         assertThat(scheduleChanges.sessionsWithChangeFlags).isEqualTo(listOf(createSession {
             dayIndex = 2
-            changedDay = true
+            changedDayIndex = true
         }))
         assertThat(scheduleChanges.oldCanceledSessions).isEmpty()
         assertThat(scheduleChanges.foundNoteworthyChanges).isTrue()
@@ -234,7 +234,7 @@ class ScheduleChangesTest {
             changedSpeakers = false
             changedLanguage = false
             changedRoomName = false
-            changedDay = false
+            changedDayIndex = false
             changedTrack = false
             changedRecordingOptOut = false
             changedTime = false
@@ -257,7 +257,7 @@ class ScheduleChangesTest {
             changedSpeakers = false
             changedLanguage = false
             changedRoomName = false
-            changedDay = false
+            changedDayIndex = false
             changedTrack = false
             changedRecordingOptOut = false
             changedTime = false
@@ -280,7 +280,7 @@ class ScheduleChangesTest {
             changedSpeakers = true
             changedLanguage = true
             changedRoomName = true
-            changedDay = true
+            changedDayIndex = true
             changedTrack = true
             changedRecordingOptOut = true
             changedTime = true

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -29,8 +29,8 @@ class SimpleSessionFormatTest {
     private val session1 = Session("S1").apply {
         title = "A talk which changes your life"
         roomName = "Yellow pavilion"
-        date = "2019-12-27T11:00:00+01:00"
-        dateUTC = DateParser.parseDateTime(date)
+        dateText = "2019-12-27T11:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(dateText)
         url = "https://example.com/2019/LD3FX9.html"
         slug = "LD3FX9"
     }
@@ -38,8 +38,8 @@ class SimpleSessionFormatTest {
     private val session2 = Session("S2").apply {
         title = "The most boring workshop ever"
         roomName = "Dark cellar"
-        date = "2019-12-28T17:00:00+01:00"
-        dateUTC = DateParser.parseDateTime(date)
+        dateText = "2019-12-28T17:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(dateText)
         url = "https://example.com/2019/U28VSA.html"
         slug = "U28VSA"
     }
@@ -47,8 +47,8 @@ class SimpleSessionFormatTest {
     private val session3 = Session("S3").apply {
         title = "Angel shifts planning"
         roomName = "Main hall"
-        date = "2019-12-29T09:00:00+01:00"
-        dateUTC = DateParser.parseDateTime(date)
+        dateText = "2019-12-29T09:00:00+01:00"
+        dateUTC = DateParser.parseDateTime(dateText)
         links = "https://events.ccc.de/congress/2019/wiki/index.php/Session:A/V_Angel_Meeting"
         url = "https://example.com/2019/U28VSA.html"
         slug = "U28VSA"
@@ -57,8 +57,8 @@ class SimpleSessionFormatTest {
     private val session4 = Session("S4").apply {
         title = "Central european summer time"
         roomName = "Sunshine tent"
-        date = "2019-09-01T16:00:00+02:00"
-        dateUTC = DateParser.parseDateTime(date)
+        dateText = "2019-09-01T16:00:00+02:00"
+        dateUTC = DateParser.parseDateTime(dateText)
         url = "https://example.com/2019/U9SD23.html"
         slug = "U9SD23"
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
@@ -1,0 +1,97 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.MethodSource
+
+class SessionPropertiesFormatterTest {
+
+    private companion object {
+
+        @JvmStatic
+        fun getLanguageTextData() = listOf(
+            of("-formal", ""),
+            of("German", "de"),
+            of("german", "de"),
+            of("Deutsch", "de"),
+            of("deutsch", "de"),
+            of("English", "en"),
+            of("english", "en"),
+            of("Englisch", "en"),
+            of("englisch", "en"),
+            of("German/English", "de/en"),
+        )
+
+    }
+
+    private val formatter = SessionPropertiesFormatter()
+
+    @Test
+    fun `getFormattedSpeakers returns empty string if speakers is null`() {
+        val session = createSession(speakers = null)
+        assertThat(formatter.getFormattedSpeakers(session)).isEmpty()
+    }
+
+    @Test
+    fun `getFormattedSpeakers returns empty string if speakers is empty`() {
+        val session = createSession(speakers = emptyList())
+        assertThat(formatter.getFormattedSpeakers(session)).isEmpty()
+    }
+
+    @Test
+    fun `getFormattedSpeakers returns single speaker name if speakers contains one name`() {
+        val session = createSession(speakers = listOf("Jane Doe"))
+        assertThat(formatter.getFormattedSpeakers(session)).isEqualTo("Jane Doe")
+    }
+
+    @Test
+    fun `getFormattedSpeakers returns speaker names if speakers contains multiple names`() {
+        val session = createSession(speakers = listOf("Jane Doe", "John Doe"))
+        assertThat(formatter.getFormattedSpeakers(session)).isEqualTo("Jane Doe, John Doe")
+    }
+
+    @Test
+    fun `getFormattedTrackLanguageText returns track name if language is empty`() {
+        val session = createSession(track = "Track", language = "")
+        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("Track")
+    }
+
+    @Test
+    fun `getFormattedTrackLanguageText returns track name and language if track and language is not empty`() {
+        val session = createSession(track = "Track", language = "de-formal")
+        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("Track [de]")
+    }
+
+    @Test
+    fun `getFormattedTrackLanguageText returns language if track is empty and language is not empty`() {
+        val session = createSession(track = "", language = "de-formal")
+        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("[de]")
+    }
+
+    @Test
+    fun `getLanguageText returns empty string if language is empty`() {
+        val session = createSession(language = "")
+        assertThat(formatter.getLanguageText(session)).isEmpty()
+    }
+
+    @ParameterizedTest(name = """getLanguageText returns "{1}" if language "{0}"""")
+    @MethodSource("getLanguageTextData")
+    fun `getLanguageText returns two-letter language code`(language: String, expected: String) {
+        val session = createSession().apply { this.language = language }
+        assertThat(formatter.getLanguageText(session)).isEqualTo(expected)
+    }
+
+    private fun createSession(
+        speakers: List<String>? = emptyList(),
+        track: String = "",
+        language: String = "",
+    ) = Session("").apply {
+        this.speakers = speakers
+        this.track = track
+        this.language = language
+    }
+
+}

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -242,7 +242,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                             session.setDescription(XmlPullParsers.getSanitizedText(parser));
                                         } else if (name.equals("person")) {
                                             parser.next();
-                                            String separator = session.getSpeakers().length() > 0 ? ";" : "";
+                                            String separator = !session.getSpeakers().isEmpty() ? ";" : "";
                                             session.setSpeakers(session.getSpeakers() + separator + XmlPullParsers.getSanitizedText(parser));
                                         } else if (name.equals("link")) {
                                             String url = parser.getAttributeValue(null, "href");
@@ -255,7 +255,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                                 url = "http://" + url;
                                             }
                                             StringBuilder sb = new StringBuilder();
-                                            if (session.getLinks().length() > 0) {
+                                            if (!session.getLinks().isEmpty()) {
                                                 sb.append(session.getLinks());
                                                 sb.append(",");
                                             }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -178,7 +178,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                         if (name.equals("room")) {
                             roomName = parser.getAttributeValue(null, "name");
                             if (roomIndexByRoomName.containsKey(roomName)) {
-                                roomMapIndex = roomIndexByRoomName.get(roomName);
+                                roomMapIndex = getOrDefault(roomIndexByRoomName, roomName, 0);
                             } else {
                                 roomIndexByRoomName.put(roomName, roomIndex);
                                 roomMapIndex = roomIndex;
@@ -191,7 +191,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                             Session session = new Session();
                             session.setSessionId(id);
                             session.setDayIndex(day);
-                            session.setRoomName(roomName);
+                            session.setRoomName(Objects.requireNonNullElse(roomName, ""));
                             session.setRoomGuid(Objects.requireNonNullElse(roomGuid, ""));
                             session.setDate(date);
                             session.setRoomIndex(roomMapIndex);
@@ -372,6 +372,14 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
             e.printStackTrace();
             return false;
         }
+    }
+
+    /** @noinspection SameParameterValue*/
+    private static <K, V> V getOrDefault(
+            @NonNull Map<K, V> map,
+            @NonNull K key,
+            @NonNull V defaultValue) {
+        return map.containsKey(key) ? map.get(key) : defaultValue;
     }
 
 }


### PR DESCRIPTION
# Description
- Preliminary cleanup of `Session` variable names.
- Prepare `AppRepository` to continue working with immutable `Session` class.
- Extract `SessionPropertiesFormatter` and `ContentDescriptionFormatter`.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/631