### PR TITLE
Random housekeeping (Copyright logo text, search icon)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Composables.kt
@@ -202,6 +202,7 @@ fun ClickableText(
                             gravity = if (textAlign == TextAlign.Center) CENTER else START
                             textSize = fontSize.value
                             text = textResource.html.toSpanned()
+                            setLineSpacing(0f, 1.5f)
                         }
                     },
                 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -43,6 +43,7 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment
 import nerd.tuxmobil.fahrplan.congress.engagements.initUserEngagement
+import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.favorites.StarredListActivity
 import nerd.tuxmobil.fahrplan.congress.favorites.StarredListFragment
@@ -133,7 +134,7 @@ class MainActivity : BaseActivity(),
         progressBar = requireViewByIdCompat(R.id.progress)
 
         setSupportActionBar(toolbar)
-        supportActionBar!!.setTitle(R.string.fahrplan)
+        supportActionBar!!.title = if (isLandscape()) getString(R.string.app_name) else ""
         supportActionBar!!.setDisplayShowHomeEnabled(true)
         supportActionBar!!.setDefaultDisplayHomeAsUpEnabled(true)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)

--- a/app/src/main/res/menu/mainmenu.xml
+++ b/app/src/main/res/menu/mainmenu.xml
@@ -26,7 +26,7 @@
             android:id="@+id/menu_item_search"
             android:icon="@drawable/ic_search"
             android:orderInCategory="60"
-            app:showAsAction="ifRoom"
+            app:showAsAction="always"
             android:title="@string/menu_item_title_search"
             android:titleCondensed="@string/menu_item_title_search">
     </item>


### PR DESCRIPTION
# Description
+ Adjust line spacing of copyright logo text in About screen.
+ Hide app name in portrait mode to make room for toolbar icons.
+ Show search toolbar icon prominently in toolbar.

# Before & after screenshots
The About screen without extra line spacing and with adjusted line spacing for the copyright logo text.
![phone-about-before](https://github.com/user-attachments/assets/7b5a3cc8-79e2-4d82-bcc6-63d7c72b2a44) ![phone-about-after](https://github.com/user-attachments/assets/854afb11-cec5-4cf5-abd3-39c07dc7efe7)

The Schedule screen toolbar without and with search icon.
![phone-toolbar-before](https://github.com/user-attachments/assets/0f71f80b-1fda-493a-a7a2-a4872e9ff002) ![phone-toolbar-after](https://github.com/user-attachments/assets/16ddbc53-60f2-45e3-a81e-d95e936f3c80)

# Successfully tested on
with `ccc37c3` & `mrmcd2024` flavors, `debug` builds
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)