### PR TITLE
Update project setup (android-test* 1.5.0, sonarqube-gradle-plugin 5.1.0.4882, unmockplugin 0.8.0).

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -53,7 +53,7 @@ object Plugins {
 object Libs {
 
     private object Versions {
-        const val androidTest = "1.4.0"
+        const val androidTest = "1.5.0"
         const val annotation = "1.8.1"
         const val appCompat = "1.7.0"
         const val betterLinkMovementMethod = "2.2.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -64,7 +64,7 @@ object Libs {
         const val engelsystem = "9.1.0"
         const val junitJupiter = "5.10.3"
         const val kotlinCoroutines = "1.8.1"
-        const val lifecycle = "2.8.3"
+        const val lifecycle = "2.8.4"
         const val markwon = "4.6.2"
         const val material = "1.12.0"
         const val mockito = "5.12.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -34,7 +34,7 @@ object Plugins {
         const val android = "8.5.1"
         const val dexcount = "4.0.0"
         const val kotlin = "2.0.0"
-        const val ksp = "2.0.0-1.0.23"
+        const val ksp = "2.0.0-1.0.24"
         const val sonarQube = "5.0.0.4638"
         const val unMock = "0.7.9"
         const val versions = "0.51.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -36,7 +36,7 @@ object Plugins {
         const val kotlin = "2.0.0"
         const val ksp = "2.0.0-1.0.24"
         const val sonarQube = "5.1.0.4882"
-        const val unMock = "0.7.9"
+        const val unMock = "0.8.0"
         const val versions = "0.51.0"
     }
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -54,7 +54,7 @@ object Libs {
 
     private object Versions {
         const val androidTest = "1.4.0"
-        const val annotation = "1.8.0"
+        const val annotation = "1.8.1"
         const val appCompat = "1.7.0"
         const val betterLinkMovementMethod = "2.2.0"
         const val constraintLayout = "2.1.4"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -35,7 +35,7 @@ object Plugins {
         const val dexcount = "4.0.0"
         const val kotlin = "2.0.0"
         const val ksp = "2.0.0-1.0.24"
-        const val sonarQube = "5.0.0.4638"
+        const val sonarQube = "5.1.0.4882"
         const val unMock = "0.7.9"
         const val versions = "0.51.0"
     }


### PR DESCRIPTION
# Description
+ Use annotation v.1.8.1.
+ Use lifecycle v.2.8.4.
+ Use android-test-* v.1.5.0.
+ Use ksp v.2.0.0-1.0.24.
+ Use sonarqube-gradle-plugin v.5.1.0.4882.
+ Use unmockplugin v.0.8.0.

# Successfully tested on
with `froscon2024` flavor, `release` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)