### PR TITLE
Add header to "alarms" screen when shown on tablets.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -35,12 +35,15 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsState.Success
 import nerd.tuxmobil.fahrplan.congress.commons.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.commons.Loading
 import nerd.tuxmobil.fahrplan.congress.commons.NoData
+import nerd.tuxmobil.fahrplan.congress.commons.SessionListHeader
 
 @Composable
 internal fun AlarmsScreen(
     state: AlarmsState,
+    showInSidePane: Boolean,
 ) {
-    EventFahrplanTheme {
+    val darkMode = false
+    EventFahrplanTheme(darkMode = darkMode) {
         Scaffold { contentPadding ->
             Box(
                 Modifier
@@ -54,7 +57,9 @@ internal fun AlarmsScreen(
                             NoAlarms()
                         } else {
                             SessionAlarmsList(
+                                darkMode = darkMode,
                                 parameters = parameters,
+                                showInSidePane = showInSidePane,
                                 onItemClick = state.onItemClick,
                                 onDeleteItemClick = state.onDeleteItemClick
                             )
@@ -77,11 +82,18 @@ private fun NoAlarms() {
 
 @Composable
 private fun SessionAlarmsList(
+    @Suppress("SameParameterValue") darkMode: Boolean,
     parameters: List<SessionAlarmParameter>,
+    showInSidePane: Boolean,
     onItemClick: (SessionAlarmParameter) -> Unit,
     onDeleteItemClick: (SessionAlarmParameter) -> Unit
 ) {
     LazyColumn(state = rememberLazyListState()) {
+        if (showInSidePane) {
+            item {
+                SessionListHeader(stringResource(R.string.reminders), darkMode)
+            }
+        }
         itemsIndexed(parameters) { index, item ->
             SessionAlarmItem(
                 parameter = item,
@@ -241,6 +253,7 @@ private fun AlarmsScreenPreview() {
             onItemClick = { _ -> },
             onDeleteItemClick = {},
         ),
+        showInSidePane = true,
     )
 }
 
@@ -252,7 +265,8 @@ private fun AlarmsScreenEmptyPreview() {
             emptyList(),
             onItemClick = { _ -> },
             onDeleteItemClick = {},
-        )
+        ),
+        showInSidePane = false,
     )
 }
 
@@ -261,5 +275,6 @@ private fun AlarmsScreenEmptyPreview() {
 private fun AlarmsScreenLoadingPreview() {
     AlarmsScreen(
         state = Loading,
+        showInSidePane = false,
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -90,6 +90,7 @@ class AlarmsFragment : Fragment() {
             setContent {
                 AlarmsScreen(
                     state = viewModel.alarmsState.collectAsState().value,
+                    showInSidePane = sidePane,
                 )
             }
             isClickable = true

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
@@ -54,7 +54,8 @@ internal fun SessionChangesScreen(
     showInSidePane: Boolean,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
 ) {
-    EventFahrplanTheme(darkMode = true) {
+    val darkMode = true
+    EventFahrplanTheme(darkMode = darkMode) {
         Scaffold { contentPadding ->
             Box(
                 Modifier
@@ -68,6 +69,7 @@ internal fun SessionChangesScreen(
                             NoScheduleChanges()
                         } else {
                             SessionChangesList(
+                                darkMode = darkMode,
                                 parameters = parameters,
                                 showInSidePane = showInSidePane,
                                 onViewEvent = onViewEvent,
@@ -91,6 +93,7 @@ private fun NoScheduleChanges() {
 
 @Composable
 private fun SessionChangesList(
+    @Suppress("SameParameterValue") darkMode: Boolean,
     parameters: List<SessionChangeParameter>,
     showInSidePane: Boolean,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
@@ -98,7 +101,7 @@ private fun SessionChangesList(
     LazyColumn(state = rememberLazyListState()) {
         if (showInSidePane) {
             item {
-                SessionListHeader(stringResource(R.string.schedule_changes))
+                SessionListHeader(stringResource(R.string.schedule_changes), darkMode)
             }
         }
         itemsIndexed(parameters) { index, parameter ->

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
@@ -342,18 +342,19 @@ private fun DayDateSeparatorItemPreview() {
 }
 
 @Composable
-fun SessionListHeader(text: String) {
+fun SessionListHeader(text: String, darkMode: Boolean) {
+    val color = if (darkMode) R.color.session_list_header_text else R.color.session_list_header_text_inverted
     Text(
         modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
         text = text,
         fontWeight = Bold,
         fontSize = 22.sp,
-        color = colorResource(R.color.session_list_header_text),
+        color = colorResource(color),
     )
 }
 
 @Preview
 @Composable
 private fun SessionListHeaderScheduleChangesPreview() {
-    SessionListHeader(stringResource(R.string.schedule_changes))
+    SessionListHeader(stringResource(R.string.schedule_changes), darkMode = true)
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,6 +2,7 @@
 <resources>
 
     <color name="text_primary">@android:color/primary_text_dark</color>
+    <color name="text_primary_inverted">@android:color/primary_text_light</color>
     <color name="text_secondary">@android:color/secondary_text_dark</color>
     <color name="text_tertiary">@android:color/tertiary_text_dark</color>
     <color name="windowBackground">#003339</color>
@@ -67,6 +68,7 @@
 
     <!-- Session item (favorites + schedule changes) -->
     <color name="session_list_header_text">@color/text_primary</color>
+    <color name="session_list_header_text_inverted">@color/text_primary_inverted</color>
     <color name="session_list_item_text">@color/text_primary</color>
     <color name="session_list_empty_text">@color/text_primary</color>
 


### PR DESCRIPTION
# Description
+ Preferable `isSystemInDarkTheme()` would be used to switch between light and dark mode colors directly. The function returns the wrong state, though. This might be fixed in the future or when there is no more XML layout involved.

# Before & after screenshots
![alarms-1](https://github.com/user-attachments/assets/21c29e46-1dfa-4658-b02d-3b8ff8b8ad0a) ![alarms-2](https://github.com/user-attachments/assets/b971a5cd-54cf-4b85-87d6-b19bb1064c9d)

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
