### PR TITLE
Replace deprecated options menu API with MenuProvider.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -12,10 +12,12 @@ import androidx.annotation.IdRes
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.OnSessionItemClickListener
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
@@ -26,7 +28,7 @@ import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
-class AlarmsFragment : Fragment() {
+class AlarmsFragment : Fragment(), MenuProvider {
 
     companion object {
         const val FRAGMENT_TAG = "ALARMS_FRAGMENT_TAG"
@@ -81,7 +83,7 @@ class AlarmsFragment : Fragment() {
         arguments?.let {
             sidePane = it.getBoolean(BundleKeys.SIDEPANE)
         }
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, this, RESUMED)
     }
 
     override fun onCreateView(
@@ -101,18 +103,16 @@ class AlarmsFragment : Fragment() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.alarms_menu, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.alarms_menu, menu)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem) = when (item.itemId) {
-        R.id.menu_item_delete_all_alarms -> {
-            viewModel.onDeleteAllClick()
-            true
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        when (menuItem.itemId) {
+            R.id.menu_item_delete_all_alarms -> viewModel.onDeleteAllClick()
+            else -> return false
         }
-
-        else -> super.onOptionsItemSelected(item)
+        return true
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -19,10 +19,12 @@ import android.widget.Toast
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.MainThread
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import info.metadude.android.eventfahrplan.commons.flow.observe
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
@@ -53,6 +55,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
  */
 class StarredListFragment :
     AbstractListFragment(),
+    MenuProvider,
     MultiChoiceModeListener,
     AbsListView.OnScrollListener {
 
@@ -101,7 +104,7 @@ class StarredListFragment :
         arguments?.let {
             sidePane = it.getBoolean(BundleKeys.SIDEPANE)
         }
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, this, RESUMED)
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
@@ -221,9 +224,8 @@ class StarredListFragment :
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.starred_list_menu, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.starred_list_menu, menu)
         var item = menu.findItem(R.id.menu_item_delete_all_favorites)
         if (item != null && (!::starredList.isInitialized || starredList.isEmpty())) {
             item.isVisible = false
@@ -237,8 +239,8 @@ class StarredListFragment :
         }
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when (item.itemId) {
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        when (menuItem.itemId) {
             R.id.menu_item_share_favorites,
             R.id.menu_item_share_favorites_text -> {
                 viewModel.share()
@@ -256,7 +258,7 @@ class StarredListFragment :
                 return requireActivity().navigateUp()
             }
         }
-        return super.onOptionsItemSelected(item)
+        return false
     }
 
     override fun onItemCheckedStateChanged(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -36,6 +36,7 @@ import androidx.appcompat.app.ActionBar.OnNavigationListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
+import androidx.core.view.MenuProvider
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -43,6 +44,7 @@ import androidx.core.widget.NestedScrollView
 import androidx.core.widget.NestedScrollView.OnScrollChangeListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -75,7 +77,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
-class FahrplanFragment : Fragment(), SessionViewEventsHandler {
+class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
 
     /**
      * Interface definition for a callback to be invoked when a session view is clicked.
@@ -180,7 +182,7 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
                 }
             }
 
-        setHasOptionsMenu(true)
+        requireActivity().addMenuProvider(this, this, RESUMED)
         val context = requireContext()
         roomTitleTypeFace = TypefaceFactory.getNewInstance(context).getTypeface(Font.Roboto.Light)
         sessionViewDrawer = SessionViewDrawer(
@@ -600,18 +602,16 @@ class FahrplanFragment : Fragment(), SessionViewEventsHandler {
         return true
     }
 
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.fahrplan_menu, menu)
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.fahrplan_menu, menu)
     }
 
-    override fun onOptionsItemSelected(menuItem: MenuItem): Boolean {
-        return if (menuItem.itemId == R.id.menu_item_refresh) {
-            viewModel.requestScheduleUpdate(isUserRequest = true)
-            true
-        } else {
-            super.onOptionsItemSelected(menuItem)
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        when (menuItem.itemId) {
+            R.id.menu_item_refresh -> viewModel.requestScheduleUpdate(isUserRequest = true)
+            else -> return false
         }
+        return true
     }
 
     private fun updateMenuItems() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Menu
+import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
@@ -19,11 +20,13 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
+import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.core.widget.ContentLoadingProgressBar
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.OnBackStackChangedListener
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import info.metadude.android.eventfahrplan.commons.flow.observe
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.about.AboutDialog
@@ -57,6 +60,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog.OnConfirmationDi
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
 
 class MainActivity : BaseActivity(),
+    MenuProvider,
     OnSidePaneCloseListener,
     OnSessionListClick,
     OnSessionClickListener,
@@ -116,6 +120,7 @@ class MainActivity : BaseActivity(),
         super.onCreate(savedInstanceState)
         instance = this
         setContentView(R.layout.main_layout)
+        addMenuProvider(this, this, RESUMED)
 
         notificationHelper = NotificationHelper(this)
 
@@ -229,12 +234,6 @@ class MainActivity : BaseActivity(),
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        super.onCreateOptionsMenu(menu)
-        menuInflater.inflate(R.menu.mainmenu, menu)
-        return true
-    }
-
     private fun showChangesDialog(scheduleVersion: String, changeStatistic: ChangeStatistic) {
         val fragment = findFragment(ChangesDialog.FRAGMENT_TAG)
         if (fragment == null) {
@@ -250,24 +249,20 @@ class MainActivity : BaseActivity(),
         AboutDialog().show(transaction, AboutDialog.FRAGMENT_TAG)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        val functionByOptionItemId = mapOf(
-            R.id.menu_item_about to { viewModel.showAboutDialog() },
-            R.id.menu_item_alarms to { openAlarms() },
-            R.id.menu_item_settings to { SettingsActivity.startForResult(this) },
-            R.id.menu_item_schedule_changes to { openSessionChanges() },
-            R.id.menu_item_favorites to { openFavorites() }
-        )
-        return when (val function = functionByOptionItemId[item.itemId]) {
-            null -> {
-                super.onOptionsItemSelected(item)
-            }
+    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+        menuInflater.inflate(R.menu.mainmenu, menu)
+    }
 
-            else -> {
-                function.invoke()
-                true
-            }
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+        when (menuItem.itemId) {
+            R.id.menu_item_about -> viewModel.showAboutDialog()
+            R.id.menu_item_alarms -> openAlarms()
+            R.id.menu_item_settings -> SettingsActivity.startForResult(this)
+            R.id.menu_item_schedule_changes -> openSessionChanges()
+            R.id.menu_item_favorites -> openFavorites()
+            else -> return false
         }
+        return true
     }
 
     private fun openSessionDetails() {


### PR DESCRIPTION
# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)

---

Resolves #507