### PR TITLE
make build time based on current commit to enable reproducible builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -235,8 +235,14 @@ def gitSha() {
     return res
 }
 
-static def buildTime() {
-    return new Date().format("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
+def buildTime() {
+    // https://reproducible-builds.org/docs/source-date-epoch/
+    def timestamp = System.getenv('SOURCE_DATE_EPOCH')
+    if (timestamp == null || timestamp.length() == 0) {
+         timestamp = "git log -1 --format=%ct".execute([], project.rootDir).text.trim()
+    }
+    def date = new Date(Long.parseLong(timestamp) * 1000)
+    return date.format("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
 }
 
 def hasSigningConfig(String flavor) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=89d4e70e4e84e2d2dfbb63e4daa53e21b25017cc70c37e4eea31ee51fb15098a
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true


### PR DESCRIPTION
# Acknowledgments
Please check the following boxes with an `x` if they apply:
* [x] I have read the recent version of the [contribution guide](
  https://github.com/EventFahrplan/EventFahrplan/blob/master/CONTRIBUTING.md) before creating this pull request.
* [x] I have checked a few other pull requests to see how they are written.
* [x] The feature I want to propose would be useful for the majority of users, not only for me personally.
* [x] I am aware that EventFahrplan is mostly developed by one person in their unpaid spare time.
* [x] I can help myself to get this feature implemented or know someone who wants to do it.

# Description

Make the build reproducible to enable the security benefits for the developer who has to make the official releases.  If the build is reproducible, then the release manager can be sure that their build environment has not been compromised.

# Before

The only diff is the build timestamp:
https://verification.f-droid.org/info.metadude.android.congress.schedule_106.apk.diffoscope.html#res-values-strings.xml

# After

The build timestamp is set based on the current commit that is being built.  This is the widely implemented standard known as `SOURCE_DATE_EPOCH`: 
https://reproducible-builds.org/specs/source-date-epoch/