### PR TITLE
Update session card layout (text size)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import android.content.Context
 import android.content.res.Resources.NotFoundException
+import android.util.TypedValue.COMPLEX_UNIT_PX
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
@@ -130,9 +131,14 @@ internal class SessionViewDrawer(
             else
                 R.color.session_item_text_on_default_background
             val textColor = ContextCompat.getColor(view.context, colorResId)
+            val resources = view.resources
+            title.setTextSize(COMPLEX_UNIT_PX, resources.getDimension(R.dimen.session_drawable_title))
             title.setTextColor(textColor)
+            subtitle.setTextSize(COMPLEX_UNIT_PX, resources.getDimension(R.dimen.session_drawable_subtitle))
             subtitle.setTextColor(textColor)
+            speakers.setTextSize(COMPLEX_UNIT_PX, resources.getDimension(R.dimen.session_drawable_speakers))
             speakers.setTextColor(textColor)
+            track.setTextSize(COMPLEX_UNIT_PX, resources.getDimension(R.dimen.session_drawable_track))
             track.setTextColor(textColor)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -115,7 +115,8 @@ internal class SessionViewDrawer(
                 0)
         sessionView.background = sessionDrawable
         val padding = getSessionPadding()
-        sessionView.setPadding(padding, padding, padding, padding)
+        val verticalPadding = (padding * 0.3).toInt()
+        sessionView.setPadding(padding, verticalPadding, padding, verticalPadding)
     }
 
     companion object {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -63,10 +63,10 @@
     <dimen name="session_drawable_inset_left">3dp</dimen>
     <dimen name="session_drawable_inset_right">1dp</dimen>
     <dimen name="session_drawable_selection_stroke_width">2dp</dimen>
-    <dimen name="session_drawable_title">20sp</dimen>
-    <dimen name="session_drawable_subtitle">16sp</dimen>
-    <dimen name="session_drawable_speakers">13sp</dimen>
-    <dimen name="session_drawable_track">13sp</dimen>
+    <dimen name="session_drawable_title">16sp</dimen>
+    <dimen name="session_drawable_subtitle">13sp</dimen>
+    <dimen name="session_drawable_speakers">12sp</dimen>
+    <dimen name="session_drawable_track">12sp</dimen>
 
     <!-- Alert dialogs -->
     <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -63,6 +63,10 @@
     <dimen name="session_drawable_inset_left">3dp</dimen>
     <dimen name="session_drawable_inset_right">1dp</dimen>
     <dimen name="session_drawable_selection_stroke_width">2dp</dimen>
+    <dimen name="session_drawable_title">20sp</dimen>
+    <dimen name="session_drawable_subtitle">16sp</dimen>
+    <dimen name="session_drawable_speakers">13sp</dimen>
+    <dimen name="session_drawable_track">13sp</dimen>
 
     <!-- Alert dialogs -->
     <!-- See: https://www.google.de/design/spec/components/dialogs.html#dialogs-specs -->


### PR DESCRIPTION
# Description
- The changes applied here are a minor part of a general layout refresh being prepared in #570.
- Here more visual space is made free to display the texts on a session card.
- All text sizes of a session card are customizable.

# Before & after screenshots
![session-card-1](https://github.com/user-attachments/assets/688b2823-b779-4e7e-b724-98607d0bc4ca) ![session-card-2](https://github.com/user-attachments/assets/49f8a1aa-a714-4168-8d3c-96e6cbcef5cd)

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)
