### PR TITLE
Update project setup (Compose compiler 1.5.1, kotlin 1.9.23, ksp 1.9.23-1.0.19, threetenbp 1.6.9, coroutines 1.8.0, turbine 1.1.0)

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -65,7 +65,7 @@ object Libs {
         const val emailIntentBuilder = "2.0.0"
         const val engelsystem = "8.1.0"
         const val junitJupiter = "5.10.2"
-        const val kotlinCoroutines = "1.7.3"
+        const val kotlinCoroutines = "1.8.0"
         const val lifecycle = "2.6.2" // compileSdk 34 is required as of 2.7.0
         const val markwon = "4.6.2"
         const val material = "1.9.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -19,7 +19,7 @@ object Compose {
 
     object Versions {
         internal const val bom = "2023.06.01" // compileSdk 34 is required as of 2023.08.00
-        const val compiler = "1.5.9"
+        const val compiler = "1.5.11"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"
@@ -35,8 +35,8 @@ object Plugins {
         const val android = "7.4.2"
         const val androidJunitJacoco = "0.16.0"
         const val dexcount = "4.0.0"
-        const val kotlin = "1.9.22"
-        const val ksp = "1.9.22-1.0.17"
+        const val kotlin = "1.9.23"
+        const val ksp = "1.9.23-1.0.19"
         const val sonarQube = "4.4.1.3373"
         const val unMock = "0.7.9"
         const val versions = "0.51.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -80,7 +80,7 @@ object Libs {
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
         const val truth = "1.4.2"
-        const val turbine = "1.0.0"
+        const val turbine = "1.1.0"
     }
 
     const val androidTestCore = "de.mannodermaus.junit5:android-test-core:${Versions.androidTest}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -69,7 +69,7 @@ object Libs {
         const val lifecycle = "2.6.2" // compileSdk 34 is required as of 2.7.0
         const val markwon = "4.6.2"
         const val material = "1.9.0"
-        const val mockito = "5.10.0"
+        const val mockito = "5.11.0"
         const val mockitoKotlin = "5.2.1"
         const val moshi = "1.15.1"
         const val okhttp = "4.12.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -77,7 +77,7 @@ object Libs {
         const val retrofit = "2.9.0"
         const val robolectric = "4.3_r2-robolectric-0"
         const val snackengage = "0.30"
-        const val threeTenBp = "1.6.8"
+        const val threeTenBp = "1.6.9"
         const val tracedroid = "3.1"
         const val truth = "1.4.2"
         const val turbine = "1.1.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -79,7 +79,7 @@ object Libs {
         const val snackengage = "0.30"
         const val threeTenBp = "1.6.8"
         const val tracedroid = "3.1"
-        const val truth = "1.4.0"
+        const val truth = "1.4.2"
         const val turbine = "1.0.0"
     }
 


### PR DESCRIPTION
# Description
+ Use mockito v.5.11.0.
+ Use truth v.1.4.2.
+ Use turbine v.1.1.0.
+ Use coroutines v.1.8.0.
+ Use threetenbp v.1.6.9.
+ Use Jetpack Compose compiler v.1.5.11 & kotlin v.1.9.23 & ksp v.1.9.23-1.0.19.

# Successfully tested on
with `ccc37c3` flavor, `release` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)