### PR TITLE
Let AppRepository be the single source of truth for "About" screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModel.kt
@@ -23,8 +23,9 @@ class AboutViewModel(
 
     init {
         launch {
-            val meta = repository.readMeta()
-            mutableAboutParameter.value = aboutParameterFactory.createAboutParameter(meta)
+            repository.meta.collect { meta ->
+                mutableAboutParameter.value = aboutParameterFactory.createAboutParameter(meta)
+            }
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -23,7 +23,6 @@ import info.metadude.android.eventfahrplan.engelsystem.EngelsystemNetworkReposit
 import info.metadude.android.eventfahrplan.engelsystem.RealEngelsystemNetworkRepository
 import info.metadude.android.eventfahrplan.engelsystem.models.ShiftsResult
 import info.metadude.android.eventfahrplan.network.models.HttpHeader
-import info.metadude.android.eventfahrplan.network.models.Meta
 import info.metadude.android.eventfahrplan.network.repositories.RealScheduleNetworkRepository
 import info.metadude.android.eventfahrplan.network.repositories.ScheduleNetworkRepository
 import info.metadude.kotlin.library.engelsystem.models.Shift
@@ -81,6 +80,7 @@ import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.Companion.c
 import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
 import okhttp3.OkHttpClient
+import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
 
 object AppRepository {
 
@@ -376,7 +376,7 @@ object AppRepository {
 
     private fun parseSchedule(scheduleXml: String,
                               httpHeader: HttpHeader,
-                              oldMeta: Meta,
+                              oldMeta: MetaNetworkModel,
                               onParsingDone: (parseScheduleResult: ParseResult) -> Unit,
                               onLoadingShiftsDone: (loadShiftsResult: LoadShiftsResult) -> Unit) {
         scheduleNetworkRepository.parseSchedule(scheduleXml, httpHeader,
@@ -795,14 +795,14 @@ object AppRepository {
             metaDatabaseRepository.query().toMetaAppModel()
 
     /**
-     * Updates the [Meta] information in the database.
+     * Updates the `Meta` information in the database.
      *
-     * The [Meta.httpHeader] properties should only be written if a
+     * The [MetaNetworkModel.httpHeader] properties should only be written if a
      * network response is received with a status code of HTTP 200 (OK).
      *
      * See also: [HttpStatus.HTTP_OK]
      */
-    private fun updateMeta(meta: Meta) {
+    private fun updateMeta(meta: MetaNetworkModel) {
         val metaDatabaseModel = meta.toMetaDatabaseModel()
         val values = metaDatabaseModel.toContentValues()
         metaDatabaseRepository.insert(values)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModelTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
 import info.metadude.android.eventfahrplan.commons.testing.verifyInvokedOnce
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
 import nerd.tuxmobil.fahrplan.congress.about.AboutViewEvent.OnPostalAddressClick
@@ -49,8 +50,9 @@ class AboutViewModelTest {
         aboutParameterFactory = aboutParameterFactory,
     )
 
-    private fun createRepository() = mock<AppRepository> {
-        on { readMeta() } doReturn Meta()
+    private fun createRepository(metaValue: Meta = Meta()) = mock<AppRepository> {
+        on { meta } doReturn flowOf(metaValue)
+        on { readMeta() } doReturn metaValue
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryMetaTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryMetaTest.kt
@@ -1,0 +1,127 @@
+package nerd.tuxmobil.fahrplan.congress.repositories
+
+import android.content.ContentValues
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.ETAG
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.NUM_DAYS
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SCHEDULE_LAST_MODIFIED
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.SUBTITLE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TIME_ZONE_NAME
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.TITLE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.MetasTable.Columns.VERSION
+import info.metadude.android.eventfahrplan.database.repositories.MetaDatabaseRepository
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+import org.threeten.bp.ZoneId
+import info.metadude.android.eventfahrplan.database.models.HttpHeader as HttpHeaderDatabaseModel
+import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
+import info.metadude.android.eventfahrplan.network.models.HttpHeader as HttpHeaderNetworkModel
+import info.metadude.android.eventfahrplan.network.models.Meta as MetaNetworkModel
+import nerd.tuxmobil.fahrplan.congress.models.HttpHeader as HttpHeaderAppModel
+import nerd.tuxmobil.fahrplan.congress.models.Meta as MetaAppModel
+
+/**
+ * Covers [AppRepository.meta] and [AppRepository.updateMeta].
+ */
+@ExtendWith(MainDispatcherTestExtension::class)
+class AppRepositoryMetaTest {
+
+    private val metaDatabaseRepository = InMemoryMetaDatabaseRepository()
+
+    private val testableAppRepository: AppRepository
+        get() = with(AppRepository) {
+            initialize(
+                context = mock(),
+                logging = mock(),
+                executionContext = TestExecutionContext,
+                databaseScope = mock(),
+                networkScope = mock(),
+                okHttpClient = mock(),
+                alarmsDatabaseRepository = mock(),
+                highlightsDatabaseRepository = mock(),
+                sessionsDatabaseRepository = mock(),
+                metaDatabaseRepository = metaDatabaseRepository,
+                scheduleNetworkRepository = mock(),
+                engelsystemNetworkRepository = mock(),
+                sharedPreferencesRepository = mock(),
+                sessionsTransformer = mock()
+            )
+            return this
+        }
+
+    @Test
+    fun `meta emits default Meta model`() = runTest {
+        val expected = MetaAppModel(version = "0.0.0")
+        testableAppRepository.meta.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `meta emits empty Meta model`() = runTest {
+        testableAppRepository.updateMeta(MetaNetworkModel())
+        val expected = MetaAppModel()
+        testableAppRepository.meta.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `meta emits custom Meta model`() = runTest {
+        testableAppRepository.updateMeta(MetaNetworkModel(
+            numDays = 4,
+            version = "1.2.3",
+            timeZoneName = "Europe/Berlin",
+            title = "37C3",
+            subtitle = "Unlocked",
+            httpHeader = HttpHeaderNetworkModel(eTag = "abc", lastModified = "9000"),
+        ))
+        val expected = MetaAppModel(
+            numDays = 4,
+            version = "1.2.3",
+            timeZoneId = ZoneId.of("Europe/Berlin"),
+            title = "37C3",
+            subtitle = "Unlocked",
+            httpHeader = HttpHeaderAppModel(eTag = "abc", lastModified = "9000")
+        )
+        testableAppRepository.meta.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+}
+
+private class InMemoryMetaDatabaseRepository : MetaDatabaseRepository {
+
+    private var meta = MetaDatabaseModel(version = "0.0.0")
+
+    override fun insert(values: ContentValues): Long {
+        meta = values.toMeta()
+        return 0
+    }
+
+    override fun query(): MetaDatabaseModel {
+        return meta
+    }
+
+}
+
+private fun ContentValues.toMeta() = MetaDatabaseModel(
+    numDays = get(NUM_DAYS) as Int,
+    version = get(VERSION) as String,
+    timeZoneName = get(TIME_ZONE_NAME) as String?,
+    title = get(TITLE) as String,
+    subtitle = get(SUBTITLE) as String,
+    httpHeader = HttpHeaderDatabaseModel(
+        eTag = get(ETAG) as String,
+        lastModified = get(SCHEDULE_LAST_MODIFIED) as String,
+    ),
+)


### PR DESCRIPTION
# Description
+ This automatically updates the open `About` screen when a new schedule version is fetched in the background and the contained `Meta` data changed.
+ Unidirectional data flow is now used for the `AboutDialog`.
+ Flow is used to emit data from the repository to the ViewModel.
+ The `AppRepository#meta` Flow is refreshed whenever meta is persisted.    

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- [Issue #246: Migrate to data driven architecture](https://github.com/EventFahrplan/EventFahrplan/issues/246)