### PR TITLE
Add new "Schedule statistic" screen available in DEBUG builds.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -89,5 +89,11 @@
             android:label="@string/starred_sessions"
             android:resizeableActivity="true" >
         </activity>
+        <activity
+            android:name="nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticActivity"
+            android:theme="@style/Theme.Congress.NoActionBar"
+            android:label="@string/schedule_statistic_title"
+            android:resizeableActivity="true" >
+        </activity>
     </application>
 </manifest>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
@@ -10,13 +10,21 @@ import androidx.compose.foundation.layout.Arrangement.Center
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.icons.Icons.AutoMirrored.Default
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
@@ -32,6 +40,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
+import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
 import androidx.compose.ui.text.withStyle
@@ -51,6 +60,52 @@ import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unav
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.toTextUnit
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun TopBar(
+    title: String,
+    onBack: () -> Unit,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    TopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = colorResource(R.color.colorPrimary),
+        ),
+        title = {
+            Text(
+                text = title,
+                fontSize = 19.sp,
+                fontWeight = SemiBold,
+                color = colorResource(R.color.text_primary),
+            )
+        },
+        navigationIcon = {
+            IconButton(
+                onClick = { onBack() },
+            ) {
+                Icon(
+                    imageVector = Default.ArrowBack,
+                    tint = colorResource(R.color.text_primary),
+                    contentDescription = stringResource(R.string.navigate_back_content_description),
+                )
+            }
+        },
+        actions = {
+            actions()
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun TopBarPreview() {
+    TopBar(
+        title = "TopBar Title",
+        onBack = {},
+        actions = {},
+    )
+}
 
 @Composable
 fun Loading() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticActivity.kt
@@ -1,0 +1,26 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
+
+class ScheduleStatisticActivity : BaseActivity() {
+
+    companion object {
+        fun start(context: Context) {
+            val intent = Intent(context, ScheduleStatisticActivity::class.java)
+            context.startActivity(intent)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_schedule_statistic)
+        if (savedInstanceState == null) {
+            addFragment(R.id.container, ScheduleStatisticFragment(), ScheduleStatisticFragment.FRAGMENT_TAG)
+        }
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
@@ -1,0 +1,296 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontStyle.Companion.Italic
+import androidx.compose.ui.text.font.FontWeight.Companion.SemiBold
+import androidx.compose.ui.text.style.TextAlign.Companion.Center
+import androidx.compose.ui.text.style.TextAlign.Companion.End
+import androidx.compose.ui.text.style.TextAlign.Companion.Start
+import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.commons.EventFahrplanTheme
+import nerd.tuxmobil.fahrplan.congress.commons.Loading
+import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
+import nerd.tuxmobil.fahrplan.congress.commons.NoData
+import nerd.tuxmobil.fahrplan.congress.commons.TopBar
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Loading
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Success
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnBackClick
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnToggleSorting
+
+@Composable
+internal fun ScheduleStatisticScreen(
+    state: ScheduleStatisticState,
+    onViewEvent: (ScheduleStatisticViewEvent) -> Unit,
+) {
+    EventFahrplanTheme {
+        Scaffold(
+            topBar = {
+                TopBar(
+                    showActions = state is Success && state.scheduleStatistic.isNotEmpty(),
+                    onViewEvent = onViewEvent,
+                )
+            },
+            content = { contentPadding ->
+                Box(
+                    Modifier
+                        .padding(contentPadding)
+                ) {
+                    when (state) {
+                        Loading -> Loading()
+                        is Success -> {
+                            val scheduleStatistic = state.scheduleStatistic
+                            if (scheduleStatistic.isEmpty()) {
+                                NoScheduleStatistic()
+                            } else {
+                                ScheduleStatisticList(scheduleStatistic)
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun TopBar(showActions: Boolean, onViewEvent: (ScheduleStatisticViewEvent) -> Unit) {
+    TopBar(
+        title = stringResource(R.string.schedule_statistic_title),
+        onBack = { onViewEvent(OnBackClick) },
+        actions = {
+            if (showActions) {
+                IconButton(
+                    onClick = { onViewEvent(OnToggleSorting) },
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_sort),
+                        tint = colorResource(R.color.tool_bar_icon),
+                        contentDescription = stringResource(R.string.schedule_statistic_toggle_sorting),
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun NoScheduleStatistic() {
+    NoData(
+        emptyContent = R.drawable.no_schedule,
+        title = stringResource(R.string.schedule_statistic_no_statistic_data_title),
+        subtitle = stringResource(R.string.schedule_statistic_no_statistic_data_subtitle),
+    )
+}
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ScheduleStatisticList(scheduleStatistic: List<ColumnStatistic>) {
+    LazyColumn(
+        Modifier.padding(16.dp),
+        state = rememberLazyListState(),
+        horizontalAlignment = CenterHorizontally,
+    ) {
+        item {
+            Text(
+                modifier = Modifier.padding(bottom = 16.dp),
+                text = stringResource(R.string.schedule_statistic_description),
+                textAlign = Center,
+                fontStyle = Italic,
+            )
+            ColumnStatisticHeader()
+        }
+        items(scheduleStatistic, key = { it.name }) {
+            ColumnStatisticItem(it, Modifier.animateItemPlacement())
+        }
+    }
+}
+
+@Composable
+private fun ColumnStatisticHeader() {
+    Row(
+        modifier = Modifier
+            .padding(bottom = 4.dp)
+            .clearAndSetSemantics { },
+        verticalAlignment = CenterVertically,
+    ) {
+        Text(
+            modifier = Modifier.defaultMinSize(minWidth = 140.dp),
+            text = stringResource(R.string.schedule_statistic_column_name),
+            fontWeight = SemiBold,
+            maxLines = 1,
+            overflow = Ellipsis,
+        )
+        Text(
+            text = stringResource(R.string.schedule_statistic_null_empty),
+            textAlign = End,
+            fontWeight = SemiBold,
+            maxLines = 1,
+            overflow = Ellipsis,
+            modifier = Modifier
+                .defaultMinSize(minWidth = 50.dp)
+                .padding(horizontal = 8.dp),
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = stringResource(R.string.schedule_statistic_non_empty),
+            textAlign = Start,
+            fontWeight = SemiBold,
+            maxLines = 1,
+            overflow = Ellipsis,
+            modifier = Modifier
+                .defaultMinSize(minWidth = 50.dp)
+                .padding(start = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun ColumnStatisticItem(
+    statistic: ColumnStatistic,
+    modifier: Modifier,
+) {
+    val rowContentDescription = buildString {
+        append(stringResource(R.string.schedule_statistic_column_name))
+        append(": ${statistic.name},")
+        append(stringResource(R.string.schedule_statistic_null_empty_content_description))
+        append(": ${statistic.countNone},")
+        append(stringResource(R.string.schedule_statistic_non_empty))
+        append(": ${statistic.countPresent}")
+    }
+    Row(
+        verticalAlignment = CenterVertically,
+        modifier = modifier
+            .padding(vertical = 4.dp)
+            .clearAndSetSemantics {
+                contentDescription = rowContentDescription
+            }
+    ) {
+        Text(
+            modifier = Modifier.defaultMinSize(minWidth = 140.dp),
+            text = "${statistic.name}:",
+        )
+        StackedHorizontalBar(
+            value1 = statistic.countNone,
+            value2 = statistic.countPresent,
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun StackedHorizontalBar(
+    value1: Int,
+    value2: Int,
+    modifier: Modifier
+) {
+    val totalValue = value1 + value2
+    val value1Fraction = if (totalValue == 0) 0f else value1.toFloat() / totalValue
+    val value2Fraction = if (totalValue == 0) 0f else value2.toFloat() / totalValue
+    val value1Percentage = value1Fraction * 100
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = CenterVertically,
+    ) {
+        Text(
+            text = "$value1",
+            textAlign = End,
+            modifier = Modifier
+                .defaultMinSize(minWidth = 50.dp)
+                .padding(end = 8.dp),
+        )
+        if (value1 > 0) {
+            Box(
+                modifier = Modifier
+                    .weight(value1Fraction)
+                    .height(20.dp)
+                    .background(colorResource(colorOf(value1Percentage)))
+            )
+        }
+        if (value2 > 0) {
+            Box(
+                modifier = Modifier
+                    .weight(value2Fraction)
+                    .height(20.dp)
+                    .background(colorResource(R.color.schedule_statistic_bar_background_no_warning))
+            )
+        }
+        Text(
+            text = "$value2",
+            textAlign = Start,
+            modifier = Modifier
+                .defaultMinSize(minWidth = 50.dp)
+                .padding(start = 8.dp)
+        )
+    }
+}
+
+private fun colorOf(percentage: Float) = when {
+    percentage < 34 -> R.color.schedule_statistic_bar_background_warning_level_1
+    percentage < 67 -> R.color.schedule_statistic_bar_background_warning_level_2
+    else -> R.color.schedule_statistic_bar_background_warning_level_3
+}
+
+@MultiDevicePreview
+@Composable
+private fun ScheduleStatisticScreenPreview() {
+    ScheduleStatisticScreen(
+        state = Success(
+            listOf(
+                ColumnStatistic("Links", countNone = 583, countPresent = 6),
+                ColumnStatistic("Language", countNone = 387, countPresent = 202),
+                ColumnStatistic("Room", countNone = 70, countPresent = 519),
+                ColumnStatistic("Track", countNone = 0, countPresent = 589),
+            )
+        ),
+        onViewEvent = {},
+    )
+}
+
+@Preview
+@Composable
+private fun ScheduleStatisticScreenEmptyPreview() {
+    ScheduleStatisticScreen(
+        state = Success(emptyList()),
+        onViewEvent = {},
+    )
+}
+
+@Preview
+@Composable
+private fun ScheduleStatisticScreenLoadingPreview() {
+    ScheduleStatisticScreen(
+        state = Loading,
+        onViewEvent = {},
+    )
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticFragment.kt
@@ -1,0 +1,51 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import androidx.fragment.app.Fragment
+import info.metadude.android.eventfahrplan.commons.flow.observe
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+
+class ScheduleStatisticFragment : Fragment() {
+
+    companion object {
+        const val FRAGMENT_TAG = "SCHEDULE_STATISTIC_FRAGMENT_TAG"
+    }
+
+    private val viewModel = ScheduleStatisticViewModel(AppRepository)
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View = inflater.inflate(R.layout.fragment_schedule_statistic, container, false).apply {
+        findViewById<ComposeView>(R.id.schedule_statistic_view).apply {
+            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                ScheduleStatisticScreen(
+                    state = viewModel.scheduleStatisticState.collectAsState().value,
+                    onViewEvent = viewModel::onViewEvent,
+                )
+            }
+            isClickable = true
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        viewModel.navigateBack.observe(viewLifecycleOwner) {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticState.kt
@@ -1,0 +1,8 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
+
+sealed interface ScheduleStatisticState {
+    data object Loading : ScheduleStatisticState
+    data class Success(val scheduleStatistic: List<ColumnStatistic>) : ScheduleStatisticState
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewEvent.kt
@@ -1,0 +1,6 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+sealed interface ScheduleStatisticViewEvent {
+    data object OnBackClick : ScheduleStatisticViewEvent
+    data object OnToggleSorting : ScheduleStatisticViewEvent
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewModel.kt
@@ -1,0 +1,60 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Loading
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Success
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnBackClick
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnToggleSorting
+
+class ScheduleStatisticViewModel(
+    repository: AppRepository,
+) : ViewModel() {
+
+    private val mutableScheduleStatisticState = MutableStateFlow<ScheduleStatisticState>(Loading)
+    val scheduleStatisticState = mutableScheduleStatisticState.asStateFlow()
+
+    private val mutableNavigateBack = Channel<Unit>()
+    val navigateBack = mutableNavigateBack.receiveAsFlow()
+
+    private val worseFirst = MutableStateFlow(true)
+
+    init {
+        combine(repository.scheduleStatistic, worseFirst) { statistic, worseFirst ->
+            val stats = statistic.filterNot { it.countNone == 0 && it.countPresent == 0 }
+            Success(
+                when (worseFirst) {
+                    true -> stats.sortedByDescending(ColumnStatistic::countNone)
+                    false -> stats.sortedBy(ColumnStatistic::name)
+                }
+            )
+        }
+            .onEach { mutableScheduleStatisticState.value = it }
+            .launchIn(viewModelScope)
+    }
+
+    fun onViewEvent(viewEvent: ScheduleStatisticViewEvent) {
+        when (viewEvent) {
+            OnBackClick -> mutableNavigateBack.sendOneTimeEvent(Unit)
+            OnToggleSorting -> worseFirst.value = !worseFirst.value
+        }
+    }
+
+    private fun <E> SendChannel<E>.sendOneTimeEvent(event: E) {
+        viewModelScope.launch {
+            send(event)
+        }
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -31,6 +31,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticActivity
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 
 class SettingsFragment : PreferenceFragmentCompat() {
@@ -61,6 +62,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             }
             true
         }
+
+        requirePreference<Preference>(getString(R.string.preference_key_schedule_statistic))
+            .onPreferenceClickListener = OnPreferenceClickListener { preference: Preference ->
+            launchScheduleStatistic(preference.context)
+            true
+        }
+
         if (!BuildConfig.DEBUG) {
             screen.removePreference(developmentCategory)
         }
@@ -166,6 +174,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
             Settings.EXTRA_APP_PACKAGE to context.packageName
         )
         startActivity(intent)
+    }
+
+    private fun launchScheduleStatistic(context: Context) {
+        ScheduleStatisticActivity.start(context)
     }
 
     /**

--- a/app/src/main/res/drawable/ic_sort.xml
+++ b/app/src/main/res/drawable/ic_sort.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="#FFFFFF"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@color/tool_bar_icon"
+        android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z" />
+
+</vector>

--- a/app/src/main/res/layout/activity_schedule_statistic.xml
+++ b/app/src/main/res/layout/activity_schedule_statistic.xml
@@ -1,0 +1,19 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:context=".schedulestatistic.ScheduleStatisticActivity"
+        tools:ignore="MergeRootFrame"
+        tools:layout="@layout/fragment_schedule_statistic" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_schedule_statistic.xml
+++ b/app/src/main/res/layout/fragment_schedule_statistic.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/schedule_statistic_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -75,6 +75,7 @@
     <string name="schedule_changes_dialog_browse">Ansehen</string>
     <string name="schedule_changes_dialog_later">Später</string>
 
+    <string name="navigate_back_content_description">Zurück</string>
     <string name="progress_loading_data">Hole Fahrplan &#8230;</string>
     <string name="progress_processing_data">Verarbeite Fahrplan &#8230;</string>
     <string name="load_data">Laden</string>
@@ -274,5 +275,15 @@
     <string name="validation_error_url_without_api_key">
         <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL ohne API-Schlüssel.
     </string>
+
+    <!-- Schedule statistic -->
+    <string name="schedule_statistic_no_statistic_data_title">Noch keine Fahrplan-Statistik verfügbar</string>
+    <string name="schedule_statistic_title">Fahrplan-Statistik</string>
+    <string name="schedule_statistic_description">Zeigt die Verteilung von null order leeren und nicht-leeren Feldern in der \"sessions\" Datenbanktabelle.</string>
+    <string name="schedule_statistic_toggle_sorting">Wechsle Sortierung</string>
+    <string name="schedule_statistic_column_name">Spaltenname</string>
+    <string name="schedule_statistic_null_empty">null/leer</string>
+    <string name="schedule_statistic_null_empty_content_description">null oder leer</string>
+    <string name="schedule_statistic_non_empty">nicht leer</string>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -81,4 +81,10 @@
     <color name="session_detailbar_text">#999</color>
     <color name="session_detailbar_icon">@color/colorAccent</color>
 
+    <!-- Schedule statistic -->
+    <color name="schedule_statistic_bar_background_warning_level_1">#FFC107</color>
+    <color name="schedule_statistic_bar_background_warning_level_2">#FF9800</color>
+    <color name="schedule_statistic_bar_background_warning_level_3">#FF5722</color>
+    <color name="schedule_statistic_bar_background_no_warning">#8BC34A</color>
+
 </resources>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -36,6 +36,11 @@
         <item>12000</item>
     </string-array>
 
+    <!-- Schedule statistic -->
+    <string name="preference_key_schedule_statistic" translatable="false">schedule_statistic</string>
+    <string name="preference_title_schedule_statistic">Schedule statistic</string>
+    <string name="preference_summary_schedule_statistic">Inspect column values of the schedule</string>
+
     <!-- Category general -->
     <string name="preference_key_category_general" translatable="false">preference_key_category_general</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="schedule_changes_dialog_browse">Browse</string>
     <string name="schedule_changes_dialog_later">Later</string>
 
+    <string name="navigate_back_content_description">Back</string>
     <string name="progress_loading_data">Get schedule &#8230;</string>
     <string name="progress_processing_data">Processing schedule &#8230;</string>
     <string name="load_data">Load</string>
@@ -306,5 +307,16 @@
     <string name="validation_error_url_without_api_key">
         <xliff:g example="Engelsystem" id="urlType">%s</xliff:g> URL without API key.
     </string>
+
+    <!-- Schedule statistic -->
+    <string name="schedule_statistic_no_statistic_data_title">No schedule statistic available yet</string>
+    <string name="schedule_statistic_no_statistic_data_subtitle" translatable="false">@string/schedule_no_schedule_data_subtitle</string>
+    <string name="schedule_statistic_title">Schedule statistic</string>
+    <string name="schedule_statistic_description">Shows the distribution of null or empty and non-empty fields in the \"sessions\" database table.</string>
+    <string name="schedule_statistic_toggle_sorting">Toggle sorting</string>
+    <string name="schedule_statistic_column_name">Column name</string>
+    <string name="schedule_statistic_null_empty">null/empty</string>
+    <string name="schedule_statistic_null_empty_content_description">null or empty</string>
+    <string name="schedule_statistic_non_empty">non-empty</string>
 
 </resources>

--- a/app/src/main/res/xml/prefs.xml
+++ b/app/src/main/res/xml/prefs.xml
@@ -19,6 +19,12 @@
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
 
+        <Preference
+            android:key="@string/preference_key_schedule_statistic"
+            android:title="@string/preference_title_schedule_statistic"
+            app:iconSpaceReserved="false"
+            app:summary="@string/preference_summary_schedule_statistic" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleStatisticTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleStatisticTest.kt
@@ -1,0 +1,110 @@
+package nerd.tuxmobil.fahrplan.congress.repositories
+
+import android.content.ContentValues
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
+import info.metadude.android.eventfahrplan.database.models.Session
+import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+
+/**
+ * Covers [AppRepository.scheduleStatistic].
+ */
+@ExtendWith(MainDispatcherTestExtension::class)
+class AppRepositoryScheduleStatisticTest {
+
+    private val sessionsDatabaseRepository = InMemorySessionDatabaseRepository()
+
+    private val testableAppRepository: AppRepository
+        get() = with(AppRepository) {
+            initialize(
+                context = mock(),
+                logging = mock(),
+                executionContext = TestExecutionContext,
+                databaseScope = mock(),
+                networkScope = mock(),
+                okHttpClient = mock(),
+                alarmsDatabaseRepository = mock(),
+                highlightsDatabaseRepository = mock(),
+                sessionsDatabaseRepository = sessionsDatabaseRepository,
+                metaDatabaseRepository = mock(),
+                scheduleNetworkRepository = mock(),
+                engelsystemNetworkRepository = mock(),
+                sharedPreferencesRepository = mock(),
+                sessionsTransformer = mock()
+            )
+            return this
+        }
+
+    @Test
+    fun `scheduleStatistic emits empty list by default`() = runTest {
+        sessionsDatabaseRepository.clear()
+        val expected = emptyList<ColumnStatistic>()
+        testableAppRepository.scheduleStatistic.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Test
+    fun `scheduleStatistic emits empty Meta model`() = runTest {
+        testableAppRepository.updateSessions(emptyList(), emptyList())
+        val expected = listOf(
+            ColumnStatistic("title", countNone = 100, countPresent = 0),
+            ColumnStatistic("subtitle", countNone = 0, countPresent = 100),
+        )
+        testableAppRepository.scheduleStatistic.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+}
+
+private class InMemorySessionDatabaseRepository : SessionsDatabaseRepository {
+
+    private var scheduleStatistic = listOf(
+        ColumnStatistic("title", countNone = 100, countPresent = 0),
+        ColumnStatistic("subtitle", countNone = 0, countPresent = 100),
+    )
+
+    fun clear() {
+        scheduleStatistic = emptyList()
+    }
+
+    override fun queryScheduleStatistic() = scheduleStatistic
+
+    override fun updateSessions(
+        contentValuesBySessionId: List<Pair<String, ContentValues>>,
+        toBeDeletedSessionIds: List<String>) {
+        // hardcoded in class property
+    }
+
+    override fun insertSessionId(sessionIdContentValues: ContentValues) =
+        throw NotImplementedError()
+
+    override fun deleteSessionIdByNotificationId(notificationId: Int) =
+        throw NotImplementedError()
+
+    override fun querySessionBySessionId(sessionId: String) =
+        throw NotImplementedError()
+
+    override fun querySessionsForDayIndexOrderedByDateUtc(dayIndex: Int) =
+        throw NotImplementedError()
+
+    override fun querySessionsOrderedByDateUtc(): List<Session> =
+        throw NotImplementedError()
+
+    override fun querySessionsWithoutRoom(roomName: String) =
+        throw NotImplementedError()
+
+    override fun querySessionsWithinRoom(roomName: String) =
+        throw NotImplementedError()
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticViewModelTest.kt
@@ -1,0 +1,110 @@
+package nerd.tuxmobil.fahrplan.congress.schedulestatistic
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Loading
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticState.Success
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnBackClick
+import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticViewEvent.OnToggleSorting
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@ExtendWith(MainDispatcherTestExtension::class)
+class ScheduleStatisticViewModelTest {
+
+    @Test
+    fun `scheduleStatisticState emits Loading initially`() = runTest {
+        val repository = createRepository(emptyFlow())
+        val viewModel = createViewModel(repository)
+        viewModel.scheduleStatisticState.test {
+            assertThat(awaitItem()).isEqualTo(Loading)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `scheduleStatisticState emits Success with stats sorted by countNone descending`() =
+        runTest {
+            val statistic = listOf(
+                ColumnStatistic("subtitle", countNone = 0, countPresent = 400),
+                ColumnStatistic("title", countNone = 100, countPresent = 300),
+            )
+            val repository = createRepository(flowOf(statistic))
+            val viewModel = createViewModel(repository)
+            val expected = Success(
+                listOf(
+                    ColumnStatistic("title", countNone = 100, countPresent = 300),
+                    ColumnStatistic("subtitle", countNone = 0, countPresent = 400),
+                )
+            )
+            viewModel.scheduleStatisticState.test {
+                assertThat(awaitItem()).isEqualTo(expected)
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `scheduleStatisticState emits Success with stats sorted by name ascending`() = runTest {
+        val statistic = listOf(
+            ColumnStatistic("title", countNone = 100, countPresent = 300),
+            ColumnStatistic("subtitle", countNone = 0, countPresent = 400),
+        )
+        val repository = createRepository(flowOf(statistic))
+        val viewModel = createViewModel(repository)
+        viewModel.onViewEvent(OnToggleSorting)
+        val expected = Success(
+            listOf(
+                ColumnStatistic("subtitle", countNone = 0, countPresent = 400),
+                ColumnStatistic("title", countNone = 100, countPresent = 300),
+            )
+        )
+        viewModel.scheduleStatisticState.test {
+            assertThat(awaitItem()).isEqualTo(expected)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `scheduleStatisticState emits Success with empty stats`() = runTest {
+        val statistic = listOf(
+            ColumnStatistic("title", countNone = 0, countPresent = 0),
+            ColumnStatistic("subtitle", countNone = 0, countPresent = 0),
+        )
+        val repository = createRepository(flowOf(statistic))
+        val viewModel = createViewModel(repository)
+        val expected = Success(emptyList())
+        viewModel.scheduleStatisticState.test {
+            assertThat(awaitItem()).isEqualTo(expected)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `navigateBack emits Unit when OnBackClick`() = runTest {
+        val repository = createRepository(emptyFlow())
+        val viewModel = createViewModel(repository)
+        viewModel.onViewEvent(OnBackClick)
+        viewModel.navigateBack.test {
+            assertThat(awaitItem()).isEqualTo(Unit)
+            expectNoEvents()
+        }
+    }
+
+    private fun createViewModel(repository: AppRepository) =
+        ScheduleStatisticViewModel(repository)
+
+    private fun createRepository(scheduleStatistic: Flow<List<ColumnStatistic>>) =
+        mock<AppRepository> {
+            on { this.scheduleStatistic } doReturn scheduleStatistic
+        }
+
+}

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -143,4 +143,83 @@ public interface FahrplanContract {
 
     }
 
+    interface StatisticsView {
+
+        String NAME = "sessions_column_stats";
+
+        interface Columns extends BaseColumns {
+            /* 00 */ String TITLE_NONE = "title_none_count";
+            /* 01 */ String TITLE_PRESENT = "title_present_count";
+
+            /* 02 */ String SUBTITLE_NONE = "subtitle_none_count";
+            /* 03 */ String SUBTITLE_PRESENT = "subtitle_present_count";
+
+            /* 04 */ String DAY_INDEX_NONE = "day_index_none_count";
+            /* 05 */ String DAY_INDEX_PRESENT = "day_index_present_count";
+
+            /* 06 */ String ROOM_NAME_NONE = "room_name_none_count";
+            /* 07 */ String ROOM_NAME_PRESENT = "room_name_present_count";
+
+            /* 08 */ String START_TIME_NONE = "start_time_none_count";
+            /* 09 */ String START_TIME_PRESENT = "start_time_present_count";
+
+            /* 10 */ String DURATION_NONE = "duration_none_count";
+            /* 11 */ String DURATION_PRESENT = "duration_present_count";
+
+            /* 12 */ String SPEAKERS_NONE = "speakers_none_count";
+            /* 13 */ String SPEAKERS_PRESENT = "speakers_present_count";
+
+            /* 14 */ String TRACK_NONE = "track_none_count";
+            /* 15 */ String TRACK_PRESENT = "track_present_count";
+
+            /* 16 */ String TYPE_NONE = "type_none_count";
+            /* 17 */ String TYPE_PRESENT = "type_present_count";
+
+            /* 18 */ String LANGUAGES_NONE = "languages_none_count";
+            /* 19 */ String LANGUAGES_PRESENT = "languages_present_count";
+
+            /* 20 */ String ABSTRACT_NONE = "abstract_none_count";
+            /* 21 */ String ABSTRACT_PRESENT = "abstract_present_count";
+
+            /* 22 */ String DESCRIPTION_NONE = "description_none_count";
+            /* 23 */ String DESCRIPTION_PRESENT = "description_present_count";
+
+            /* 24 */ String RELATIVE_START_TIME_NONE = "relative_start_time_none_count";
+            /* 25 */ String RELATIVE_START_TIME_PRESENT = "relative_start_time_present_count";
+
+            /* 26 */ String DATE_TEXT_NONE = "date_text_none_count";
+            /* 27 */ String DATE_TEXT_PRESENT = "date_text_present_count";
+
+            /* 28 */ String LINKS_NONE = "links_none_count";
+            /* 29 */ String LINKS_PRESENT = "links_present_count";
+
+            /* 30 */ String DATE_UTC_NONE = "date_utc_none_count";
+            /* 31 */ String DATE_UTC_PRESENT = "date_utc_present_count";
+
+            /* 32 */ String ROOM_INDEX_NONE = "room_index_none_count";
+            /* 33 */ String ROOM_INDEX_PRESENT = "room_index_present_count";
+
+            /* 34 */ String RECORDING_LICENSE_NONE = "recording_license_none_count";
+            /* 35 */ String RECORDING_LICENSE_PRESENT = "recording_license_present_count";
+
+            /* 36 */ String RECORDING_OPTOUT_NONE = "recording_optout_none_count";
+            /* 37 */ String RECORDING_OPTOUT_PRESENT = "recording_optout_present_count";
+
+            /* 38 */ String SLUG_NONE = "slug_none_count";
+            /* 39 */ String SLUG_PRESENT = "slug_present_count";
+
+            /* 40 */ String URL_NONE = "url_none_count";
+            /* 41 */ String URL_PRESENT = "url_present_count";
+
+            /* 42 */ String TIME_ZONE_OFFSET_NONE = "time_zone_offset_none_count";
+            /* 43 */ String TIME_ZONE_OFFSET_PRESENT = "time_zone_offset_present_count";
+
+            /* 44 */ String ROOM_IDENTIFIER_NONE = "room_identifier_none_count";
+            /* 45 */ String ROOM_IDENTIFIER_PRESENT = "room_identifier_present_count";
+
+            /* 46 */ String FEEDBACK_URL_NONE = "feedback_url_none_count";
+            /* 47 */ String FEEDBACK_URL_PRESENT = "feedback_url_present_count";
+        }
+    }
+
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/ColumnStatistic.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/ColumnStatistic.kt
@@ -1,0 +1,14 @@
+package info.metadude.android.eventfahrplan.database.models
+
+/**
+ * Represents the statistic about a [column][name] in a database table.
+ *
+ * @param name The name of the column.
+ * @param countNone The number of rows where the column value is `null` or empty.
+ * @param countPresent The number of rows where the column value is not `null` nor empty.
+ */
+data class ColumnStatistic(
+    val name: String = "",
+    val countNone: Int = 0,
+    val countPresent: Int = 0,
+)

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
@@ -46,6 +46,55 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.TYPE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.URL
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Values.REC_OPT_OUT_OFF
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ABSTRACT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ABSTRACT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_TEXT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_TEXT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_UTC_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_UTC_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DAY_INDEX_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DAY_INDEX_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DESCRIPTION_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DESCRIPTION_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DURATION_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DURATION_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.FEEDBACK_URL_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.FEEDBACK_URL_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LANGUAGES_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LANGUAGES_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LINKS_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LINKS_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_LICENSE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_LICENSE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_OPTOUT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_OPTOUT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RELATIVE_START_TIME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RELATIVE_START_TIME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_IDENTIFIER_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_IDENTIFIER_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_INDEX_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_INDEX_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_NAME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_NAME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SLUG_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SLUG_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SPEAKERS_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SPEAKERS_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.START_TIME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.START_TIME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SUBTITLE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SUBTITLE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TIME_ZONE_OFFSET_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TIME_ZONE_OFFSET_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TITLE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TITLE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TRACK_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TRACK_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TYPE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TYPE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.URL_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.URL_PRESENT
 import info.metadude.android.eventfahrplan.database.extensions.delete
 import info.metadude.android.eventfahrplan.database.extensions.getInt
 import info.metadude.android.eventfahrplan.database.extensions.getIntOrNull
@@ -56,6 +105,7 @@ import info.metadude.android.eventfahrplan.database.extensions.insert
 import info.metadude.android.eventfahrplan.database.extensions.map
 import info.metadude.android.eventfahrplan.database.extensions.read
 import info.metadude.android.eventfahrplan.database.extensions.updateRow
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
 import info.metadude.android.eventfahrplan.database.models.Session
 import info.metadude.android.eventfahrplan.database.sqliteopenhelper.SessionsDBOpenHelper
 
@@ -239,6 +289,156 @@ internal class RealSessionsDatabaseRepository(
             )
         }
     }
+
+    override fun queryScheduleStatistic(): List<ColumnStatistic> =
+        with(sqLiteOpenHelper.readableDatabase) {
+            val cursor = try {
+                read(StatisticsView.NAME)
+            } catch (e: SQLiteException) {
+                e.printStackTrace()
+                return emptyList()
+            }
+
+            val stats = cursor.use {
+                if (cursor.moveToFirst()) {
+                    listOf(
+                        cursor.toColumnStatistic(
+                            name = TITLE,
+                            columnNameNone = TITLE_NONE,
+                            columnNamePresent = TITLE_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = SUBTITLE,
+                            columnNameNone = SUBTITLE_NONE,
+                            columnNamePresent = SUBTITLE_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = DAY,
+                            columnNameNone = DAY_INDEX_NONE,
+                            columnNamePresent = DAY_INDEX_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = ROOM_NAME,
+                            columnNameNone = ROOM_NAME_NONE,
+                            columnNamePresent = ROOM_NAME_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = START,
+                            columnNameNone = START_TIME_NONE,
+                            columnNamePresent = START_TIME_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = DURATION,
+                            columnNameNone = DURATION_NONE,
+                            columnNamePresent = DURATION_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = SPEAKERS,
+                            columnNameNone = SPEAKERS_NONE,
+                            columnNamePresent = SPEAKERS_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = TRACK,
+                            columnNameNone = TRACK_NONE,
+                            columnNamePresent = TRACK_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = TYPE,
+                            columnNameNone = TYPE_NONE,
+                            columnNamePresent = TYPE_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = LANG,
+                            columnNameNone = LANGUAGES_NONE,
+                            columnNamePresent = LANGUAGES_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = ABSTRACT,
+                            columnNameNone = ABSTRACT_NONE,
+                            columnNamePresent = ABSTRACT_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = DESCR,
+                            columnNameNone = DESCRIPTION_NONE,
+                            columnNamePresent = DESCRIPTION_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = REL_START,
+                            columnNameNone = RELATIVE_START_TIME_NONE,
+                            columnNamePresent = RELATIVE_START_TIME_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = DATE_TEXT,
+                            columnNameNone = DATE_TEXT_NONE,
+                            columnNamePresent = DATE_TEXT_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = LINKS,
+                            columnNameNone = LINKS_NONE,
+                            columnNamePresent = LINKS_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = DATE_UTC,
+                            columnNameNone = DATE_UTC_NONE,
+                            columnNamePresent = DATE_UTC_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = ROOM_INDEX,
+                            columnNameNone = ROOM_INDEX_NONE,
+                            columnNamePresent = ROOM_INDEX_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = REC_LICENSE,
+                            columnNameNone = RECORDING_LICENSE_NONE,
+                            columnNamePresent = RECORDING_LICENSE_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = REC_OPTOUT,
+                            columnNameNone = RECORDING_OPTOUT_NONE,
+                            columnNamePresent = RECORDING_OPTOUT_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = SLUG,
+                            columnNameNone = SLUG_NONE,
+                            columnNamePresent = SLUG_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = URL,
+                            columnNameNone = URL_NONE,
+                            columnNamePresent = URL_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = TIME_ZONE_OFFSET,
+                            columnNameNone = TIME_ZONE_OFFSET_NONE,
+                            columnNamePresent = TIME_ZONE_OFFSET_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = ROOM_IDENTIFIER,
+                            columnNameNone = ROOM_IDENTIFIER_NONE,
+                            columnNamePresent = ROOM_IDENTIFIER_PRESENT,
+                        ),
+                        cursor.toColumnStatistic(
+                            name = FEEDBACK_URL,
+                            columnNameNone = FEEDBACK_URL_NONE,
+                            columnNamePresent = FEEDBACK_URL_PRESENT,
+                        ),
+                    )
+                } else {
+                    emptyList()
+                }
+            }
+            return stats
+        }
+
+    private fun Cursor.toColumnStatistic(
+        name: String,
+        columnNameNone: String,
+        columnNamePresent: String,
+    ) = ColumnStatistic(
+        name = name,
+        countNone = getInt(columnNameNone),
+        countPresent = getInt(columnNamePresent),
+    )
 
     private val Int.isChanged
         get() = this != 0

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
@@ -3,6 +3,7 @@ package info.metadude.android.eventfahrplan.database.repositories
 import android.content.ContentValues
 import android.content.Context
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
 import info.metadude.android.eventfahrplan.database.models.Session
 import info.metadude.android.eventfahrplan.database.sqliteopenhelper.SessionsDBOpenHelper
 
@@ -26,5 +27,6 @@ interface SessionsDatabaseRepository {
     fun querySessionsOrderedByDateUtc(): List<Session>
     fun querySessionsWithoutRoom(roomName: String): List<Session>
     fun querySessionsWithinRoom(roomName: String): List<Session>
+    fun queryScheduleStatistic(): List<ColumnStatistic>
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
@@ -47,6 +47,55 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Defaults.DATE_UTC_DEFAULT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Defaults.ROOM_IDX_DEFAULT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Values.REC_OPT_OUT_OFF
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ABSTRACT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ABSTRACT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_TEXT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_TEXT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_UTC_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DATE_UTC_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DAY_INDEX_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DAY_INDEX_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DESCRIPTION_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DESCRIPTION_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DURATION_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.DURATION_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.FEEDBACK_URL_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.FEEDBACK_URL_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LANGUAGES_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LANGUAGES_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LINKS_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.LINKS_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_LICENSE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_LICENSE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_OPTOUT_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RECORDING_OPTOUT_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RELATIVE_START_TIME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.RELATIVE_START_TIME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_IDENTIFIER_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_IDENTIFIER_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_INDEX_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_INDEX_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_NAME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.ROOM_NAME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SLUG_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SLUG_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SPEAKERS_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SPEAKERS_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.START_TIME_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.START_TIME_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SUBTITLE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.SUBTITLE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TIME_ZONE_OFFSET_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TIME_ZONE_OFFSET_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TITLE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TITLE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TRACK_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TRACK_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TYPE_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.TYPE_PRESENT
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.URL_NONE
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.StatisticsView.Columns.URL_PRESENT
 import info.metadude.android.eventfahrplan.database.extensions.addIntegerColumn
 import info.metadude.android.eventfahrplan.database.extensions.addTextColumn
 import info.metadude.android.eventfahrplan.database.extensions.columnExists
@@ -60,7 +109,7 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
 ) {
 
     private companion object {
-        const val DATABASE_VERSION = 15
+        const val DATABASE_VERSION = 16
         const val DATABASE_NAME = "lectures" // Keep table name to avoid database migration.
 
         // language=sql
@@ -112,12 +161,66 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
         const val SESSION_BY_NOTIFICATION_ID_TABLE_CREATE =
             "CREATE TABLE IF NOT EXISTS ${SessionByNotificationIdTable.NAME} (" +
                     "$_ID INTEGER PRIMARY KEY AUTOINCREMENT, ${SessionByNotificationIdTable.Columns.SESSION_ID} TEXT)"
+
+        // language=sql
+        const val SCHEDULE_STATISTIC_VIEW_CREATE =
+            "CREATE VIEW IF NOT EXISTS ${StatisticsView.NAME} AS SELECT " +
+                    "COUNT(CASE WHEN $TITLE IS NULL OR $TITLE = '' THEN 1 END) AS $TITLE_NONE, " +
+                    "COUNT(CASE WHEN $TITLE IS NOT NULL AND $TITLE != '' THEN 1 END) AS $TITLE_PRESENT, " +
+                    "COUNT(CASE WHEN $SUBTITLE IS NULL OR $SUBTITLE = '' THEN 1 END) AS $SUBTITLE_NONE, " +
+                    "COUNT(CASE WHEN $SUBTITLE IS NOT NULL AND $SUBTITLE != '' THEN 1 END) AS $SUBTITLE_PRESENT, " +
+                    "COUNT(CASE WHEN $DAY IS NULL OR $DAY = '' THEN 1 END) AS $DAY_INDEX_NONE, " +
+                    "COUNT(CASE WHEN $DAY IS NOT NULL AND $DAY != '' THEN 1 END) AS $DAY_INDEX_PRESENT, " +
+                    "COUNT(CASE WHEN $ROOM_NAME IS NULL OR $ROOM_NAME = '' THEN 1 END) AS $ROOM_NAME_NONE, " +
+                    "COUNT(CASE WHEN $ROOM_NAME IS NOT NULL AND $ROOM_NAME != '' THEN 1 END) AS $ROOM_NAME_PRESENT, " +
+                    "COUNT(CASE WHEN $START IS NULL OR $START = '' THEN 1 END) AS $START_TIME_NONE, " +
+                    "COUNT(CASE WHEN $START IS NOT NULL AND $START != '' THEN 1 END) AS $START_TIME_PRESENT, " +
+                    "COUNT(CASE WHEN $DURATION IS NULL OR $DURATION = '' THEN 1 END) AS $DURATION_NONE, " +
+                    "COUNT(CASE WHEN $DURATION IS NOT NULL AND $DURATION != '' THEN 1 END) AS $DURATION_PRESENT, " +
+                    "COUNT(CASE WHEN $SPEAKERS IS NULL OR $SPEAKERS = '' THEN 1 END) AS $SPEAKERS_NONE, " +
+                    "COUNT(CASE WHEN $SPEAKERS IS NOT NULL AND $SPEAKERS != '' THEN 1 END) AS $SPEAKERS_PRESENT, " +
+                    "COUNT(CASE WHEN $TRACK IS NULL OR $TRACK = '' THEN 1 END) AS $TRACK_NONE, " +
+                    "COUNT(CASE WHEN $TRACK IS NOT NULL AND $TRACK != '' THEN 1 END) AS $TRACK_PRESENT, " +
+                    "COUNT(CASE WHEN $TYPE IS NULL OR $TYPE = '' THEN 1 END) AS $TYPE_NONE, " +
+                    "COUNT(CASE WHEN $TYPE IS NOT NULL AND $TYPE != '' THEN 1 END) AS $TYPE_PRESENT, " +
+                    "COUNT(CASE WHEN $LANG IS NULL OR $LANG = '' THEN 1 END) AS $LANGUAGES_NONE, " +
+                    "COUNT(CASE WHEN $LANG IS NOT NULL AND $LANG != '' THEN 1 END) AS $LANGUAGES_PRESENT, " +
+                    "COUNT(CASE WHEN $ABSTRACT IS NULL OR $ABSTRACT = '' THEN 1 END) AS $ABSTRACT_NONE, " +
+                    "COUNT(CASE WHEN $ABSTRACT IS NOT NULL AND $ABSTRACT != '' THEN 1 END) AS $ABSTRACT_PRESENT, " +
+                    "COUNT(CASE WHEN $DESCR IS NULL OR $DESCR = '' THEN 1 END) AS $DESCRIPTION_NONE, " +
+                    "COUNT(CASE WHEN $DESCR IS NOT NULL AND $DESCR != '' THEN 1 END) AS $DESCRIPTION_PRESENT, " +
+                    "COUNT(CASE WHEN $REL_START IS NULL OR $REL_START = '' THEN 1 END) AS $RELATIVE_START_TIME_NONE, " +
+                    "COUNT(CASE WHEN $REL_START IS NOT NULL AND $REL_START != '' THEN 1 END) AS $RELATIVE_START_TIME_PRESENT, " +
+                    "COUNT(CASE WHEN $DATE_TEXT IS NULL OR $DATE_TEXT = '' THEN 1 END) AS $DATE_TEXT_NONE, " +
+                    "COUNT(CASE WHEN $DATE_TEXT IS NOT NULL AND $DATE_TEXT != '' THEN 1 END) AS $DATE_TEXT_PRESENT, " +
+                    "COUNT(CASE WHEN $LINKS IS NULL OR $LINKS = '' THEN 1 END) AS $LINKS_NONE, " +
+                    "COUNT(CASE WHEN $LINKS IS NOT NULL AND $LINKS != '' THEN 1 END) AS $LINKS_PRESENT, " +
+                    "COUNT(CASE WHEN $DATE_UTC IS NULL OR $DATE_UTC = '' THEN 1 END) AS $DATE_UTC_NONE, " +
+                    "COUNT(CASE WHEN $DATE_UTC IS NOT NULL AND $DATE_UTC != '' THEN 1 END) AS $DATE_UTC_PRESENT, " +
+                    "COUNT(CASE WHEN $ROOM_INDEX IS NULL OR $ROOM_INDEX = '' THEN 1 END) AS $ROOM_INDEX_NONE, " +
+                    "COUNT(CASE WHEN $ROOM_INDEX IS NOT NULL AND $ROOM_INDEX != '' THEN 1 END) AS $ROOM_INDEX_PRESENT, " +
+                    "COUNT(CASE WHEN $REC_LICENSE IS NULL OR $REC_LICENSE = '' THEN 1 END) AS $RECORDING_LICENSE_NONE, " +
+                    "COUNT(CASE WHEN $REC_LICENSE IS NOT NULL AND $REC_LICENSE != '' THEN 1 END) AS $RECORDING_LICENSE_PRESENT, " +
+                    "COUNT(CASE WHEN $REC_OPTOUT IS NULL OR $REC_OPTOUT = '' THEN 1 END) AS $RECORDING_OPTOUT_NONE, " +
+                    "COUNT(CASE WHEN $REC_OPTOUT IS NOT NULL AND $REC_OPTOUT != '' THEN 1 END) AS $RECORDING_OPTOUT_PRESENT, " +
+                    "COUNT(CASE WHEN $SLUG IS NULL OR $SLUG = '' THEN 1 END) AS $SLUG_NONE, " +
+                    "COUNT(CASE WHEN $SLUG IS NOT NULL AND $SLUG != '' THEN 1 END) AS $SLUG_PRESENT, " +
+                    "COUNT(CASE WHEN $URL IS NULL OR $URL = '' THEN 1 END) AS $URL_NONE, " +
+                    "COUNT(CASE WHEN $URL IS NOT NULL AND $URL != '' THEN 1 END) AS $URL_PRESENT, " +
+                    "COUNT(CASE WHEN $TIME_ZONE_OFFSET IS NULL OR $TIME_ZONE_OFFSET = '' THEN 1 END) AS $TIME_ZONE_OFFSET_NONE, " +
+                    "COUNT(CASE WHEN $TIME_ZONE_OFFSET IS NOT NULL AND $TIME_ZONE_OFFSET != '' THEN 1 END) AS $TIME_ZONE_OFFSET_PRESENT, " +
+                    "COUNT(CASE WHEN $ROOM_IDENTIFIER IS NULL OR $ROOM_IDENTIFIER = '' THEN 1 END) AS $ROOM_IDENTIFIER_NONE, " +
+                    "COUNT(CASE WHEN $ROOM_IDENTIFIER IS NOT NULL AND $ROOM_IDENTIFIER != '' THEN 1 END) AS $ROOM_IDENTIFIER_PRESENT, " +
+                    "COUNT(CASE WHEN $FEEDBACK_URL IS NULL OR $FEEDBACK_URL = '' THEN 1 END) AS $FEEDBACK_URL_NONE, " +
+                    "COUNT(CASE WHEN $FEEDBACK_URL IS NOT NULL AND $FEEDBACK_URL != '' THEN 1 END) AS $FEEDBACK_URL_PRESENT " +
+                    "FROM ${SessionsTable.NAME}"
     }
 
     override fun onCreate(db: SQLiteDatabase) = with(db) {
         transaction {
             execSQL(SESSIONS_TABLE_CREATE)
             execSQL(SESSION_BY_NOTIFICATION_ID_TABLE_CREATE)
+            execSQL(SCHEDULE_STATISTIC_VIEW_CREATE)
         }
     }
 
@@ -191,6 +294,9 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
             if (!columnExists(SessionsTable.NAME, FEEDBACK_URL)) {
                 addTextColumn(FEEDBACK_URL, default = null)
             }
+        }
+        if (oldVersion < 16) {
+            execSQL(SCHEDULE_STATISTIC_VIEW_CREATE)
         }
     }
 

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -89,3 +89,14 @@ The app prompts the user for in the following topics if enabled via a `buildConf
 - Google Play beta testing via `ENGAGE_GOOGLE_BETA_TESTING`
 - Google Play rating via `ENGAGE_GOOGLE_PLAY_RATING`
 - to learn about the screen estate in landscape mode via `ENGAGE_LANDSCAPE_ORIENTATION`
+
+## 6. Development features
+
+The following features are available when the build type is "debug". They are located in the
+"Development" section of the "Settings" screen. They are intended for the preparation phase of the
+app to verify that the schedule data is loaded and processed correctly.
+
+### Schedule statistic
+
+The "Schedule statistic" screen shows the distribution of null or empty and non-empty fields in
+the "sessions" database table. This can be useful for identify missing data in the schedule.


### PR DESCRIPTION
# Description
+ This screen allows to inspect columns of the schedule database. The bar chart shows the distribution of null/empty vs. non-empty values for each column.
+ The statistic is intended to quickly detect missing schedule data.
+ Optimized to be usable with TalkBack.

# New item in settings for DEBUG builds
![stats-congress-settings](https://github.com/user-attachments/assets/46a75fb2-b5d8-4e98-b7a2-f1cad71a55fa)

# Schedule statistic screen
![stats-congress](https://github.com/user-attachments/assets/534fc7a0-a12c-4030-950b-fc659b6ada5a) ![stats-camp](https://github.com/user-attachments/assets/876b1180-fb19-4af7-981d-9dcc161cb5c6) ![stats-jev](https://github.com/user-attachments/assets/1d44a011-423c-4969-8f44-8d6d963ca34a)

# Successfully tested on
with `ccc37c3`, `cccamp2023`, `jev2022` flavors, `debug` builds
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)