### PR TITLE
Fix interchanged video icons in schedule changes screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -68,17 +68,17 @@ abstract class SessionsAdapter protected constructor(
                 TYPE_ITEM -> {
                     rowView = localInflater.inflate(R.layout.session_list_item, parent, false)
                     viewHolder = ViewHolder(
-                        rowView.requireViewByIdCompat(R.id.session_list_item_title_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_subtitle_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_speakers_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_language_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_day_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_time_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_room_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_duration_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_video_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_no_video_view),
-                        rowView.requireViewByIdCompat(R.id.session_list_item_without_video_recording_view),
+                        title = rowView.requireViewByIdCompat(R.id.session_list_item_title_view),
+                        subtitle = rowView.requireViewByIdCompat(R.id.session_list_item_subtitle_view),
+                        speakers = rowView.requireViewByIdCompat(R.id.session_list_item_speakers_view),
+                        lang = rowView.requireViewByIdCompat(R.id.session_list_item_language_view),
+                        day = rowView.requireViewByIdCompat(R.id.session_list_item_day_view),
+                        time = rowView.requireViewByIdCompat(R.id.session_list_item_time_view),
+                        room = rowView.requireViewByIdCompat(R.id.session_list_item_room_view),
+                        duration = rowView.requireViewByIdCompat(R.id.session_list_item_duration_view),
+                        video = rowView.requireViewByIdCompat(R.id.session_list_item_video_view),
+                        noVideo = rowView.requireViewByIdCompat(R.id.session_list_item_no_video_view),
+                        withoutVideoRecording = rowView.requireViewByIdCompat(R.id.session_list_item_without_video_recording_view),
                     )
                     rowView.tag = viewHolder
                 }


### PR DESCRIPTION
# Description
+ Broken since: f27b7c43325076a41bef9afa631d67ee86c570b3.
+ The icons were mixed up because the named parameters were omitted and the order of properties in the `ViewHolder` class did not match the order of view ID references. See `ViewHolder#video` and `ViewHolder#noVideo` properties.

# Before
![phone-schedule-changes-master1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/f29539e7-73e0-482e-a6a3-15704283f248) ![phone-schedule-changes-master2](https://github.com/EventFahrplan/EventFahrplan/assets/144518/7a53c0c5-191a-4511-b3f4-b16fc1577364) ![phone-schedule-changes-master3](https://github.com/EventFahrplan/EventFahrplan/assets/144518/2370b1fc-9b66-4c9e-a4f1-025b0a336e34)


# After
![phone-schedule-changes-fix1](https://github.com/EventFahrplan/EventFahrplan/assets/144518/b325d704-8366-4d15-9cb9-14b8dd518668) ![phone-schedule-changes-fix2](https://github.com/EventFahrplan/EventFahrplan/assets/144518/a7a3c688-1eee-4d4d-8722-e76db28eec97) ![phone-schedule-changes-fix3](https://github.com/EventFahrplan/EventFahrplan/assets/144518/67ef2a9d-b6b1-4288-803f-a6c424c7c499)

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/454
- https://github.com/EventFahrplan/EventFahrplan/issues/448