### PR TITLE
Migrate Session class from Java to Kotlin (part 3)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -128,7 +128,6 @@ class AlarmServices @VisibleForTesting constructor(
         val schedulableAlarm = alarm.toSchedulableAlarm()
         scheduleSessionAlarm(schedulableAlarm, true)
         repository.updateAlarm(alarm)
-        session.hasAlarm = true
     }
 
     /**
@@ -144,7 +143,6 @@ class AlarmServices @VisibleForTesting constructor(
             discardSessionAlarm(schedulableAlarm)
             repository.deleteAlarmForSessionId(sessionId)
         }
-        session.hasAlarm = false
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -294,7 +294,7 @@ class StarredListFragment :
 
     private fun deleteSession(session: Session) {
         session.highlight = false
-        viewModel.delete(session)
+        viewModel.unfavorSession(session)
     }
 
     private fun deleteItems(checkedItemPositions: SparseBooleanArray) {
@@ -324,7 +324,7 @@ class StarredListFragment :
         if (!::starredList.isInitialized || starredList.isEmpty()) {
             return
         }
-        viewModel.deleteAll()
+        viewModel.unfavorAllSessions()
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -292,17 +292,12 @@ class StarredListFragment :
         }
     }
 
-    private fun deleteSession(session: Session) {
-        session.highlight = false
-        viewModel.unfavorSession(session)
-    }
-
     private fun deleteItems(checkedItemPositions: SparseBooleanArray) {
         val itemsCount = currentListView.adapter.count
         for (itemId in itemsCount - 1 downTo 0) {
             if (checkedItemPositions[itemId]) {
                 val session = starredListAdapter.getSession(itemId - 1)
-                deleteSession(session)
+                viewModel.unfavorSession(session)
             }
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -43,7 +43,7 @@ class StarredListViewModel(
 
     fun unfavorSession(session: Session) {
         launch {
-            repository.updateHighlight(session)
+            repository.deleteHighlight(session.sessionId)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -41,13 +41,13 @@ class StarredListViewModel(
     private val mutableShareJson = Channel<String>()
     val shareJson = mutableShareJson.receiveAsFlow()
 
-    fun delete(session: Session) {
+    fun unfavorSession(session: Session) {
         launch {
             repository.updateHighlight(session)
         }
     }
 
-    fun deleteAll() {
+    fun unfavorAllSessions() {
         launch {
             repository.deleteAllHighlights()
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.java
@@ -255,19 +255,25 @@ public class Session {
         return result;
     }
 
-    public void cancel() {
-        changedIsCanceled = true;
-        changedTitle = false;
-        changedSubtitle = false;
-        changedRoomName = false;
-        changedDayIndex = false;
-        changedSpeakers = false;
-        changedRecordingOptOut = false;
-        changedLanguage = false;
-        changedTrack = false;
-        changedIsNew = false;
-        changedStartTime = false;
-        changedDuration = false;
+    /**
+     * Returns a new session with {@link #changedIsCanceled} set to {@code true}
+     * and all other change flags set to {@code false}.
+     */
+    public Session cancel() {
+        Session session = new Session(this);
+        session.changedIsCanceled = true;
+        session.changedTitle = false;
+        session.changedSubtitle = false;
+        session.changedRoomName = false;
+        session.changedDayIndex = false;
+        session.changedSpeakers = false;
+        session.changedRecordingOptOut = false;
+        session.changedLanguage = false;
+        session.changedTrack = false;
+        session.changedIsNew = false;
+        session.changedStartTime = false;
+        session.changedDuration = false;
+        return session;
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -679,6 +679,14 @@ object AppRepository {
     }
 
     @WorkerThread
+    fun deleteHighlight(sessionId: String) {
+        highlightsDatabaseRepository.delete(sessionId)
+        refreshStarredSessions()
+        refreshSelectedSession()
+        refreshUncanceledSessions()
+    }
+
+    @WorkerThread
     fun deleteAllHighlights() {
         highlightsDatabaseRepository.deleteAll()
         refreshStarredSessions()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -14,6 +14,8 @@ import kotlin.collections.indices
 import kotlin.collections.mutableMapOf
 import kotlin.collections.set
 
+private typealias SessionId = String
+
 data class LayoutCalculator @JvmOverloads constructor(
 
         val standardHeight: Int,
@@ -30,13 +32,13 @@ data class LayoutCalculator @JvmOverloads constructor(
         return standardHeight * minutes / DIVISOR
     }
 
-    fun calculateLayoutParams(roomData: RoomData, conference: Conference): Map<Session, LinearLayout.LayoutParams> {
+    fun calculateLayoutParams(roomData: RoomData, conference: Conference): Map<SessionId, LinearLayout.LayoutParams> {
         val sessions = roomData.sessions
         var previousSessionEndsAt: Int = conference.firstSessionStartsAt.minuteOfDay
         var startTime: Int
         var margin: Int
         var previousSession: Session? = null
-        val layoutParamsBySession = mutableMapOf<Session, LinearLayout.LayoutParams>()
+        val layoutParamsBySession = mutableMapOf<SessionId, LinearLayout.LayoutParams>()
 
         for (sessionIndex in sessions.indices) {
             val session = sessions[sessionIndex]
@@ -47,7 +49,7 @@ data class LayoutCalculator @JvmOverloads constructor(
                 // consecutive session
                 margin = calculateDisplayDistance(startTime - previousSessionEndsAt)
                 if (previousSession != null) {
-                    layoutParamsBySession[previousSession]!!.bottomMargin = margin
+                    layoutParamsBySession[previousSession.sessionId]!!.bottomMargin = margin
                     margin = 0
                 }
             } else {
@@ -57,11 +59,11 @@ data class LayoutCalculator @JvmOverloads constructor(
 
             fixOverlappingSessions(sessionIndex, sessions)
 
-            if (!layoutParamsBySession.containsKey(session)) {
-                layoutParamsBySession[session] = createLayoutParams(session)
+            if (!layoutParamsBySession.containsKey(session.sessionId)) {
+                layoutParamsBySession[session.sessionId] = createLayoutParams(session)
             }
 
-            layoutParamsBySession[session]!!.topMargin = margin
+            layoutParamsBySession[session.sessionId]!!.topMargin = margin
             previousSessionEndsAt = startTime + session.duration
             previousSession = session
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
@@ -12,7 +12,7 @@ internal interface SessionViewEventsHandler : View.OnCreateContextMenuListener, 
 
 internal class SessionViewColumnAdapter(
         private val sessions: List<Session>,
-        private val layoutParamsBySession: Map<Session, LinearLayout.LayoutParams>,
+        private val layoutParamsBySession: Map</* sessionId */ String, LinearLayout.LayoutParams>,
         private val useDeviceTimeZone: Boolean,
         private val drawer: SessionViewDrawer,
         private val eventsHandler: SessionViewEventsHandler
@@ -21,7 +21,7 @@ internal class SessionViewColumnAdapter(
     override fun onBindViewHolder(viewHolder: SessionViewHolder, position: Int) {
         val session = sessions[position]
         viewHolder.itemView.tag = session
-        viewHolder.itemView.layoutParams = layoutParamsBySession[session]
+        viewHolder.itemView.layoutParams = layoutParamsBySession[session.sessionId]
         drawer.updateSessionView(viewHolder.itemView, session, useDeviceTimeZone)
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -126,7 +126,7 @@ data class ScheduleChanges private constructor(
             if (oldNotCanceledSessions.isNotEmpty()) {
                 // Flag all "old" sessions which are not present in the "new" set as canceled
                 // and append them to the "new" set.
-                sessionsWithChangeFlags += oldNotCanceledSessions.map { it.toCanceledSession() }
+                sessionsWithChangeFlags += oldNotCanceledSessions.map { it.cancel() }
                 foundNoteworthyChanges = true
             }
 
@@ -150,8 +150,6 @@ data class ScheduleChanges private constructor(
                 var changedStartTime: Boolean = false,
                 var changedDuration: Boolean = false
         )
-
-        private fun SessionAppModel.toCanceledSession() = SessionAppModel(this).apply { cancel() }
 
         private fun SessionAppModel.equalsInNoteworthyProperties(session: SessionAppModel): Boolean {
             return title == session.title &&

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -57,7 +57,6 @@ class AlarmServicesTest {
         whenever(formattingDelegate.getFormattedDateTimeShort(any(), any(), any())) doReturn "not relevant"
         val session = Session("S1").apply {
             dayIndex = 1
-            hasAlarm = false
             title = "Title"
             dateUTC = 1536332400000L // 2018-09-07T17:00:00+02:00
             timeZoneOffset = ZoneOffset.of("+02:00")
@@ -65,7 +64,6 @@ class AlarmServicesTest {
 
         alarmServices.addSessionAlarm(session, alarmTimesValues.indexOf("60"))
         // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
-        assertThat(session.hasAlarm).isTrue()
         val expectedAlarm = Alarm(
             alarmTimeInMin = 60,
             day = 1,
@@ -96,7 +94,7 @@ class AlarmServicesTest {
     }
 
     @Test
-    fun `deleteSessionAlarm discards a session alarm when the alarms was scheduled`() {
+    fun `deleteSessionAlarm discards a session alarm when the alarm was scheduled`() {
         val formattingDelegate = mock<FormattingDelegate>()
         val alarmServices = createAlarmServices(formattingDelegate = formattingDelegate)
         val alarm = Alarm(10, 2, 0, "S3", "Title", 1536332400000L, "Lorem ipsum")
@@ -107,21 +105,19 @@ class AlarmServicesTest {
         // AlarmServices invokes discardSessionAlarm() which is tested separately.
         verifyNoInteractions(formattingDelegate)
         verifyInvokedOnce(repository).deleteAlarmForSessionId("S3")
-        assertThat(session.hasAlarm).isFalse()
     }
 
     @Test
-    fun `deleteSessionAlarm resets the session alarm flag when no alarms was scheduled`() {
+    fun `deleteSessionAlarm returns without action when no alarm was scheduled`() {
         val pendingIntentDelegate = mock<PendingIntentDelegate>()
         val formattingDelegate = mock<FormattingDelegate>()
         val alarmServices = createAlarmServices(pendingIntentDelegate = pendingIntentDelegate, formattingDelegate = formattingDelegate)
         whenever(repository.readAlarms(any())) doReturn emptyList()
-        val session = Session("S4").apply { hasAlarm = true }
+        val session = Session("S4")
 
         alarmServices.deleteSessionAlarm(session)
         verifyNoInteractions(pendingIntentDelegate)
         verifyNoInteractions(formattingDelegate)
-        assertThat(session.hasAlarm).isFalse()
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
@@ -76,7 +76,7 @@ class StarredListViewModelTest {
         val repository = createRepository()
         val viewModel = createViewModel(repository)
         viewModel.unfavorSession(Session("42"))
-        verifyInvokedOnce(repository).updateHighlight(any())
+        verifyInvokedOnce(repository).deleteHighlight("42")
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModelTest.kt
@@ -72,18 +72,18 @@ class StarredListViewModelTest {
     }
 
     @Test
-    fun `delete invokes repository functions`() {
+    fun `unfavorSession invokes repository functions`() {
         val repository = createRepository()
         val viewModel = createViewModel(repository)
-        viewModel.delete(Session("42"))
+        viewModel.unfavorSession(Session("42"))
         verifyInvokedOnce(repository).updateHighlight(any())
     }
 
     @Test
-    fun `deleteAll invokes repository functions`() {
+    fun `unfavorAllSessions invokes repository functions`() {
         val repository = createRepository()
         val viewModel = createViewModel(repository)
-        viewModel.deleteAll()
+        viewModel.unfavorAllSessions()
         verifyInvokedOnce(repository).deleteAllHighlights()
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -287,7 +287,7 @@ class SessionTest {
             changedIsNew = true
             changedIsCanceled = false
         }
-        val canceledSession = Session("0").apply {
+        val comparableCanceledSession = Session("0").apply {
             changedTitle = false
             changedSubtitle = false
             changedRoomName = false
@@ -301,7 +301,9 @@ class SessionTest {
             changedIsNew = false
             changedIsCanceled = true
         }
-        assertThat(session.apply { cancel() }).isEqualTo(canceledSession)
+        val canceledSession = session.cancel()
+        assertThat(canceledSession).isEqualTo(comparableCanceledSession)
+        assertThat(canceledSession).isNotSameInstanceAs(session)
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -33,7 +33,7 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val sessionParams = layoutParams[sessions.first()]
+        val sessionParams = layoutParams[sessions.first().sessionId]
 
         assertMargins(sessionParams, 0, 0)
     }
@@ -46,7 +46,7 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val sessionParams = layoutParams[sessions.first()]
+        val sessionParams = layoutParams[sessions.first().sessionId]
 
         assertMargins(sessionParams, 0, 0)
     }
@@ -65,8 +65,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1]
-        val session2Params = layoutParams[session2]
+        val session1Params = layoutParams[session1.sessionId]
+        val session2Params = layoutParams[session2.sessionId]
 
         assertMargins(session1Params, 0, gapMinutes)
         assertMargins(session2Params, 0, 0)
@@ -100,7 +100,7 @@ class LayoutCalculatorTest {
         val roomData = listOf(session2).toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session2Params = layoutParams[session2]
+        val session2Params = layoutParams[session2.sessionId]
         val gapMinutes = 60
 
         assertMargins(session2Params, gapMinutes, 0)
@@ -122,8 +122,8 @@ class LayoutCalculatorTest {
 
         val layoutParamsRoom1 = layoutCalculator.calculateLayoutParams(roomData1, conference)
         val layoutParamsRoom2 = layoutCalculator.calculateLayoutParams(roomData2, conference)
-        val session1Params = layoutParamsRoom1[session1]
-        val session2Params = layoutParamsRoom2[session2]
+        val session1Params = layoutParamsRoom1[session1.sessionId]
+        val session2Params = layoutParamsRoom2[session2.sessionId]
         val gapMinutes = 5 + 60 // 5 minutes in new day. 60 minutes on previous day, from session1, which starts at 11am
 
         assertMargins(session1Params, 0, 0)
@@ -143,8 +143,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1]
-        val session2Params = layoutParams[session2]
+        val session1Params = layoutParams[session1.sessionId]
+        val session2Params = layoutParams[session2.sessionId]
         val gapMinutes = 30
 
         assertMargins(session1Params, 0, gapMinutes)
@@ -164,8 +164,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1]
-        val session2Params = layoutParams[session2]
+        val session1Params = layoutParams[session1.sessionId]
+        val session2Params = layoutParams[session2.sessionId]
 
         assertMargins(session1Params, 0, 0)
         assertMargins(session2Params, 0, 0)
@@ -187,8 +187,8 @@ class LayoutCalculatorTest {
 
         val layoutParamsRoom1 = layoutCalculator.calculateLayoutParams(roomData1, conference)
         val layoutParamsRoom2 = layoutCalculator.calculateLayoutParams(roomData2, conference)
-        val session1Params = layoutParamsRoom1[session1]
-        val session2Params = layoutParamsRoom2[session2]
+        val session1Params = layoutParamsRoom1[session1.sessionId]
+        val session2Params = layoutParamsRoom2[session2.sessionId]
 
         assertMargins(session1Params, 0, 0)
         assertMargins(session2Params, 35, 0)
@@ -203,7 +203,7 @@ class LayoutCalculatorTest {
 
         val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
         val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = listOf(session1, session2)
+        val sessions = mutableListOf(session1, session2)
 
         layoutCalculator.fixOverlappingSessions(0, sessions)
         assertThat(sessions[0].duration).isEqualTo(35) // gets cut
@@ -219,7 +219,7 @@ class LayoutCalculatorTest {
 
         val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
         val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = listOf(session1, session2)
+        val sessions = mutableListOf(session1, session2)
 
         layoutCalculator.fixOverlappingSessions(0, sessions)
         assertThat(sessions[0].duration).isEqualTo(45) // stays the same
@@ -235,7 +235,7 @@ class LayoutCalculatorTest {
 
         val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
         val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = listOf(session1, session2)
+        val sessions = mutableListOf(session1, session2)
 
         layoutCalculator.fixOverlappingSessions(1, sessions)
         assertThat(sessions[0].duration).isEqualTo(45) // stays the same

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -203,11 +203,11 @@ class LayoutCalculatorTest {
 
         val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
         val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = mutableListOf(session1, session2)
 
-        layoutCalculator.fixOverlappingSessions(0, sessions)
-        assertThat(sessions[0].duration).isEqualTo(35) // gets cut
-        assertThat(sessions[1].duration).isEqualTo(45) // stays the same
+        val updatedSession1 = layoutCalculator.fixOverlappingSessions(session1, session2)
+        assertThat(session1.duration).isEqualTo(45) // not mutated
+        assertThat(updatedSession1.duration).isEqualTo(35) // gets cut
+        assertThat(session2.duration).isEqualTo(45) // not mutated
     }
 
     @Test
@@ -219,29 +219,12 @@ class LayoutCalculatorTest {
 
         val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
         val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = mutableListOf(session1, session2)
 
-        layoutCalculator.fixOverlappingSessions(0, sessions)
-        assertThat(sessions[0].duration).isEqualTo(45) // stays the same
-        assertThat(sessions[1].duration).isEqualTo(45) // stays the same
+        val updatedSession1 = layoutCalculator.fixOverlappingSessions(session1, session2)
+        assertThat(session1.duration).isEqualTo(45) // not mutated
+        assertThat(updatedSession1.duration).isEqualTo(45) // stays the same
+        assertThat(session2.duration).isEqualTo(45) // not mutated
     }
-
-    @Test
-    fun `fixOverlappingSessions keeps the duration of a session without a successor`() {
-        val duration1 = 45
-        val duration2 = 45
-        val startTime1 = 10 * 60 // 10:00am
-        val startTime2 = startTime1 + duration1 - 10 // 10:35am (10 minutes overlap)
-
-        val session1 = createSession(date = conferenceDate, startTime = startTime1, duration = duration1)
-        val session2 = createSession(date = conferenceDate, startTime = startTime2, duration = duration2)
-        val sessions = mutableListOf(session1, session2)
-
-        layoutCalculator.fixOverlappingSessions(1, sessions)
-        assertThat(sessions[0].duration).isEqualTo(45) // stays the same
-        assertThat(sessions[1].duration).isEqualTo(45) // unmodified because no session follows
-    }
-
 
     private fun assertMargins(sessionParams: LinearLayout.LayoutParams?, top: Int, bottom: Int) {
         assertThat(sessionParams!!).isNotNull()

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -8,6 +8,7 @@ interface HighlightsDatabaseRepository {
     fun update(values: ContentValues, sessionId: String): Long
     fun query(): List<Highlight>
     fun queryBySessionId(sessionId: Int): Highlight?
+    fun delete(sessionId: String): Int
     fun deleteAll(): Int
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealHighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealHighlightsDatabaseRepository.kt
@@ -14,6 +14,7 @@ import info.metadude.android.eventfahrplan.database.extensions.getString
 import info.metadude.android.eventfahrplan.database.extensions.insert
 import info.metadude.android.eventfahrplan.database.extensions.map
 import info.metadude.android.eventfahrplan.database.extensions.read
+import info.metadude.android.eventfahrplan.database.extensions.updateRow
 import info.metadude.android.eventfahrplan.database.extensions.updateRows
 import info.metadude.android.eventfahrplan.database.extensions.upsert
 import info.metadude.android.eventfahrplan.database.models.Highlight
@@ -74,6 +75,23 @@ class RealHighlightsDatabaseRepository(
             } else {
                 null
             }
+        }
+    }
+
+    /**
+     * Resets the value of the [HIGHLIGHT] column to [`false`][HIGHLIGHT_STATE_OFF] for the row
+     * with the given [sessionId].
+     */
+    override fun delete(sessionId: String): Int {
+        with(sqLiteOpenHelper) {
+            return writableDatabase.updateRow(
+                tableName = HighlightsTable.NAME,
+                contentValues = ContentValues().apply {
+                    put(HIGHLIGHT, HIGHLIGHT_STATE_OFF)
+                },
+                columnName = SESSION_ID,
+                columnValue = sessionId,
+            )
         }
     }
 


### PR DESCRIPTION
# Description
- Remove unneeded modification of `Session#hasAlarm` when adding or deleting session alarms.
- Prepare `LayoutCalculator` to continue working with immutable `Session` class.
- Prepare `Session#cancel` to continue working with immutable `Session` class.
- Prepare `StarredListFragment#deleteSession` to continue working with immutable `Session` class.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/631
- https://github.com/EventFahrplan/EventFahrplan/pull/632
- https://github.com/EventFahrplan/EventFahrplan/pull/633