### PR TITLE
Simplify color customization for alarms, schedule changes, search and details screens.

### DIFF
--- a/app/src/cccamp2023/res/values/colors.xml
+++ b/app/src/cccamp2023/res/values/colors.xml
@@ -11,7 +11,6 @@
     <color name="windowBackground">#1a1a1a</color>
     <color name="text_link_on_light">#32CC1B</color>
     <color name="multi_choice_background">#ffc600</color>
-    <color name="session_background">#ffffff</color>
     <color name="session_details_list_item">@color/colorPrimaryDark</color>
     <color name="session_detailbar_background">@color/colorPrimaryDark</color>
     <color name="session_detailbar_text">#fff</color>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -39,10 +39,10 @@ import nerd.tuxmobil.fahrplan.congress.commons.SessionListHeader
 
 @Composable
 internal fun AlarmsScreen(
+    darkMode: Boolean,
     state: AlarmsState,
     showInSidePane: Boolean,
 ) {
-    val darkMode = false
     EventFahrplanTheme(darkMode = darkMode) {
         Scaffold { contentPadding ->
             Box(
@@ -208,6 +208,7 @@ private fun DeleteIcon(
 @Composable
 private fun AlarmsScreenPreview() {
     AlarmsScreen(
+        darkMode = false,
         Success(
             listOf(
                 SessionAlarmParameter(
@@ -261,6 +262,7 @@ private fun AlarmsScreenPreview() {
 @Composable
 private fun AlarmsScreenEmptyPreview() {
     AlarmsScreen(
+        darkMode = false,
         state = Success(
             emptyList(),
             onItemClick = { _ -> },
@@ -274,6 +276,7 @@ private fun AlarmsScreenEmptyPreview() {
 @Composable
 private fun AlarmsScreenLoadingPreview() {
     AlarmsScreen(
+        darkMode = false,
         state = Loading,
         showInSidePane = false,
     )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -90,6 +90,7 @@ class AlarmsFragment : Fragment(), MenuProvider {
         savedInstanceState: Bundle?
     ) = content {
         AlarmsScreen(
+            darkMode = resources.getBoolean(R.bool.dark_mode_enabled),
             state = viewModel.alarmsState.collectAsState().value,
             showInSidePane = sidePane,
         )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -82,6 +82,7 @@ class ChangeListFragment : Fragment() {
             setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 SessionChangesScreen(
+                    darkMode = resources.getBoolean(R.bool.dark_mode_enabled),
                     state = viewModel.sessionChangesState.collectAsState().value,
                     showInSidePane = sidePane,
                     onViewEvent = viewModel::onViewEvent,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
@@ -50,11 +50,11 @@ import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unav
 
 @Composable
 internal fun SessionChangesScreen(
+    darkMode: Boolean,
     state: SessionChangeState,
     showInSidePane: Boolean,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
 ) {
-    val darkMode = true
     EventFahrplanTheme(darkMode = darkMode) {
         Scaffold { contentPadding ->
             Box(
@@ -108,7 +108,7 @@ private fun SessionChangesList(
             when (parameter) {
                 is Separator -> DayDateSeparatorItem(parameter.text)
                 is SessionChange -> {
-                    SessionChangeItem(parameter, Modifier.clickable {
+                    SessionChangeItem(darkMode, parameter, Modifier.clickable {
                         if (!parameter.isCanceled) {
                             onViewEvent(OnSessionChangeItemClick(parameter.id))
                         }
@@ -125,6 +125,7 @@ private fun SessionChangesList(
 
 @Composable
 fun SessionChangeItem(
+    darkMode: Boolean,
     session: SessionChange,
     modifier: Modifier = Modifier,
 ) {
@@ -138,7 +139,10 @@ fun SessionChangeItem(
             horizontalArrangement = SpaceBetween,
             verticalAlignment = CenterVertically,
         ) {
-            val color = session.title.changeState.color
+            val titleColor = when (darkMode) {
+                true -> session.title.changeState.colorOnDark
+                false -> session.title.changeState.colorOnLight
+            }
             val textDecoration = textDecorationOf(session.title)
             Text(
                 modifier = Modifier
@@ -149,44 +153,55 @@ fun SessionChangeItem(
                 text = session.title.value,
                 fontSize = 16.sp,
                 fontWeight = Bold,
-                color = colorResource(color),
+                color = colorResource(titleColor),
                 textDecoration = textDecoration,
                 maxLines = 1,
                 overflow = Ellipsis,
             )
+            val iconColor = when (darkMode) {
+                true -> session.videoRecordingState.changeState.colorOnDark
+                false -> session.videoRecordingState.changeState.colorOnLight
+            }
             VideoRecordingIcon(
                 session.videoRecordingState.value,
-                session.videoRecordingState.changeState.color,
+                iconColor,
             )
         }
         SecondaryText(
+            darkMode,
             session.subtitle
         )
         SecondaryText(
             modifier = Modifier.padding(top = 4.dp),
+            darkMode = darkMode,
             property = session.speakerNames,
         )
         Row {
             SecondaryText(
                 modifier = Modifier.padding(end = 8.dp),
+                darkMode = darkMode,
                 property = session.dayText,
             )
             SecondaryText(
                 modifier = Modifier.padding(end = 8.dp),
+                darkMode = darkMode,
                 property = session.startsAt,
             )
             SecondaryText(
                 modifier = Modifier
                     .widthIn(55.dp)
                     .padding(end = 8.dp),
+                darkMode = darkMode,
                 property = session.duration,
             )
             SecondaryText(
                 modifier = Modifier.weight(1f),
+                darkMode = darkMode,
                 property = session.roomName,
             )
             SecondaryText(
                 modifier = Modifier.padding(start = 16.dp),
+                darkMode = darkMode,
                 property = session.languages,
             )
         }
@@ -194,9 +209,16 @@ fun SessionChangeItem(
 }
 
 @Composable
-private fun SecondaryText(property: SessionChangeProperty<String>, modifier: Modifier = Modifier) {
+private fun SecondaryText(
+    darkMode: Boolean,
+    property: SessionChangeProperty<String>,
+    modifier: Modifier = Modifier,
+) {
     if (property.value.isNotEmpty()) {
-        val color = property.changeState.color
+        val color = when (darkMode) {
+            true -> property.changeState.colorOnDark
+            false -> property.changeState.colorOnLight
+        }
         val textDecoration = textDecorationOf(property)
         Text(
             modifier = modifier.semantics {
@@ -220,6 +242,7 @@ private fun textDecorationOf(property: SessionChangeProperty<String>) =
 @Composable
 private fun SessionChangesScreenPreview() {
     SessionChangesScreen(
+        darkMode = false,
         Success(
             listOf(
                 Separator("Day 1 - 31.02.2023"),
@@ -319,6 +342,7 @@ private fun SessionChangesScreenPreview() {
 @Composable
 private fun SessionChangesScreenEmptyPreview() {
     SessionChangesScreen(
+        darkMode = false,
         Success(emptyList()),
         showInSidePane = false,
         onViewEvent = {},
@@ -329,6 +353,7 @@ private fun SessionChangesScreenEmptyPreview() {
 @Composable
 private fun SessionChangesScreenLoadingPreview() {
     SessionChangesScreen(
+        darkMode = false,
         state = Loading,
         showInSidePane = false,
         onViewEvent = {},

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeProperty.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeProperty.kt
@@ -9,11 +9,11 @@ data class SessionChangeProperty<T>(
     val changeState: ChangeState,
 ) {
 
-    enum class ChangeState(@ColorRes val color: Int) {
-        UNCHANGED(R.color.session_list_item_text),
-        NEW(R.color.schedule_change_new),
-        CANCELED(R.color.schedule_change_canceled),
-        CHANGED(R.color.schedule_change),
+    enum class ChangeState(@ColorRes val colorOnLight: Int, @ColorRes val colorOnDark: Int) {
+        UNCHANGED(R.color.session_list_item_text_inverted, R.color.session_list_item_text),
+        NEW(R.color.schedule_change_new, R.color.schedule_change_new),
+        CANCELED(R.color.schedule_change_canceled, R.color.schedule_change_canceled),
+        CHANGED(R.color.schedule_change, R.color.schedule_change_canceled),
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -64,12 +64,12 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenB
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
+    darkMode: Boolean,
     searchQuery: String,
     searchHistory: List<String>,
     state: SearchResultState,
     onViewEvent: (SearchViewEvent) -> Unit,
 ) {
-    val darkMode = true
     EventFahrplanTheme(darkMode = darkMode) {
         Scaffold { contentPadding ->
             Box(
@@ -368,6 +368,7 @@ private fun InsertSearchHistoryIcon() {
 @Composable
 private fun SearchScreenPreview() {
     SearchScreen(
+        darkMode = false,
         searchQuery = "Lorem ipsum",
         searchHistory = emptyList(),
         state = Success(
@@ -394,6 +395,7 @@ private fun SearchScreenPreview() {
 @Composable
 private fun SearchScreenHistoryPreview() {
     SearchScreen(
+        darkMode = false,
         searchQuery = "",
         searchHistory = listOf("Lorem ipsum", "Dolor sit amet"),
         state = Success(emptyList()),
@@ -405,6 +407,7 @@ private fun SearchScreenHistoryPreview() {
 @Composable
 private fun SearchScreenEmptyPreview() {
     SearchScreen(
+        darkMode = false,
         searchQuery = "foobar",
         searchHistory = emptyList(),
         state = Success(emptyList()),
@@ -416,6 +419,7 @@ private fun SearchScreenEmptyPreview() {
 @Composable
 private fun SearchScreenLoadingPreview() {
     SearchScreen(
+        darkMode = false,
         searchQuery = "",
         searchHistory = emptyList(),
         state = Loading,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
@@ -13,6 +13,7 @@ import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
 import info.metadude.android.eventfahrplan.commons.flow.observe
+import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenNavigation
@@ -85,6 +86,7 @@ class SearchFragment : Fragment() {
     ) = content {
         with(viewModel) {
             SearchScreen(
+                darkMode = resources.getBoolean(R.bool.dark_mode_enabled),
                 searchQuery = searchQuery,
                 searchHistory = searchHistory.collectAsState(emptyList()).value,
                 state = searchResultsState.collectAsState().value,

--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <bool name="dark_mode_enabled">false</bool>
     <bool name="bundle_key_schedule_url_updated_default_value">false</bool>
     <bool name="bundle_key_engelsystem_shifts_url_updated_default_value">false</bool>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,6 @@
     <color name="text_link_pressed_background_on_light">#aafec700</color>
     <color name="session_alarm_item_bell_icon_fill">@color/colorAccent</color>
     <color name="session_alarm_item_bell_icon_text">#000000</color>
-    <color name="session_background">#ffffff</color>
 
     <!-- Scrollbar -->
     <color name="scrollbar_background">@color/colorAccent</color>
@@ -79,7 +78,7 @@
     <color name="spinner_drop_down_text">#cc0000</color>
 
     <!-- Session details -->
-    <color name="session_details_background">@color/session_background</color>
+    <color name="session_details_background">#ffffff</color>
     <color name="session_details_text">@android:color/black</color>
     <color name="session_details_list_item">@color/colorPrimary</color>
     <color name="session_detailbar_background">#eee</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -72,6 +72,7 @@
     <color name="session_list_header_text">@color/text_primary</color>
     <color name="session_list_header_text_inverted">@color/text_primary_inverted</color>
     <color name="session_list_item_text">@color/text_primary</color>
+    <color name="session_list_item_text_inverted">@color/text_primary_inverted</color>
     <color name="session_list_empty_text">@color/text_primary</color>
 
     <!-- Spinner -->

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -61,10 +61,11 @@ In some of the steps it is the easiest to copy and adapt configuration settings,
 9. Add track resource names in *res/xml/track_resource_names.xml*
 10. Customize track colors in *res/values/colors_congress.xml*
 11. Customize app colors in *res/values/colors.xml*
-12. Add a launcher icon in different resolutions as *res/mipmap-[...]/ic_launcher.png*
-13. Add a notification icon in different resolutions as *res/drawable-[...]/ic_notification.png*
-14. Add an about dialog logo as *res/drawable/dialog_logo.xml*
-15. Customize bell and video recording icons in *res/drawable/* (optional)
+12. Customize screen background colors via *dark_mode_enabled*, in *res/values/booleans.xml*
+13. Add a launcher icon in different resolutions as *res/mipmap-[...]/ic_launcher.png*
+14. Add a notification icon in different resolutions as *res/drawable-[...]/ic_notification.png*
+15. Add an about dialog logo as *res/drawable/dialog_logo.xml*
+16. Customize bell and video recording icons in *res/drawable/* (optional)
 
 ## 4. Optional customization
 


### PR DESCRIPTION
# Description
+ Ease customizing light/dark mode for alarms, schedule changes and search screens.
  + Schedule changes is light now.
+ Simplify background color assignment for session details screen.
+ Update customization guide.

# Before & after screens
![session-changed-before](https://github.com/user-attachments/assets/7b80a03f-b808-49fc-9f70-83959a8effd2) ![session-changed-after](https://github.com/user-attachments/assets/107ec4ab-9f7a-42ef-9601-33a801ad4303)

![session-changes-dark](https://github.com/user-attachments/assets/2591d0de-0afe-4fcf-8860-c58503456c60) ![session-changes-light](https://github.com/user-attachments/assets/f58b6dd1-9885-4f13-9911-ca68de50ed96)




# Successfully tested on
with `ccc37c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Google Pixel 6, Android 14 (API 34)