### PR TITLE
Fix OnBootReceiver not receiving any BOOT_COMPLETED intent.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import nerd.tuxmobil.fahrplan.congress.alarms.AlarmReceiver
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.autoupdate.UpdateService
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSchedulableAlarm
@@ -22,7 +21,7 @@ class OnBootReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action ?: return
-        if (action != AlarmReceiver.ALARM_UPDATE) {
+        if (action != Intent.ACTION_BOOT_COMPLETED) {
             return
         }
 


### PR DESCRIPTION
# Description
+ The wrong action filter applied in a095e89dc87aa9d7d626dbb05f3eecc21858205b prevented the `UpdateService` from ever being started :disappointed: 

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)