### PR TITLE
Fix broken screen navigation.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -45,9 +45,8 @@ class AlarmsFragment : Fragment() {
     private lateinit var appRepository: AppRepository
     private lateinit var resourceResolving: ResourceResolving
     private lateinit var alarmServices: AlarmServices
-    private lateinit var screenNavigation: ScreenNavigation
     private val viewModel: AlarmsViewModel by viewModels {
-        AlarmsViewModelFactory(appRepository, resourceResolving, alarmServices, screenNavigation)
+        AlarmsViewModelFactory(appRepository, resourceResolving, alarmServices)
     }
     private var sidePane = false
     private var onSessionItemClickListener: OnSessionItemClickListener? = null
@@ -57,7 +56,7 @@ class AlarmsFragment : Fragment() {
         appRepository = AppRepository
         resourceResolving = ResourceResolver(context)
         alarmServices = AlarmServices.newInstance(context, appRepository)
-        screenNavigation = ScreenNavigation { sessionId ->
+        viewModel.screenNavigation = ScreenNavigation { sessionId ->
             onSessionItemClickListener?.onSessionItemClick(sessionId)
         }
         onSessionItemClickListener = try {
@@ -69,6 +68,7 @@ class AlarmsFragment : Fragment() {
 
     override fun onDetach() {
         onSessionItemClickListener = null
+        viewModel.screenNavigation = null
         super.onDetach()
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -21,10 +21,11 @@ internal class AlarmsViewModel(
     private val repository: AppRepository = AppRepository,
     private val executionContext: ExecutionContext,
     private val alarmServices: AlarmServices,
-    private val screenNavigation: ScreenNavigation,
     private val alarmsStateFactory: AlarmsStateFactory,
 
 ) : ViewModel() {
+
+    var screenNavigation: ScreenNavigation? = null
 
     private val useDeviceTimeZone: Boolean
         get() = repository.readUseDeviceTimeZoneEnabled()
@@ -44,7 +45,7 @@ internal class AlarmsViewModel(
     }
 
     private fun navigateToSessionDetails(value: SessionAlarmParameter) {
-        screenNavigation.navigateToSessionDetails(value.sessionId)
+        screenNavigation?.navigateToSessionDetails(value.sessionId)
     }
 
     private fun deleteSessionAlarm(value: SessionAlarmParameter) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelFactory.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
-import nerd.tuxmobil.fahrplan.congress.commons.ScreenNavigation
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
@@ -11,7 +10,6 @@ internal class AlarmsViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
     private val alarmServices: AlarmServices,
-    private val screenNavigation: ScreenNavigation,
 ) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -20,7 +18,6 @@ internal class AlarmsViewModelFactory(
             repository = appRepository,
             executionContext = AppExecutionContext,
             alarmServices = alarmServices,
-            screenNavigation = screenNavigation,
             alarmsStateFactory = AlarmsStateFactory(resourceResolving),
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelFactory.kt
@@ -8,13 +8,11 @@ import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
 internal class AlarmsViewModelFactory(
-
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
     private val alarmServices: AlarmServices,
     private val screenNavigation: ScreenNavigation,
-
-    ) : Factory {
+) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -56,12 +56,10 @@ class ChangeListFragment : Fragment() {
     }
 
     private var onSessionListClickListener: OnSessionListClick? = null
-    private lateinit var screenNavigation: ScreenNavigation
     private val viewModelFactory by lazy {
         ChangeListViewModelFactory(
             AppRepository,
             ResourceResolver(requireContext()),
-            screenNavigation,
             SessionPropertiesFormatter(),
             ContentDescriptionFormatter(requireContext()),
         )
@@ -109,11 +107,11 @@ class ChangeListFragment : Fragment() {
     @CallSuper
     override fun onAttach(context: Context) {
         super.onAttach(context)
+        viewModel.screenNavigation = ScreenNavigation { sessionId ->
+            onSessionListClickListener?.onSessionListClick(sessionId)
+        }
         if (context is OnSessionListClick) {
             onSessionListClickListener = context
-            screenNavigation = ScreenNavigation { sessionId ->
-                onSessionListClickListener?.onSessionListClick(sessionId)
-            }
         } else {
             error("$context must implement OnSessionListClick")
         }
@@ -124,6 +122,7 @@ class ChangeListFragment : Fragment() {
     override fun onDetach() {
         super.onDetach()
         onSessionListClickListener = null
+        viewModel.screenNavigation = null
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
@@ -21,9 +21,10 @@ import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 class ChangeListViewModel(
     private val repository: AppRepository,
     private val executionContext: ExecutionContext,
-    private val screenNavigation: ScreenNavigation,
     private val sessionChangeParametersFactory: SessionChangeParametersFactory,
 ) : ViewModel() {
+
+    var screenNavigation: ScreenNavigation? = null
 
     private val mutableSessionChangeState = MutableStateFlow<SessionChangeState>(Loading)
     val sessionChangesState = mutableSessionChangeState.asStateFlow()
@@ -47,7 +48,7 @@ class ChangeListViewModel(
 
     fun onViewEvent(viewEvent: SessionChangeViewEvent) {
         when (viewEvent) {
-            is OnSessionChangeItemClick -> screenNavigation.navigateToSessionDetails(viewEvent.sessionId)
+            is OnSessionChangeItemClick -> screenNavigation?.navigateToSessionDetails(viewEvent.sessionId)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
-import nerd.tuxmobil.fahrplan.congress.commons.ScreenNavigation
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
@@ -13,7 +12,6 @@ import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 class ChangeListViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
-    private val screenNavigation: ScreenNavigation,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
     private val contentDescriptionFormatter: ContentDescriptionFormatter,
 ) : Factory {
@@ -23,7 +21,6 @@ class ChangeListViewModelFactory(
         return ChangeListViewModel(
             repository = appRepository,
             executionContext = AppExecutionContext,
-            screenNavigation = screenNavigation,
             sessionChangeParametersFactory = SessionChangeParametersFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatter = sessionPropertiesFormatter,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.changes
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelProvider.Factory
 import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenNavigation
@@ -16,7 +16,7 @@ class ChangeListViewModelFactory(
     private val screenNavigation: ScreenNavigation,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
     private val contentDescriptionFormatter: ContentDescriptionFormatter,
-) : ViewModelProvider.Factory {
+) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         @Suppress("UNCHECKED_CAST")

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -99,7 +99,8 @@ class AlarmsViewModelTest {
         )
         val screenNavigation = mock<ScreenNavigation>()
         doNothing().`when`(screenNavigation).navigateToSessionDetails(any())
-        val viewModel = createViewModel(repository, screenNavigation = screenNavigation)
+        val viewModel = createViewModel(repository)
+        viewModel.screenNavigation = screenNavigation
         viewModel.alarmsState.take(1).collect { state ->
             assertThat(state).isInstanceOf(Success::class.java)
             val success = state as Success
@@ -187,12 +188,10 @@ class AlarmsViewModelTest {
     private fun createViewModel(
         repository: AppRepository,
         alarmServices: AlarmServices = mock(),
-        screenNavigation: ScreenNavigation = mock(),
     ) = AlarmsViewModel(
         repository = repository,
         executionContext = TestExecutionContext,
         alarmServices = alarmServices,
-        screenNavigation = screenNavigation,
         alarmsStateFactory = createAlarmsStateFactory(),
     )
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
@@ -134,7 +134,8 @@ class ChangeListViewModelTest {
     @Test
     fun `onViewEvent(OnSessionChangeItemClick) invokes navigateToSessionDetails`() = runTest {
         val screenNavigation = mock<ScreenNavigation>()
-        val viewModel = createViewModel(createRepository(), screenNavigation)
+        val viewModel = createViewModel(createRepository())
+        viewModel.screenNavigation = screenNavigation
         viewModel.onViewEvent(OnSessionChangeItemClick(sessionId = "42"))
         verifyInvokedOnce(screenNavigation).navigateToSessionDetails(sessionId = "42")
     }
@@ -219,12 +220,10 @@ class ChangeListViewModelTest {
 
     private fun createViewModel(
         repository: AppRepository,
-        screenNavigation: ScreenNavigation = mock(),
         factory: SessionChangeParametersFactory = mock(),
     ) = ChangeListViewModel(
         repository = repository,
         executionContext = TestExecutionContext,
-        screenNavigation = screenNavigation,
         sessionChangeParametersFactory = factory,
     )
 


### PR DESCRIPTION
# Description
+ Fix broken screen navigation when tapping session alarm item. 
  + When the device was rotated while the alarms screen was visible then tapping the session alarm resulted in no action.
  + The `onSessionItemClickListener` referenced in the `ScreenNavigation` lambda was `null` once the fragment was recreated.
+ Fix broken screen navigation when tapping session change item.
  + When the device was rotated while the alarms screen was visible then tapping the session change resulted in no action.
  + The `onSessionListClickListener` referenced in the `ScreenNavigation` lambda was `null` once the fragment was recreated.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)

# Related
- #550 
- #661