### PR TITLE
Bumps minSdkVersion to meet play store requirements:

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 26 ]
+        api-level: [ 33 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,6 +60,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
@@ -75,6 +76,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -11,7 +11,7 @@ object Config {
 object Android {
     const val buildToolsVersion = "34.0.0"
     const val compileSdkVersion = 34
-    const val minSdkVersion = 21
+    const val minSdkVersion = 33
     const val targetSdkVersion = 34
 }
 


### PR DESCRIPTION
# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [x] I have read the recent version of the [contribution guide](
  https://github.com/EventFahrplan/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [x] I have checked a few other pull requests to see how they are written.
* [x] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [x] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [x] I can help myself to get this feature implemented or know someone who wants to do it.

# Description
On 31st of August, Play store will hide apps that have a lower minSdk Version than 33(targeting Android 12). To stay visible, the minSdkVersion needs to be bumped from 21 to 33
More info here: https://developer.android.com/google/play/requirements/target-sdk
