### PR TITLE
Update project setup (Jetpack Compose UI 2024.11.00, engelsystem 9.2.0, ksp 2.0.21-1.0.28, unmockplugin 0.9.0).

### DIFF
--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -36,7 +36,7 @@ object Plugins {
         const val kotlin = "2.0.21"
         const val ksp = "2.0.21-1.0.28"
         const val sonarQube = "5.1.0.4882"
-        const val unMock = "0.8.0"
+        const val unMock = "0.9.0"
         const val versions = "0.51.0"
     }
 

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -34,7 +34,7 @@ object Plugins {
         const val android = "8.7.2"
         const val dexcount = "4.0.0"
         const val kotlin = "2.0.21"
-        const val ksp = "2.0.21-1.0.26"
+        const val ksp = "2.0.21-1.0.28"
         const val sonarQube = "5.1.0.4882"
         const val unMock = "0.8.0"
         const val versions = "0.51.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -62,7 +62,7 @@ object Libs {
         const val coreKtx = "1.13.1" // compileSdk 35 is required as of 1.15.0
         const val coreTesting = "2.2.0"
         const val emailIntentBuilder = "2.0.0"
-        const val engelsystem = "9.1.0"
+        const val engelsystem = "9.2.0"
         const val fragmentCompose = "1.8.5"
         const val junitJupiter = "5.11.3"
         const val kotlinCoroutines = "1.9.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -18,7 +18,7 @@ object Android {
 object Compose {
 
     private object Versions {
-        const val bom = "2024.10.01"
+        const val bom = "2024.11.00"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Description
+ Use Gradle wrapper v.8.11.1.
+ Use engelsystem v.9.2.0.
+ Use ksp v.2.0.21-1.0.28.
+ Use unmockplugin v.0.9.0.
+ Use Jetpack Compose UI 2024.11.00.

# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)