### PR TITLE
Use compileSdk & targetSdk 34 (Android 14).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/HorizontalSnapScrollView.kt
@@ -103,21 +103,22 @@ class HorizontalSnapScrollView(context: Context, attrs: AttributeSet) : Horizont
         }
 
         override fun onFling(
-            start: MotionEvent,
+            start: MotionEvent?,
             end: MotionEvent,
             velocityX: Float,
             velocityY: Float
         ): Boolean {
-            val normalizedVelocityX = velocityX / resources.displayMetrics.density
-            val columns = ceil((normalizedVelocityX / SWIPE_THRESHOLD_VELOCITY * FLING_COLUMN_MULTIPLIER).toDouble()).toInt()
+            if (start != null) {
+                val normalizedVelocityX = velocityX / resources.displayMetrics.density
+                val columns = ceil((normalizedVelocityX / SWIPE_THRESHOLD_VELOCITY * FLING_COLUMN_MULTIPLIER).toDouble()).toInt()
 
-            logging.d(LOG_TAG, "onFling -> $velocityX/$velocityY $normalizedVelocityX $columns")
+                logging.d(LOG_TAG, "onFling -> $velocityX/$velocityY $normalizedVelocityX $columns")
 
-            if (checkScrollDistance(start.x, end.x) && checkFlingVelocity(normalizedVelocityX)) {
-                scrollToColumn(horizontalSnapScrollState.activeColumnIndex - columns, fast = false)
-                return true
+                if (checkScrollDistance(start.x, end.x) && checkFlingVelocity(normalizedVelocityX)) {
+                    scrollToColumn(horizontalSnapScrollState.activeColumnIndex - columns, fast = false)
+                    return true
+                }
             }
-
             return super.onFling(start, end, velocityX, velocityY)
         }
     }

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- TODO Automate localeConfig, see https://developer.android.com/about/versions/14/features#app-languages -->
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
    <locale android:name="en"/>
    <locale android:name="da"/>

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -10,9 +10,9 @@ object Config {
 
 object Android {
     const val buildToolsVersion = "34.0.0"
-    const val compileSdkVersion = 33
+    const val compileSdkVersion = 34
     const val minSdkVersion = 21
-    const val targetSdkVersion = 33
+    const val targetSdkVersion = 34
 }
 
 object Compose {


### PR DESCRIPTION
# Description
* Use `compileSdk` 34.
* Use `targetSdk` 34.
* Update function signature of `SimpleOnGestureListener#onFling`.
* Add TODO to automate locale-config.

# Test scenarios
- Fresh install
- App update

# Successfully tested on
with `foss4g2024` flavor, `release` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)

# Related
- [Issue #611: Protect BroadcastReceiver in ConnectivityObserver from access by external apps.](https://github.com/EventFahrplan/EventFahrplan/pull/611)
- [Issue #614: Support scheduling exact alarms for sessions.](https://github.com/EventFahrplan/EventFahrplan/pull/614)

---

Resolves #625