### PR TITLE
Improve text linkification.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -143,7 +143,7 @@ class SessionDetailsFragment : Fragment() {
         markwon = Markwon.builder(context)
             .usePlugin(HEADINGS_PLUGIN)
             .usePlugin(createListItemsPlugin(context))
-            .usePlugin(LinkifyPlugin.create(EMAIL_ADDRESSES or WEB_URLS, false))
+            .usePlugin(LinkifyPlugin.create(EMAIL_ADDRESSES or WEB_URLS, true))
             .build()
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -9,6 +9,8 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.os.Bundle
 import android.provider.Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM
+import android.text.util.Linkify.EMAIL_ADDRESSES
+import android.text.util.Linkify.WEB_URLS
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
@@ -141,7 +143,7 @@ class SessionDetailsFragment : Fragment() {
         markwon = Markwon.builder(context)
             .usePlugin(HEADINGS_PLUGIN)
             .usePlugin(createListItemsPlugin(context))
-            .usePlugin(LinkifyPlugin.create())
+            .usePlugin(LinkifyPlugin.create(EMAIL_ADDRESSES or WEB_URLS, false))
             .build()
     }
 


### PR DESCRIPTION
# Description
+ Stop the linking of phone numbers which incorrectly highlights all kinds of digits.
  + The linkified digits appeared when the language of the app was set to German.
+ Use `androidx.core.text.util.LinkifyCompat` in `LinkifyPlugin`.


# Before
![linkify-before](https://github.com/EventFahrplan/EventFahrplan/assets/144518/9989236d-7969-4140-922a-35fd07224439) ![linkify-after](https://github.com/EventFahrplan/EventFahrplan/assets/144518/6d66fe43-abb1-4d98-9a0e-3eb346b1278c)

# Successfully tested on
with `ccc37c3`, `foss4g2024` flavors, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)