### PR TITLE
Fix content description for session without speaker names.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -24,13 +24,16 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
         return resourceResolving.getString(R.string.session_list_item_room_content_description, roomName)
     }
 
-    fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String) =
-        if (formattedSpeakerNames.isEmpty()) ""
-        else resourceResolving.getQuantityString(
-            R.plurals.session_list_item_speakers_content_description,
-            speakersCount,
-            formattedSpeakerNames
-        )
+    fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String): String =
+        if (speakersCount == 0 || formattedSpeakerNames.isEmpty()) {
+            resourceResolving.getString(R.string.session_list_item_zero_speakers_content_description)
+        } else {
+            resourceResolving.getQuantityString(
+                R.plurals.session_list_item_speakers_content_description,
+                speakersCount,
+                formattedSpeakerNames
+            )
+        }
 
     fun getFormattedTrackContentDescription(trackName: String, languageCode: String) =
         buildString {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- Menu items -->
     <string name="menu_item_title_about">Info</string>
@@ -230,8 +230,8 @@
     <string name="session_list_item_no_video_content_description">Ohne Videoaufzeichnung</string>
     <string name="session_list_item_video_content_description">Mit Videoaufzeichnung</string>
     <string name="session_list_item_without_video_content_description">Ohne Videoaufzeichnung</string>
-    <plurals name="session_list_item_speakers_content_description" tools:ignore="UnusedQuantity">
-        <item quantity="zero">Keine Sprecher innen</item>
+    <string name="session_list_item_zero_speakers_content_description">Keine Sprecher innen</string>
+    <plurals name="session_list_item_speakers_content_description">
         <item quantity="one">Sprecher in: <xliff:g example="Jane Doe" id="name">%s</xliff:g></item>
         <item quantity="other">Sprecher innen: <xliff:g example="Jane Doe, John Doe" id="names">%s</xliff:g></item>
     </plurals>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -205,10 +205,11 @@
     <string name="session_list_item_no_video_content_description">Bez nagrania</string>
     <string name="session_list_item_video_content_description">Z nagraniem</string>
     <string name="session_list_item_without_video_content_description">Bez nagrania</string>
+    <string name="session_list_item_zero_speakers_content_description">Brak prelegentów</string>
     <plurals name="session_list_item_speakers_content_description">
         <item quantity="one">Prelegent: <xliff:g example="Jane Doe" id="name">%s</xliff:g></item>
-        <item quantity="few">Kilkoro prelegentów</item>
-        <item quantity="many">Wielu prelegentów</item>
+        <item quantity="few">Prelegenci: <xliff:g example="Jane Doe, John Doe" id="names">%s</xliff:g></item>
+        <item quantity="many">Prelegenci: <xliff:g example="Jane Doe, John Doe" id="names">%s</xliff:g></item>
         <item quantity="other">Prelegenci: <xliff:g example="Jane Doe, John Doe" id="names">%s</xliff:g></item>
     </plurals>
     <!-- Session item -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -262,8 +262,8 @@
     <string name="session_list_item_no_video_content_description">Without video recording</string>
     <string name="session_list_item_video_content_description">With video recording</string>
     <string name="session_list_item_without_video_content_description">Without video recording</string>
+    <string name="session_list_item_zero_speakers_content_description">No speakers</string>
     <plurals name="session_list_item_speakers_content_description">
-        <item quantity="zero">No speakers</item>
         <item quantity="one">Speaker: <xliff:g example="Jane Doe" id="name">%s</xliff:g></item>
         <item quantity="other">Speakers: <xliff:g example="Jane Doe, John Doe" id="names">%s</xliff:g></item>
     </plurals>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -67,7 +67,7 @@ class SearchResultParameterFactoryTest {
                 SearchResultParameter.SearchResult(
                     id = "123",
                     title = SearchResultProperty(value = "-", contentDescription = ""),
-                    speakerNames = SearchResultProperty(value = "-", contentDescription = ""),
+                    speakerNames = SearchResultProperty(value = "-", contentDescription = "No speakers"),
                     startsAt = SearchResultProperty(value = "$SOME_DATE, $SOME_TIME", contentDescription = "Start time: $SOME_DATE, $SOME_TIME"),
                 )
             )
@@ -97,6 +97,7 @@ private object CompleteResourceResolver : ResourceResolving {
         R.string.dash -> "-"
         R.string.session_list_item_title_content_description -> "Title: Session 123"
         R.string.session_list_item_start_time_content_description -> "Start time: $SOME_DATE, $SOME_TIME"
+        R.string.session_list_item_zero_speakers_content_description -> "No speakers"
         R.plurals.session_list_item_speakers_content_description -> "Speakers: Jane Doe; John Doe"
         else -> fail("Unknown string id : $id")
     }
@@ -105,7 +106,7 @@ private object CompleteResourceResolver : ResourceResolving {
         when (id) {
             R.plurals.session_list_item_speakers_content_description ->
                 when (quantity) {
-                    0 -> ""
+                    0 -> "No speakers"
                     else -> "Speakers: Jane Doe; John Doe"
                 }
 


### PR DESCRIPTION
# Description
+ Previously, the correct text for zero speakers was never read out when using TalkBalk. The quantity string system of Android is not intended to be used without a digit in the actual text.
+ This affects all screens where sessions are shown: schedule screen, favorites, alarms, schedule changes, search results.
+ Ref: https://developer.android.com/guide/topics/resources/string-resource#Plurals

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)

# Related
- https://stackoverflow.com/a/42884713/356895
- https://stackoverflow.com/a/65723755/356895