### PR TITLE
Indicate progress of horizontal scrolling above room names.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -36,6 +36,7 @@ import androidx.appcompat.app.ActionBar.OnNavigationListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.core.widget.NestedScrollView
@@ -239,6 +240,9 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 viewDay(scheduleData, useDeviceTimeZone, numDays, dayIndex)
                 updateHorizontalScrollingProgressLine(0)
             }
+        viewModel.showHorizontalScrollingProgressLine.observe(this) { shouldShow ->
+            updateHorizontalScrollingProgressLine(shouldShow)
+        }
         viewModel.fahrplanEmptyParameter.observe(viewLifecycleOwner) { (scheduleVersion) ->
             val errorMessage = errorMessageFactory.getMessageForEmptySchedule(scheduleVersion)
             errorMessage.show(requireContext(), shouldShowLong = false)
@@ -321,6 +325,11 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         } else {
             lineView.translationX = 0f
         }
+    }
+
+    private fun updateHorizontalScrollingProgressLine(visible: Boolean) {
+        val lineView = requireView().requireViewByIdCompat<View>(R.id.horizontalScrollingProgressLine)
+        lineView.isInvisible = !visible
     }
 
     /**

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -7,11 +7,18 @@
 
     <include layout="@layout/schedule_no_content" />
 
+    <View
+        android:id="@+id/horizontalScrollingProgressLine"
+        android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
+        android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+
     <LinearLayout
         android:id="@+id/roomNameLandscape"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_below="@+id/horizontalScrollingProgressLine"
         android:background="@color/schedule_room_name_header_background"
         android:orientation="horizontal">
 

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <include layout="@layout/schedule_no_content" />
 
     <LinearLayout
-            android:id="@+id/roomNameLandscape"
-            android:orientation="horizontal"
-            android:layout_alignParentTop="true"
-            android:layout_width="match_parent"
-            android:background="@color/schedule_room_name_header_background"
-            android:layout_height="wrap_content">
+        android:id="@+id/roomNameLandscape"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_room_name_header_background"
+        android:orientation="horizontal">
 
         <Space
             android:layout_width="@dimen/time_width"
@@ -21,15 +21,15 @@
             tools:layout_height="22dp" />
 
         <HorizontalScrollView
-                android:id="@+id/roomScroller"
-                android:scrollbars="none"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+            android:id="@+id/roomScroller"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollbars="none">
 
             <LinearLayout
-                    android:orientation="horizontal"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
                 <!-- Room title views are added here at runtime. -->
 
@@ -38,44 +38,44 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/verticalScrollView"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_below="@+id/roomNameLandscape">
+        android:id="@+id/verticalScrollView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/roomNameLandscape">
 
         <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
             <LinearLayout
-                    android:id="@+id/times_layout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:background="@color/schedule_time_column_background">
+                android:id="@+id/times_layout"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@color/schedule_time_column_background"
+                android:orientation="vertical">
+
+                <!-- Time column views are added here at runtime. -->
+
             </LinearLayout>
 
             <nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView
-                    android:id="@+id/horizScroller"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:fadingEdge="none"
-                    android:scrollbars="none">
+                android:id="@+id/horizScroller"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fadingEdge="none"
+                android:scrollbars="none">
 
                 <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:orientation="horizontal">
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="horizontal">
 
                     <!-- Room column views are added here at runtime. -->
 
                 </LinearLayout>
 
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
-
         </LinearLayout>
-
     </androidx.core.widget.NestedScrollView>
-
 </RelativeLayout>

--- a/app/src/main/res/layout-port/schedule.xml
+++ b/app/src/main/res/layout-port/schedule.xml
@@ -12,7 +12,9 @@
         android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
         android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
         android:layout_alignParentTop="true"
-        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+        android:background="@color/schedule_horizontal_scrolling_progress_line"
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/roomNameLandscape"

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <include layout="@layout/schedule_no_content" />
 
     <LinearLayout
-            android:id="@+id/roomNameLandscape"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:background="@color/schedule_room_name_header_background"
-            android:orientation="horizontal">
+        android:id="@+id/roomNameLandscape"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_room_name_header_background"
+        android:orientation="horizontal">
 
         <Space
             android:layout_width="@dimen/time_width"
@@ -21,15 +21,15 @@
             tools:layout_height="22dp" />
 
         <HorizontalScrollView
-                android:id="@+id/roomScroller"
-                android:scrollbars="none"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+            android:id="@+id/roomScroller"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollbars="none">
 
             <LinearLayout
-                    android:orientation="horizontal"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content">
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
                 <!-- Room title views are added here at runtime. -->
 
@@ -39,43 +39,46 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/verticalScrollView"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_below="@+id/roomNameLandscape"
-            android:fadingEdge="none">
+        android:id="@+id/verticalScrollView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/roomNameLandscape"
+        android:fadingEdge="none">
 
         <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
             <LinearLayout
-                    android:id="@+id/times_layout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_weight="0"
-                    android:background="@color/schedule_time_column_background"
-                    android:orientation="vertical">
+                android:id="@+id/times_layout"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:background="@color/schedule_time_column_background"
+                android:orientation="vertical">
+
+                <!-- Time column views are added here at runtime. -->
 
             </LinearLayout>
 
             <nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView
-                    android:id="@+id/horizScroller"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:fadingEdge="none"
-                    android:scrollbars="none">
+                android:id="@+id/horizScroller"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fadingEdge="none"
+                android:scrollbars="none">
 
                 <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_weight="1"
-                        android:orientation="horizontal">
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
 
                     <!-- Room column views are added here at runtime. -->
 
                 </LinearLayout>
+
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -7,11 +7,18 @@
 
     <include layout="@layout/schedule_no_content" />
 
+    <View
+        android:id="@+id/horizontalScrollingProgressLine"
+        android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
+        android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+
     <LinearLayout
         android:id="@+id/roomNameLandscape"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_below="@+id/horizontalScrollingProgressLine"
         android:background="@color/schedule_room_name_header_background"
         android:orientation="horizontal">
 

--- a/app/src/main/res/layout/schedule_land.xml
+++ b/app/src/main/res/layout/schedule_land.xml
@@ -12,7 +12,9 @@
         android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
         android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
         android:layout_alignParentTop="true"
-        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+        android:background="@color/schedule_horizontal_scrolling_progress_line"
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/roomNameLandscape"

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <include layout="@layout/schedule_no_content" />
 
     <LinearLayout
-            android:id="@+id/roomNameLandscape"
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentTop="true"
-            android:background="@color/schedule_room_name_header_background"
-            >
+        android:id="@+id/roomNameLandscape"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_room_name_header_background"
+        android:orientation="horizontal">
 
         <Space
             android:layout_width="@dimen/time_width"
@@ -22,15 +21,15 @@
             tools:layout_height="22dp" />
 
         <HorizontalScrollView
-                android:id="@+id/roomScroller"
-                android:scrollbars="none"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+            android:id="@+id/roomScroller"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollbars="none">
 
             <LinearLayout
-                    android:orientation="horizontal"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
                 <!-- Room title views are added here at runtime. -->
 
@@ -39,43 +38,46 @@
     </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
-            android:id="@+id/verticalScrollView"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_below="@+id/roomNameLandscape"
-            android:fadingEdge="none">
+        android:id="@+id/verticalScrollView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/roomNameLandscape"
+        android:fadingEdge="none">
 
         <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
 
             <LinearLayout
-                    android:id="@+id/times_layout"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:layout_weight="0"
-                    android:background="@color/schedule_time_column_background"
-                    android:orientation="vertical">
+                android:id="@+id/times_layout"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:background="@color/schedule_time_column_background"
+                android:orientation="vertical">
+
+                <!-- Time column views are added here at runtime. -->
 
             </LinearLayout>
 
             <nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView
-                    android:id="@+id/horizScroller"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:fadingEdge="none"
-                    android:scrollbars="none">
+                android:id="@+id/horizScroller"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fadingEdge="none"
+                android:scrollbars="none">
 
                 <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:layout_weight="1"
-                        android:orientation="horizontal">
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_weight="1"
+                    android:orientation="horizontal">
 
                     <!-- Room column views are added here at runtime. -->
 
                 </LinearLayout>
+
             </nerd.tuxmobil.fahrplan.congress.schedule.HorizontalSnapScrollView>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -7,11 +7,18 @@
 
     <include layout="@layout/schedule_no_content" />
 
+    <View
+        android:id="@+id/horizontalScrollingProgressLine"
+        android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
+        android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
+        android:layout_alignParentTop="true"
+        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+
     <LinearLayout
         android:id="@+id/roomNameLandscape"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
+        android:layout_below="@+id/horizontalScrollingProgressLine"
         android:background="@color/schedule_room_name_header_background"
         android:orientation="horizontal">
 

--- a/app/src/main/res/layout/schedule_land_large.xml
+++ b/app/src/main/res/layout/schedule_land_large.xml
@@ -12,7 +12,9 @@
         android:layout_width="@dimen/schedule_horizontal_scrolling_progress_line_width"
         android:layout_height="@dimen/schedule_horizontal_scrolling_progress_line_height"
         android:layout_alignParentTop="true"
-        android:background="@color/schedule_horizontal_scrolling_progress_line" />
+        android:background="@color/schedule_horizontal_scrolling_progress_line"
+        android:visibility="invisible"
+        tools:visibility="visible" />
 
     <LinearLayout
         android:id="@+id/roomNameLandscape"

--- a/app/src/main/res/values-land/schedule.xml
+++ b/app/src/main/res/values-land/schedule.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="layout" name="schedule">
+    <item name="schedule" type="layout">
         @layout/schedule_land
     </item>
-
 </resources>

--- a/app/src/main/res/values-sw600dp/schedule.xml
+++ b/app/src/main/res/values-sw600dp/schedule.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="layout" name="schedule">
+    <item name="schedule" type="layout">
         @layout/schedule_land_large
     </item>
-
 </resources>

--- a/app/src/main/res/values-xlarge/schedule.xml
+++ b/app/src/main/res/values-xlarge/schedule.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item type="layout" name="schedule">
+    <item name="schedule" type="layout">
         @layout/schedule_land_large
     </item>
-
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -46,6 +46,7 @@
     <color name="schedule_time_column_item_background_emphasized">#fff</color>
     <color name="schedule_time_column_item_text_normal">#fff</color>
     <color name="schedule_time_column_item_text_emphasized">#000</color>
+    <color name="schedule_horizontal_scrolling_progress_line">@color/colorAccent</color>
     <color name="schedule_room_name_header_background">#000</color>
     <color name="schedule_room_name_header_text">#fff</color>
     <color name="session_item_alarm_icon">#fff</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -40,6 +40,10 @@
     <!-- Progress bar -->
     <dimen name="progress_bar_elevation">@dimen/tool_bar_elevation</dimen>
 
+    <!-- Horizontal scrolling progress line -->
+    <dimen name="schedule_horizontal_scrolling_progress_line_height">2dp</dimen>
+    <dimen name="schedule_horizontal_scrolling_progress_line_width">50dp</dimen>
+
     <!-- SnackEngage -->
     <dimen name="snack_engage_c3nav_pixel_offset">20dp</dimen>
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -24,8 +24,19 @@ import nerd.tuxmobil.fahrplan.congress.models.Meta
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.net.HttpStatus.HTTP_NOT_FOUND
+import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Fetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialFetching
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialParsing
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseFailure
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.ParseSuccess
+import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanEmptyParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToCurrentSessionParameter
@@ -36,6 +47,8 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
@@ -45,9 +58,47 @@ import org.threeten.bp.ZoneOffset
 @ExtendWith(MainDispatcherTestExtension::class)
 class FahrplanViewModelTest {
 
+    companion object {
+        private val fetchFailure = FetchFailure(
+            httpStatus = HTTP_NOT_FOUND,
+            hostName = "example.com",
+            exceptionMessage = "",
+            isUserRequest = false,
+        )
+        private val parseFailure = ParseFailure(
+            ParseScheduleResult(isSuccess = true, version = "")
+        )
+
+        @JvmStatic
+        fun showByState() = listOf(
+            arrayOf(InitialFetching, false),
+            arrayOf(Fetching, false),
+            arrayOf(InitialParsing, false),
+            arrayOf(Parsing, false),
+            arrayOf(FetchSuccess, true),
+            arrayOf(fetchFailure, true),
+            arrayOf(ParseSuccess, true),
+            arrayOf(parseFailure, true),
+        )
+    }
+
     private val simpleSessionFormat = mock<SimpleSessionFormat>()
     private val jsonSessionFormat = mock<JsonSessionFormat>()
     private val scrollAmountCalculator = mock<ScrollAmountCalculator>()
+
+    @ParameterizedTest(name = "{index}: showHorizontalScrollingProgressLine property emits {1} when loadScheduleState is {0}")
+    @MethodSource("showByState")
+    fun `HorizontalProgressLine #`(
+        state: LoadScheduleState,
+        shouldShow: Boolean
+    ) = runTest {
+        val repository = createRepository(loadScheduleStateFlow = flowOf(state))
+        val viewModel = createViewModel(repository)
+        viewModel.showHorizontalScrollingProgressLine.test {
+            assertThat(awaitItem()).isEqualTo(shouldShow)
+            expectNoEvents()
+        }
+    }
 
     @Nested
     inner class ScheduleUpdateAlarm {
@@ -624,6 +675,7 @@ class FahrplanViewModelTest {
         uncanceledSessionsForDayIndexFlow: Flow<ScheduleData> = emptyFlow(),
         sessionsWithoutShiftsFlow: Flow<List<Session>> = emptyFlow(),
         loadUncanceledSessionsForDayIndex: ScheduleData = mock(),
+        loadScheduleStateFlow: Flow<LoadScheduleState> = emptyFlow(),
         alarmsFlow: Flow<List<Alarm>> = flowOf(emptyList()),
         meta: Meta = Meta(numDays = 0, version = "test-version"),
         isAutoUpdateEnabled: Boolean = true,
@@ -634,6 +686,7 @@ class FahrplanViewModelTest {
         on { uncanceledSessionsForDayIndex } doReturn uncanceledSessionsForDayIndexFlow
         on { sessionsWithoutShifts } doReturn sessionsWithoutShiftsFlow
         on { loadUncanceledSessionsForDayIndex() } doReturn loadUncanceledSessionsForDayIndex
+        on { loadScheduleState } doReturn loadScheduleStateFlow
         on { alarms } doReturn alarmsFlow
         on { readMeta() } doReturn meta
         on { readAutoUpdateEnabled() } doReturn isAutoUpdateEnabled


### PR DESCRIPTION
# Description
+ This is intended to help users to understand how many rooms are hidden off-screen and to encourage horizontal scrolling.
+ As the user scrolls from room to room, the progress line moves by a corresponding amount. This shows where the current room is in relation to the full width of all rooms.
+ Using progress indicator dots has been considered but discarded because with the amount of rooms there was no way to place that many dots while improving the user experience.
+ Hide progress line while progress bar is still animating.
  + The `MainActivity` hosts a `progressBar` view which is displayed when schedule data is fetched or parsed. While the `progressBar` is animating, the progress line in the `FahrplanFragment` is invisible. This helps to avoid visual clutter because the progress line is placed directly below the progress bar.

# Smartphone before & after
![phone-portrait-before](https://github.com/user-attachments/assets/b7472f2a-91cc-4d95-9aa6-f337d39e8d81) ![phone-portrait-after](https://github.com/user-attachments/assets/9b84127d-66e1-4d3d-8419-c22ad47ec236)

![phone-landscape-before](https://github.com/user-attachments/assets/04ddb8b6-cf8f-46c9-948c-43e33d41d756) ![phone-landscape-after](https://github.com/user-attachments/assets/3b690d35-2a5b-4e8b-9f88-a05975ef26c3)

# Tablet before & after
![tablet-before](https://github.com/user-attachments/assets/38aa1ba7-9801-473e-819e-3ec16d1cf563) ![tablet-after](https://github.com/user-attachments/assets/d89a309a-5a20-428f-96d6-d3ea2f414ef6)


# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---

Resolves #532