### PR TITLE
Random housekeeping

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
 import android.content.Context
+import android.content.res.Resources.NotFoundException
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -83,7 +84,11 @@ internal class SessionViewDrawer(
         } else {
             trackNameBackgroundColorDefaultPairs[track] ?: R.color.track_background_default
         }
-        @ColorInt val backgroundColor = ContextCompat.getColor(context, backgroundColorResId)
+        @ColorInt val backgroundColor = try {
+            ContextCompat.getColor(context, backgroundColorResId)
+        } catch (e: NotFoundException) {
+            throw NotFoundException("Missing color for track \"$track\". Entries in track_resource_names.xml must be present in track_background_* colors.")
+        }
         val sessionDrawable = if (isFavored && isAlternativeHighlightingEnabled()) {
             SessionDrawable(
                     backgroundColor,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.schedulestatistic
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -110,7 +109,6 @@ private fun NoScheduleStatistic() {
 }
 
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ScheduleStatisticList(scheduleStatistic: List<ColumnStatistic>) {
     LazyColumn(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
@@ -128,7 +128,7 @@ private fun ScheduleStatisticList(scheduleStatistic: List<ColumnStatistic>) {
             ColumnStatisticHeader()
         }
         items(scheduleStatistic, key = { it.name }) {
-            ColumnStatisticItem(it, Modifier.animateItemPlacement())
+            ColumnStatisticItem(it, Modifier.animateItem())
         }
     }
 }


### PR DESCRIPTION
# Description
- Ease understanding missing track color error.
- Replace deprecated `Modifier#animateItemPlacement` with `Modifier#animateItem`.
- Remove unneeded opt-in.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)