### PR TITLE
Migrate Session class from Java to Kotlin (part 2)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
@@ -30,7 +30,7 @@ class CalendarDescriptionComposer(
         appendSpeakers(session)
         appendAbstract(session)
         appendDescription(session)
-        if (session.getLinks().containsWikiLink()) {
+        if (session.links.containsWikiLink()) {
             // TODO: It seems that wiki links are no longer added to the links XML attribute.
             // Therefore, this code path might be removed in the future.
             // To be verified with VOC wiki scripts.
@@ -42,7 +42,7 @@ class CalendarDescriptionComposer(
     }
 
     private fun StringBuilder.appendSubtitle(session: Session) {
-        appendParagraphIfNotEmpty(session.subtitle.orEmpty())
+        appendParagraphIfNotEmpty(session.subtitle)
     }
 
     private fun StringBuilder.appendSpeakers(session: Session) {
@@ -50,20 +50,20 @@ class CalendarDescriptionComposer(
     }
 
     private fun StringBuilder.appendAbstract(session: Session) {
-        appendMarkdownParagraphIfNotEmpty(session.abstractt.orEmpty())
+        appendMarkdownParagraphIfNotEmpty(session.abstractt)
     }
 
     private fun StringBuilder.appendDescription(session: Session) {
-        appendMarkdownParagraphIfNotEmpty(session.description.orEmpty())
+        appendMarkdownParagraphIfNotEmpty(session.description)
     }
 
     private fun StringBuilder.appendWikiLinks(session: Session) {
-        val links = session.getLinks().separateByHtmlLineBreaks()
+        val links = session.links.separateByHtmlLineBreaks()
         append(markdownConversion.markdownLinksToHtmlLinks(links))
     }
 
     private fun StringBuilder.appendLinks(session: Session) {
-        val links = session.getLinks().separateByHtmlLineBreaks()
+        val links = session.links.separateByHtmlLineBreaks()
         appendMarkdownParagraphIfNotEmpty(markdownConversion.markdownLinksToHtmlLinks(links))
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -172,39 +172,52 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
  * are derived from track names, see [TrackBackgrounds].
  */
 fun Session.sanitize(): Session {
-    if (title.isEmpty() && subtitle.isNotEmpty()) {
-        title = subtitle
-        subtitle = ""
+    var tempTitle = title
+    var tempSubtitle = subtitle
+    var tempAbstract = abstractt
+    var tempDescription = description
+    var tempTrack = track
+    var tempLanguage = language
+    if (tempTitle.isEmpty() && tempSubtitle.isNotEmpty()) {
+        tempTitle = tempSubtitle
+        tempSubtitle = ""
     }
-    if (title == subtitle) {
-        subtitle = ""
+    if (tempTitle == tempSubtitle) {
+        tempSubtitle = ""
     }
-    if (abstractt == description) {
-        abstractt = ""
+    if (tempAbstract == tempDescription) {
+        tempAbstract = ""
     }
-    if (createSpeakersString(speakers) == subtitle) {
-        subtitle = ""
+    if (createSpeakersString(speakers) == tempSubtitle) {
+        tempSubtitle = ""
     }
-    if (description.isEmpty()) {
-        description = abstractt
-        abstractt = ""
+    if (tempDescription.isEmpty()) {
+        tempDescription = tempAbstract
+        tempAbstract = ""
     }
-    if (!language.isNullOrEmpty()) {
-        language = language.lowercase()
+    if (!tempLanguage.isNullOrEmpty()) {
+        tempLanguage = tempLanguage.lowercase()
     }
-    if (("Sendezentrum-Bühne" == track || "Sendezentrum Bühne" == track || "xHain Berlin" == track) && !type.isNullOrEmpty()) {
-        track = type
+    if (("Sendezentrum-Bühne" == tempTrack || "Sendezentrum Bühne" == tempTrack || "xHain Berlin" == tempTrack) && !type.isNullOrEmpty()) {
+        tempTrack = type
     }
-    if ("classics" == roomName && "Other" == type && track.isNullOrEmpty()) {
-        track = "Classics"
+    if ("classics" == roomName && "Other" == type && tempTrack.isNullOrEmpty()) {
+        tempTrack = "Classics"
     }
     if ("rC3 Lounge" == roomName) {
-        track = "Music"
+        tempTrack = "Music"
     }
-    if (track.isNullOrEmpty() && !type.isNullOrEmpty()) {
-        track = type
+    if (tempTrack.isNullOrEmpty() && !type.isNullOrEmpty()) {
+        tempTrack = type
     }
-    return this
+    return Session(this).apply {
+        title = tempTitle
+        subtitle = tempSubtitle
+        abstractt = tempAbstract
+        description = tempDescription
+        track = tempTrack
+        language = tempLanguage
+    }
 }
 
 /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -195,19 +195,19 @@ fun Session.sanitize(): Session {
         tempDescription = tempAbstract
         tempAbstract = ""
     }
-    if (!tempLanguage.isNullOrEmpty()) {
+    if (tempLanguage.isNotEmpty()) {
         tempLanguage = tempLanguage.lowercase()
     }
-    if (("Sendezentrum-Bühne" == tempTrack || "Sendezentrum Bühne" == tempTrack || "xHain Berlin" == tempTrack) && !type.isNullOrEmpty()) {
+    if (("Sendezentrum-Bühne" == tempTrack || "Sendezentrum Bühne" == tempTrack || "xHain Berlin" == tempTrack) && type.isNotEmpty()) {
         tempTrack = type
     }
-    if ("classics" == roomName && "Other" == type && tempTrack.isNullOrEmpty()) {
+    if ("classics" == roomName && "Other" == type && tempTrack.isEmpty()) {
         tempTrack = "Classics"
     }
     if ("rC3 Lounge" == roomName) {
         tempTrack = "Music"
     }
-    if (tempTrack.isNullOrEmpty() && !type.isNullOrEmpty()) {
+    if (tempTrack.isEmpty() && type.isNotEmpty()) {
         tempTrack = type
     }
     return Session(this).apply {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -7,6 +7,7 @@ import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
 import nerd.tuxmobil.fahrplan.congress.models.Room
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.schedule.TrackBackgrounds
 import org.threeten.bp.ZoneOffset
 import info.metadude.android.eventfahrplan.database.models.Highlight as HighlightDatabaseModel
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
@@ -163,6 +164,13 @@ fun SessionNetworkModel.toSessionAppModel(): Session {
     return session
 }
 
+/**
+ * Rewrites certain properties of a session to make its rendering more pleasant and to reduce
+ * visual clutter. This is accomplished by removing duplicate information, moving content to more
+ * appropriate properties, and normalizing properties. To visually guide users, a common color
+ * scheme is used for similar sessions. This is achieved by customizing related track names. Colors
+ * are derived from track names, see [TrackBackgrounds].
+ */
 fun Session.sanitize(): Session {
     if (title.isEmpty() && subtitle.isNotEmpty()) {
         title = subtitle

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -13,12 +13,12 @@ import info.metadude.android.eventfahrplan.database.models.Highlight as Highligh
 import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
 import info.metadude.android.eventfahrplan.network.models.Session as SessionNetworkModel
 
-fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>): Session {
+fun Session.shiftRoomIndexOnDays(dayIndices: Set<Int>) =
     if (dayIndex in dayIndices) {
-        shiftRoomIndexBy(1)
+        Session(this).apply { roomIndex += 1 }
+    } else {
+        this
     }
-    return this
-}
 
 fun Session.toRoom() = Room(identifier = roomIdentifier, name = roomName)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -137,7 +137,7 @@ internal class SessionDetailsViewModel(
         val formattedZonedDateTimeLong = formattingDelegate.getFormattedDateTimeLong(useDeviceTimeZone, dateUTC, timeZoneOffset)
         val formattedAbstract = markdownConversion.markdownLinksToHtmlLinks(abstractt)
         val formattedDescription = markdownConversion.markdownLinksToHtmlLinks(description)
-        val linksHtml = sessionFormatter.getFormattedLinks(getLinks())
+        val linksHtml = sessionFormatter.getFormattedLinks(links)
         val formattedLinks = markdownConversion.markdownLinksToHtmlLinks(linksHtml)
         val sessionUrl = sessionUrlComposition.getSessionUrl(this)
         val sessionLink = sessionFormatter.getFormattedUrl(sessionUrl)
@@ -152,19 +152,19 @@ internal class SessionDetailsViewModel(
             hasDateUtc = dateUTC > 0,
             formattedZonedDateTimeShort = formattedZonedDateTimeShort,
             formattedZonedDateTimeLong = formattedZonedDateTimeLong,
-            title = title.orEmpty(),
-            subtitle = subtitle.orEmpty(),
+            title = title,
+            subtitle = subtitle,
             speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(this),
             speakersCount = speakers.size,
-            abstract = abstractt.orEmpty(),
+            abstract = abstractt,
             formattedAbstract = formattedAbstract,
-            description = description.orEmpty(),
+            description = description,
             formattedDescription = formattedDescription,
-            roomName = roomName.orEmpty(),
-            track = track.orEmpty(),
-            hasLinks = getLinks().isNotEmpty(),
+            roomName = roomName,
+            track = track,
+            hasLinks = links.isNotEmpty(),
             formattedLinks = formattedLinks,
-            hasWikiLinks = getLinks().containsWikiLink(),
+            hasWikiLinks = links.containsWikiLink(),
             sessionLink = sessionLink,
             // Options menu
             isFlaggedAsFavorite = highlight,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/SessionExtensions.kt
@@ -9,7 +9,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
  * See: https://github.com/EventFahrplan/EventFahrplan/pull/157
  */
 val Session.originatesFromPretalx
-    get() = !url.isNullOrEmpty() && !slug.isNullOrEmpty() && url.contains("/talk/") && subtitle.isNullOrEmpty()
+    get() = url.isNotEmpty() && slug.isNotEmpty() && url.contains("/talk/") && subtitle.isEmpty()
 
 // The track name constant must match the "track" name in the schedule.xml!
 const val WIKI_SESSION_TRACK_NAME = "self organized sessions"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -21,12 +21,16 @@ import nerd.tuxmobil.fahrplan.congress.schedule.Conference;
  */
 public class Session {
 
+    @NonNull
     public String title;
+    @NonNull
     public String subtitle;
     @Nullable
     public String feedbackUrl;          // URL to Frab/Pretalx feedback system, e.g. feedbackUrl = "https://talks.event.net/2023/talk/V8LUNA/feedback"
+    @NonNull
     public String url;
     public int dayIndex;                // XML values start with 1
+    @NonNull
     public String dateText;             // YYYY-MM-DD
     public long dateUTC;                // milliseconds
     @Nullable
@@ -35,7 +39,9 @@ public class Session {
     public int relStartTime;            // minutes since conference start
     public int duration;                // minutes
 
+    @NonNull
     public String roomName;
+    @NonNull
     public String roomIdentifier;       // Unique identifier of a room, e.g. "bccb6a5b-b26b-4f17-90b9-b5966f5e34d8"
 
     /**
@@ -46,23 +52,32 @@ public class Session {
     @Deprecated
     public int roomIndex;
 
+    @NonNull
     public List<String> speakers;
+    @NonNull
     public String track;
     public String sessionId;
+    @NonNull
     public String type;
+    @NonNull
     public String language;
+    @NonNull
     public String slug;
+    @NonNull
     public String abstractt;
+    @NonNull
     public String description;
 
     /**
      * Comma separated Markdown formatted links, see ParserTask#parseFahrplan.
      */
+    @NonNull
     public String links;
 
     public boolean highlight;
     public boolean hasAlarm;
 
+    @NonNull
     public String recordingLicense;
     public boolean recordingOptOut;
 
@@ -164,11 +179,6 @@ public class Session {
         this.changedTrack = session.changedTrack;
         this.changedIsNew = session.changedIsNew;
         this.changedIsCanceled = session.changedIsCanceled;
-    }
-
-    @NonNull
-    public String getLinks() {
-        return links == null ? "" : links;
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -268,8 +268,4 @@ public class Session {
                 changedStartTime || changedTitle || changedTrack;
     }
 
-    public void shiftRoomIndexBy(int amount) {
-        roomIndex += amount;
-    }
-
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -510,10 +510,10 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         val context = requireContext()
         when (menuItemIndex) {
             CONTEXT_MENU_ITEM_ID_FAVORITES -> {
-                session.highlight = !session.highlight
-                viewModel.updateFavorStatus(session)
-                sessionViewDrawer.setSessionBackground(session.highlight, session.track, contextMenuView)
-                SessionViewDrawer.setSessionTextColor(session.highlight, contextMenuView)
+                val updatedSession = Session(session).apply { highlight = !session.highlight }
+                viewModel.updateFavorStatus(updatedSession)
+                sessionViewDrawer.setSessionBackground(updatedSession.highlight, updatedSession.track, contextMenuView)
+                SessionViewDrawer.setSessionTextColor(updatedSession.highlight, contextMenuView)
                 updateMenuItems()
             }
             CONTEXT_MENU_ITEM_ID_SET_ALARM -> {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -512,8 +512,8 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
             CONTEXT_MENU_ITEM_ID_FAVORITES -> {
                 session.highlight = !session.highlight
                 viewModel.updateFavorStatus(session)
-                sessionViewDrawer.setSessionBackground(session, contextMenuView)
-                SessionViewDrawer.setSessionTextColor(session, contextMenuView)
+                sessionViewDrawer.setSessionBackground(session.highlight, session.track, contextMenuView)
+                SessionViewDrawer.setSessionTextColor(session.highlight, contextMenuView)
                 updateMenuItems()
             }
             CONTEXT_MENU_ITEM_ID_SET_ALARM -> {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -71,21 +71,20 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         }
         ViewCompat.setStateDescription(sessionView, contentDescriptionFormatter
             .getStateContentDescription(session, useDeviceTimeZone))
-        setSessionBackground(session, sessionView)
-        setSessionTextColor(session, sessionView)
+        setSessionBackground(session.highlight, session.track, sessionView)
+        setSessionTextColor(session.highlight, sessionView)
         sessionView.tag = session
     }
 
-    fun setSessionBackground(session: Session, sessionView: View) {
+    fun setSessionBackground(isFavored: Boolean, track: String, sessionView: View) {
         val context = sessionView.context
-        val sessionIsFavored = session.highlight
-        @ColorRes val backgroundColorResId = if (sessionIsFavored) {
-            trackNameBackgroundColorHighlightPairs[session.track] ?: R.color.track_background_highlight
+        @ColorRes val backgroundColorResId = if (isFavored) {
+            trackNameBackgroundColorHighlightPairs[track] ?: R.color.track_background_highlight
         } else {
-            trackNameBackgroundColorDefaultPairs[session.track] ?: R.color.track_background_default
+            trackNameBackgroundColorDefaultPairs[track] ?: R.color.track_background_default
         }
         @ColorInt val backgroundColor = ContextCompat.getColor(context, backgroundColorResId)
-        val sessionDrawable = if (sessionIsFavored && isAlternativeHighlightingEnabled()) {
+        val sessionDrawable = if (isFavored && isAlternativeHighlightingEnabled()) {
             SessionDrawable(
                     backgroundColor,
                     sessionDrawableCornerRadius.toFloat(),
@@ -117,12 +116,12 @@ internal class SessionViewDrawer @JvmOverloads constructor(
         const val LOG_TAG = "SessionViewDrawer"
 
         @JvmStatic
-        fun setSessionTextColor(session: Session, view: View) {
+        fun setSessionTextColor(isFavored: Boolean, view: View) {
             val title = view.requireViewByIdCompat<TextView>(R.id.session_title_view)
             val subtitle = view.requireViewByIdCompat<TextView>(R.id.session_subtitle_view)
             val speakers = view.requireViewByIdCompat<TextView>(R.id.session_speakers_view)
             val track = view.requireViewByIdCompat<TextView>(R.id.session_track_view)
-            val colorResId = if (session.highlight)
+            val colorResId = if (isFavored)
                 R.color.session_item_text_on_highlight_background
             else
                 R.color.session_item_text_on_default_background

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -61,7 +61,7 @@ class SimpleSessionFormat {
         append(COMMA)
         append(SPACE)
         append(session.roomName)
-        if (!session.getLinks().containsWikiLink()) {
+        if (!session.links.containsWikiLink()) {
             append(LINE_BREAK)
             append(LINE_BREAK)
             val sessionUrl = SessionUrlComposer().getSessionUrl(session)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
@@ -5,7 +5,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 class SessionPropertiesFormatter {
 
     fun getFormattedSpeakers(session: Session) =
-        session.speakers?.joinToString(", ").orEmpty()
+        session.speakers.joinToString(", ")
 
     fun getFormattedTrackLanguageText(session: Session) =
         buildString {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -30,14 +30,12 @@ class SessionUrlComposer @JvmOverloads constructor(
      */
     override fun getSessionUrl(session: Session): String = when (serverBackEndType) {
             PENTABARF.name -> getComposedSessionUrl(session.slug)
-            else -> if (session.url.isNullOrEmpty()) {
+            else -> session.url.ifEmpty {
                 if (session.roomName in specialRoomNames) {
                     NO_URL
                 } else {
                     getComposedSessionUrl(session.sessionId)
                 }
-            } else {
-                session.url
             }
         }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -107,7 +107,7 @@ class CalendarDescriptionComposerTest {
 
     @Test
     fun `getCalendarDescription returns session online with uninitialized session`() {
-        val session = createSession(subtitle = null, speakers = emptyList(), abstract = null, description = null, links = null)
+        val session = createSession(subtitle = "", speakers = emptyList(), abstract = "", description = "", links = "")
         assertThat(createComposer().getCalendarDescription(session)).isEqualTo("""
             Session online: https://events.ccc.de/congress/2021/Fahrplan/events/2342.html
             """.trimIndent())
@@ -126,11 +126,11 @@ class CalendarDescriptionComposerTest {
     }
 
     private fun createSession(
-        subtitle: String? = "",
+        subtitle: String = "",
         speakers: List<String> = emptyList(),
-        abstract: String? = "",
-        description: String? = "",
-        links: String? = ""
+        abstract: String = "",
+        description: String = "",
+        links: String = ""
     ) = Session("2342").apply {
         this.subtitle = subtitle
         this.speakers = speakers

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -15,6 +15,42 @@ import nerd.tuxmobil.fahrplan.congress.models.Session as SessionAppModel
 class SessionExtensionsTest {
 
     @Test
+    fun `shiftRoomIndexOnDays shifts the room index by 1 if the day index is contained in the given set`() {
+        val session = Session("").apply {
+            dayIndex = 3
+            roomIndex = 17
+        }
+        val dayIndices = setOf(3)
+        val shiftedSession = session.shiftRoomIndexOnDays(dayIndices)
+        assertThat(shiftedSession.roomIndex).isEqualTo(18)
+        assertThat(shiftedSession).isNotSameInstanceAs(session)
+    }
+
+    @Test
+    fun `shiftRoomIndexOnDays does not shift the room index if the day index is not contained in the given set`() {
+        val session = Session("").apply {
+            dayIndex = 3
+            roomIndex = 17
+        }
+        val dayIndices = setOf(1, 2)
+        val shiftedSession = session.shiftRoomIndexOnDays(dayIndices)
+        assertThat(shiftedSession.roomIndex).isEqualTo(17)
+        assertThat(shiftedSession).isSameInstanceAs(session)
+    }
+
+    @Test
+    fun `shiftRoomIndexOnDays does not shift the room index if the given set is empty`() {
+        val session = Session("").apply {
+            dayIndex = 3
+            roomIndex = 17
+        }
+        val dayIndices = emptySet<Int>()
+        val shiftedSession = session.shiftRoomIndexOnDays(dayIndices)
+        assertThat(shiftedSession.roomIndex).isEqualTo(17)
+        assertThat(shiftedSession).isSameInstanceAs(session)
+    }
+
+    @Test
     fun `toSessionDatabaseModel returns a database session derived from an app session`() {
         val session = SessionDatabaseModel(
                 sessionId = "7331",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
@@ -30,12 +30,6 @@ class SessionPropertiesFormatterTest {
     private val formatter = SessionPropertiesFormatter()
 
     @Test
-    fun `getFormattedSpeakers returns empty string if speakers is null`() {
-        val session = createSession(speakers = null)
-        assertThat(formatter.getFormattedSpeakers(session)).isEmpty()
-    }
-
-    @Test
     fun `getFormattedSpeakers returns empty string if speakers is empty`() {
         val session = createSession(speakers = emptyList())
         assertThat(formatter.getFormattedSpeakers(session)).isEmpty()
@@ -85,7 +79,7 @@ class SessionPropertiesFormatterTest {
     }
 
     private fun createSession(
-        speakers: List<String>? = emptyList(),
+        speakers: List<String> = emptyList(),
         track: String = "",
         language: String = "",
     ) = Session("").apply {


### PR DESCRIPTION
# Description
- Prepare `Session` to be converted from Java to Kotlin.
  + Add **nullability** to the fields of the `Session` Java class in the `app` module.
  + The annotations are based directly on the type definition in the following places:
      1. Properties of the `Session` Kotlin data class in the `database` module in combination with the cursor query methods e.g. `getString()` vs. `getStringOrNull()` in [`RealSessionsDatabaseRepository#query`](https://github.com/EventFahrplan/EventFahrplan/blob/5756c2a686c1001eb29827736a836179bb51fbb0/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt#L186).
      2. In [`ParserTask`](https://github.com/EventFahrplan/EventFahrplan/blob/5756c2a686c1001eb29827736a836179bb51fbb0/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java#L129) in the `network` module all `Session` properties are intentionally set as nullable resp. non-nullable values by immediately sanitizing the parsed values.
- Prepare **extension functions** to continue working with immutable `Session` class.
- Prepare **context menu** to continue working with immutable `Session` class.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/631
- https://github.com/EventFahrplan/EventFahrplan/pull/632