### PR TITLE
Fix instrumentation tests being skipped by GitHub Actions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
           script: ./gradlew :database:connectedAndroidTest
 
       - name: Publish unit-test results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         if: always()
         with:
           check_name: Test results (androidTest), API level ${{ matrix.api-level }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 21 ]
+        api-level: [ 26 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description
+ JUnit 5 is built on top of Java 8 and cannot be executed on devices older than API 26 because of that.
   See: https://github.com/mannodermaus/android-junit5?tab=readme-ov-file#instrumentation-test-support
+ Broken since: 023e57ff7c5a13b95843c296906b5e50d14044e1

---

Resolves https://github.com/ReactiveCircus/android-emulator-runner/issues/395
