### PR TITLE
Migrate from Session ID to GUID

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
@@ -47,15 +47,15 @@ class AlarmReceiver : BroadcastReceiver() {
             ALARM_DISMISSED -> onSessionAlarmNotificationDismissed(intent)
             ALARM_UPDATE -> UpdateService.start(context)
             ALARM_SESSION -> {
-                val sessionId = intent.getStringExtra(BundleKeys.ALARM_SESSION_ID)!!
+                val guid = intent.getStringExtra(BundleKeys.ALARM_GUID)!!
                 val day = intent.getIntExtra(BundleKeys.ALARM_DAY, 1)
                 val start = intent.getLongExtra(BundleKeys.ALARM_START_TIME, System.currentTimeMillis())
                 val title = intent.getStringExtra(BundleKeys.ALARM_TITLE)!!
-                logging.report(LOG_TAG, "sessionId = $sessionId, intent = $intent")
+                logging.report(LOG_TAG, "guid = $guid, intent = $intent")
                 //Toast.makeText(context, "Alarm worked.", Toast.LENGTH_LONG).show();
 
-                val uniqueNotificationId = AppRepository.createSessionAlarmNotificationId(sessionId)
-                val launchIntent = createLaunchIntent(context, sessionId, day, uniqueNotificationId)
+                val uniqueNotificationId = AppRepository.createSessionAlarmNotificationId(guid)
+                val launchIntent = createLaunchIntent(context, guid, day, uniqueNotificationId)
                 val contentIntent = PendingIntentProvider.getPendingIntentActivity(context, launchIntent)
 
                 val notificationHelper = NotificationHelper(context)
@@ -72,7 +72,7 @@ class AlarmReceiver : BroadcastReceiver() {
                 val isInsistentAlarmsEnabled = AppRepository.readInsistentAlarmsEnabled()
                 notificationHelper.notify(uniqueNotificationId, builder, isInsistentAlarmsEnabled)
 
-                AppRepository.deleteAlarmForSessionId(sessionId)
+                AppRepository.deleteAlarmForGuid(guid)
             }
         }
     }
@@ -87,7 +87,7 @@ class AlarmReceiver : BroadcastReceiver() {
 
     internal class AlarmIntentFactory(
         val context: Context,
-        val sessionId: String,
+        val guid: String,
         val title: String,
         val day: Int,
         val startTime: Long,
@@ -95,13 +95,13 @@ class AlarmReceiver : BroadcastReceiver() {
 
         fun getIntent(isAddAlarmIntent: Boolean) = Intent(context, AlarmReceiver::class.java)
             .withExtras(
-                BundleKeys.ALARM_SESSION_ID to sessionId,
+                BundleKeys.ALARM_GUID to guid,
                 BundleKeys.ALARM_DAY to day,
                 BundleKeys.ALARM_TITLE to title,
                 BundleKeys.ALARM_START_TIME to startTime
             ).apply {
                 action = if (isAddAlarmIntent) ALARM_SESSION else ALARM_DELETE
-                data = "alarm://$sessionId".toUri()
+                data = "alarm://$guid".toUri()
             }
 
         companion object {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
@@ -28,8 +28,8 @@ class AlarmsActivity : BaseActivity(),
         }
     }
 
-    override fun onSessionItemClick(sessionId: String) {
-        if (AppRepository.updateSelectedSessionId(sessionId)) {
+    override fun onSessionItemClick(guid: String) {
+        if (AppRepository.updateSelectedGuid(guid)) {
             SessionDetailsActivity.start(this)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -209,7 +209,7 @@ private fun AlarmsScreenPreview() {
         Success(
             listOf(
                 SessionAlarmParameter(
-                    sessionId = "s1",
+                    guid = "11111111-1111-1111-1111-111111111111",
                     title = "Some random title",
                     titleContentDescription = "",
                     subtitle = "A longer subtitle to be displayed",
@@ -222,7 +222,7 @@ private fun AlarmsScreenPreview() {
                     dayIndex = 0,
                 ),
                 SessionAlarmParameter(
-                    sessionId = "s2",
+                    guid = "11111111-1111-1111-1111-111111111112",
                     title = "Second title",
                     titleContentDescription = "",
                     subtitle = "A longer subtitle to be displayed lorem ipsum",
@@ -235,7 +235,7 @@ private fun AlarmsScreenPreview() {
                     dayIndex = 0,
                 ),
                 SessionAlarmParameter(
-                    sessionId = "s3",
+                    guid = "11111111-1111-1111-1111-111111111113",
                     title = "No subtitle present for this item",
                     titleContentDescription = "",
                     subtitle = "",

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -60,8 +60,8 @@ class AlarmsFragment : Fragment(), MenuProvider {
         appRepository = AppRepository
         resourceResolving = ResourceResolver(context)
         alarmServices = AlarmServices.newInstance(context, appRepository)
-        viewModel.screenNavigation = ScreenNavigation { sessionId ->
-            onSessionItemClickListener?.onSessionItemClick(sessionId)
+        viewModel.screenNavigation = ScreenNavigation { guid ->
+            onSessionItemClickListener?.onSessionItemClick(guid)
         }
         onSessionItemClickListener = try {
             context as OnSessionItemClickListener

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactory.kt
@@ -18,7 +18,7 @@ class AlarmsStateFactory(
         useDeviceTimeZone: Boolean,
     ): List<SessionAlarmParameter> = alarms.mapNotNull { alarm ->
         sessions
-            .find { session -> session.sessionId == alarm.sessionId }
+            .find { session -> session.guid == alarm.guid }
             ?.let { found ->
                 val titleContentDescription = resourceResolving.getString(
                     R.string.session_list_item_title_content_description,
@@ -48,7 +48,7 @@ class AlarmsStateFactory(
                 )
 
                 SessionAlarmParameter(
-                    sessionId = found.sessionId,
+                    guid = found.guid,
                     title = found.title,
                     titleContentDescription = titleContentDescription,
                     subtitle = found.subtitle,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -45,15 +45,15 @@ internal class AlarmsViewModel(
     }
 
     private fun navigateToSessionDetails(value: SessionAlarmParameter) {
-        screenNavigation?.navigateToSessionDetails(value.sessionId)
+        screenNavigation?.navigateToSessionDetails(value.guid)
     }
 
     private fun deleteSessionAlarm(value: SessionAlarmParameter) {
         launch {
-            repository.deleteAlarmForSessionId(value.sessionId)
+            repository.deleteAlarmForGuid(value.guid)
             val alarm = SchedulableAlarm(
                 day = value.dayIndex,
-                sessionId = value.sessionId,
+                guid = value.guid,
                 sessionTitle = value.title,
                 startTime = value.firesAt
             )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmParameter.kt
@@ -7,7 +7,7 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsState.Success
  * property in the [AlarmsViewModel] which is observed by the [AlarmsFragment].
  */
 data class SessionAlarmParameter(
-    val sessionId: String,
+    val guid: String,
     val title: String,
     val titleContentDescription: String,
     val subtitle: String,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.kt
@@ -27,9 +27,9 @@ abstract class AbstractListFragment : ListFragment() {
          * to the activity and potentially other fragments contained in that
          * activity.
          *
-         * @param sessionId The ID of the session which was clicked.
+         * @param guid The ID of the session which was clicked.
          */
-        fun onSessionListClick(sessionId: String)
+        fun onSessionListClick(guid: String)
     }
 
     protected lateinit var appRepository: AppRepository

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/OnSessionItemClickListener.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/OnSessionItemClickListener.kt
@@ -2,6 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.base
 
 fun interface OnSessionItemClickListener {
 
-    fun onSessionItemClick(sessionId: String)
+    fun onSessionItemClick(guid: String)
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
@@ -42,8 +42,8 @@ class ChangeListActivity :
         supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
     }
 
-    override fun onSessionListClick(sessionId: String) {
-        if (AppRepository.updateSelectedSessionId(sessionId)) {
+    override fun onSessionListClick(guid: String) {
+        if (AppRepository.updateSelectedGuid(guid)) {
             SessionDetailsActivity.start(this)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -112,8 +112,8 @@ class ChangeListFragment : Fragment() {
     @CallSuper
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        viewModel.screenNavigation = ScreenNavigation { sessionId ->
-            onSessionListClickListener?.onSessionListClick(sessionId)
+        viewModel.screenNavigation = ScreenNavigation { guid ->
+            onSessionListClickListener?.onSessionListClick(guid)
         }
         if (context is OnSessionListClick) {
             onSessionListClickListener = context

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
@@ -48,7 +48,7 @@ class ChangeListViewModel(
 
     fun onViewEvent(viewEvent: SessionChangeViewEvent) {
         when (viewEvent) {
-            is OnSessionChangeItemClick -> screenNavigation?.navigateToSessionDetails(viewEvent.sessionId)
+            is OnSessionChangeItemClick -> screenNavigation?.navigateToSessionDetails(viewEvent.guid)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -63,7 +63,7 @@ class SessionChangeParametersFactory(
         val title = if (session.changedTitle && session.title.isEmpty()) dash else session.title
 
         return SessionChange(
-            id = session.sessionId,
+            id = session.guid,
             title = SessionChangeProperty(
                 value = title,
                 contentDescription = title,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeViewEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeViewEvent.kt
@@ -1,5 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.changes
 
 sealed interface SessionChangeViewEvent {
-    data class OnSessionChangeItemClick(val sessionId: String) : SessionChangeViewEvent
+    data class OnSessionChangeItemClick(val guid: String) : SessionChangeViewEvent
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ScreenNavigation.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ScreenNavigation.kt
@@ -2,6 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.commons
 
 fun interface ScreenNavigation {
 
-    fun navigateToSessionDetails(sessionId: String)
+    fun navigateToSessionDetails(guid: String)
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
@@ -3,14 +3,14 @@ package nerd.tuxmobil.fahrplan.congress.contract
 object BundleKeys {
 
     // Add + delete alarm
-    const val ALARM_SESSION_ID = "nerd.tuxmobil.fahrplan.congress.ALARM_SESSION_ID"
+    const val ALARM_GUID = "nerd.tuxmobil.fahrplan.congress.ALARM_GUID"
     const val ALARM_DAY = "nerd.tuxmobil.fahrplan.congress.ALARM_DAY"
     const val ALARM_TITLE = "nerd.tuxmobil.fahrplan.congress.ALARM_TITLE"
     const val ALARM_START_TIME = "nerd.tuxmobil.fahrplan.congress.ALARM_START_TIME"
 
     // Session alarm notification
-    const val SESSION_ALARM_SESSION_ID =
-        "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_SESSION_ID"
+    const val SESSION_ALARM_GUID =
+        "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_GUID"
     const val SESSION_ALARM_DAY_INDEX =
         "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_DAY_INDEX"
     const val SESSION_ALARM_NOTIFICATION_ID =

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
@@ -11,7 +11,7 @@ fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
         alarmTimeInMin = alarmTimeInMin,
         day = day,
         displayTime = displayTime,
-        sessionId = sessionId,
+        guid = guid,
         title = sessionTitle,
         time = startTime,
         timeText = timeText
@@ -19,7 +19,7 @@ fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
 
 fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
         day = day,
-        sessionId = sessionId,
+        guid = guid,
         sessionTitle = sessionTitle,
         startTime = startTime
 )
@@ -29,7 +29,7 @@ fun DatabaseAlarm.toAlarmAppModel() = Alarm(
         alarmTimeInMin = alarmTimeInMin,
         day = day,
         displayTime = displayTime,
-        sessionId = sessionId,
+        guid = guid,
         sessionTitle = title,
         startTime = time,
         timeText = timeText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -25,13 +25,13 @@ fun SessionAppModel.toRoom() = Room(identifier = roomIdentifier, name = roomName
 fun SessionDatabaseModel.toDateInfo(): DateInfo = DateInfo(dayIndex, Moment.parseDate(dateText))
 
 fun SessionAppModel.toHighlightDatabaseModel() = HighlightDatabaseModel(
-        sessionId = Integer.parseInt(sessionId),
+        guid = guid,
         isHighlight = isHighlight
 )
 
 fun SessionDatabaseModel.toSessionAppModel(): SessionAppModel {
     return SessionAppModel(
-        sessionId = sessionId,
+        guid = guid,
         abstractt = abstractt,
         dateText = dateText,
         dateUTC = dateUTC,
@@ -76,7 +76,7 @@ fun SessionDatabaseModel.toSessionAppModel(): SessionAppModel {
 
 fun SessionDatabaseModel.toSessionNetworkModel(): SessionNetworkModel {
     return SessionNetworkModel(
-        sessionId = sessionId,
+        guid = guid,
         abstractt = abstractt,
         dateText = dateText,
         dateUTC = dateUTC,
@@ -121,7 +121,7 @@ fun SessionDatabaseModel.toSessionNetworkModel(): SessionNetworkModel {
 
 fun SessionNetworkModel.toSessionDatabaseModel(): SessionDatabaseModel {
     return SessionDatabaseModel(
-        sessionId = sessionId,
+        guid = guid,
         abstractt = abstractt,
         dateText = dateText,
         dateUTC = dateUTC,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/ShiftExtensions.kt
@@ -21,7 +21,7 @@ fun Shift.toSessionNetworkModel(
         dayRanges: List<DayRange>
 
 ) = SessionNetworkModel(
-    sessionId = "${SHIFT_ID_OFFSET + sID}",
+    guid = "17363248-3847-${"%04x".format(sID)}-e734-2389e8437483", // Create GUID for Shifts
     abstractt = "",
     dateText = startsAtLocalDateString,
     dateUTC = dateUtcMs,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SelectedSessionParameter.kt
@@ -7,7 +7,7 @@ package nerd.tuxmobil.fahrplan.congress.details
 data class SelectedSessionParameter(
 
     // Details content
-    val sessionId: String,
+    val guid: String,
 
     val hasDateUtc: Boolean,
     val formattedZonedDateTimeShort: String,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -279,7 +279,7 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
         textView.contentDescription = contentDescriptionFormatter
             .getRoomNameContentDescription(model.roomName)
         textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
-        textView.text = if (model.sessionId.isEmpty()) "" else textView.context.getString(R.string.session_details_session_id, model.sessionId)
+        textView.text = if (model.guid.isEmpty()) "" else textView.context.getString(R.string.session_details_session_id, model.guid)
 
         // Title
         textView = view.requireViewByIdCompat(R.id.session_details_content_title_view)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -122,7 +122,7 @@ internal class SessionDetailsViewModel(
 
         return SelectedSessionParameter(
             // Details content
-            sessionId = sessionId,
+            guid = guid,
             hasDateUtc = dateUTC > 0,
             formattedZonedDateTimeShort = formattedZonedDateTimeShort,
             formattedZonedDateTimeLong = formattedZonedDateTimeLong,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
@@ -43,8 +43,8 @@ class StarredListActivity :
         }
     }
 
-    override fun onSessionListClick(sessionId: String) {
-        if (AppRepository.updateSelectedSessionId(sessionId)) {
+    override fun onSessionListClick(guid: String) {
+        if (AppRepository.updateSelectedGuid(guid)) {
             SessionDetailsActivity.start(this)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -220,7 +220,7 @@ class StarredListFragment :
             // fragment is attached to one) that an item has been selected.
             currentPosition--
             val clicked = starredListAdapter.getSession(currentPosition)
-            onSessionListClickListener?.onSessionListClick(clicked.sessionId)
+            onSessionListClickListener?.onSessionListClick(clicked.guid)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -43,7 +43,7 @@ class StarredListViewModel(
 
     fun unfavorSession(session: Session) {
         launch {
-            repository.deleteHighlight(session.sessionId)
+            repository.deleteHighlight(session.guid)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
@@ -8,7 +8,7 @@ data class Alarm(
         val alarmTimeInMin: Int,
         val day: Int,
         val displayTime: Long,
-        val sessionId: String,
+        val guid: String,
         val sessionTitle: String,
         val startTime: Long,
         val timeText: String
@@ -19,7 +19,7 @@ data class Alarm(
             alarmTimeInMin: Int,
             day: Int,
             displayTime: Long,
-            sessionId: String,
+            guid: String,
             sessionTitle: String,
             startTime: Long,
             timeText: String
@@ -28,7 +28,7 @@ data class Alarm(
             alarmTimeInMin,
             day,
             displayTime,
-            sessionId,
+            guid,
             sessionTitle,
             startTime,
             timeText

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
@@ -3,7 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.models
 data class SchedulableAlarm(
 
         val day: Int,
-        val sessionId: String,
+        val guid: String,
         val sessionTitle: String,
         val startTime: Long
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleData.kt
@@ -34,12 +34,12 @@ data class ScheduleData(
         get() = roomDataList.flatMap { it.sessions }.sortedBy { it.dateUTC }
 
     /**
-     * Returns the first [Session] found which matches the given [sessionId] or `null` if not found.
+     * Returns the first [Session] found which matches the given [guid] or `null` if not found.
      */
-    fun findSession(sessionId: String): Session? {
+    fun findSession(guid: String): Session? {
         return roomDataList.asSequence()
                 .flatMap { it.sessions.asSequence() }
-                .firstOrNull { it.sessionId == sessionId }
+                .firstOrNull { it.guid == guid }
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.kt
@@ -9,7 +9,7 @@ import org.threeten.bp.ZoneOffset
  * Application model representing a lecture, a workshop or any similar time-framed happening.
  */
 data class Session(
-    val sessionId: String,
+    val guid: String,
     val title: String = "",
     val subtitle: String = "",
     val abstractt: String = "",
@@ -104,7 +104,7 @@ data class Session(
 }
 
 private data class EssentialSession(
-    val sessionId: String,
+    val guid: String,
     val title: String,
     val subtitle: String,
     val feedbackUrl: String?,
@@ -124,7 +124,7 @@ private data class EssentialSession(
     val recordingOptOut: Boolean,
 ) {
     constructor(session: Session) : this(
-        sessionId = session.sessionId,
+        guid = session.guid,
         title = session.title,
         subtitle = session.subtitle,
         feedbackUrl = session.feedbackUrl,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
@@ -14,7 +14,7 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
         const val DISPLAY_DAY_INDEX_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.DISPLAY_DAY_INDEX"
         const val ENGELSYSTEM_SHIFTS_HASH_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_HASH"
         const val SCHEDULE_LAST_FETCHED_AT_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT"
-        const val SELECTED_SESSION_ID_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SELECTED_SESSION_ID_KEY"
+        const val SELECTED_GUID_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SELECTED_GUID_KEY"
         const val SEARCH_HISTORY_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SEARCH_HISTORY_KEY"
         const val SEARCH_HISTORY_SEPARATOR = ";"
 
@@ -116,11 +116,11 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
         putInt(ENGELSYSTEM_SHIFTS_HASH_KEY, hash)
     }
 
-    override fun getSelectedSessionId() =
-        preferences.getString(SELECTED_SESSION_ID_KEY, "")!!
+    override fun getSelectedGuid() =
+        preferences.getString(SELECTED_GUID_KEY, "")!!
 
-    override fun setSelectedSessionId(sessionId: String): Boolean = preferences.edit()
-        .putString(SELECTED_SESSION_ID_KEY, sessionId)
+    override fun setSelectedGuid(guid: String): Boolean = preferences.edit()
+        .putString(SELECTED_GUID_KEY, guid)
         .commit()
 
     override fun getSearchHistory(): List<String> {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -32,8 +32,8 @@ interface SharedPreferencesRepository {
     fun getLastEngelsystemShiftsHash(): Int
     fun setLastEngelsystemShiftsHash(hash: Int)
 
-    fun getSelectedSessionId(): String
-    fun setSelectedSessionId(sessionId: String): Boolean
+    fun getSelectedGuid(): String
+    fun setSelectedGuid(guid: String): Boolean
 
     fun getSearchHistory(): List<String>
     fun setSearchHistory(history: List<String>)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -86,7 +86,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         /**
          * Called when the session view has been clicked.
          */
-        fun onSessionClick(sessionId: String)
+        fun onSessionClick(guid: String)
     }
 
     companion object {
@@ -271,8 +271,8 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
             val boxHeight = getNormalizedBoxHeight()
             scrollToCurrent(boxHeight, scheduleData, dateInfos)
         }
-        viewModel.scrollToSessionParameter.observe(viewLifecycleOwner) { (sessionId, verticalPosition, roomIndex) ->
-            scrollTo(sessionId, verticalPosition, roomIndex)
+        viewModel.scrollToSessionParameter.observe(viewLifecycleOwner) { (guid, verticalPosition, roomIndex) ->
+            scrollTo(guid, verticalPosition, roomIndex)
         }
         viewModel.requestPostNotificationsPermission.observe(viewLifecycleOwner) {
             postNotificationsPermissionRequestLauncher.launch(POST_NOTIFICATIONS)
@@ -296,12 +296,12 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         activity.invalidateOptionsMenu()
         val intent = activity.intent
         // TODO Consume session alarm in MainActivity and let it orchestrate its fragments
-        val sessionId = intent.getStringExtra(BundleKeys.SESSION_ALARM_SESSION_ID)
-        if (sessionId != null) {
+        val guid = intent.getStringExtra(BundleKeys.SESSION_ALARM_GUID)
+        if (guid != null) {
             val sessionAlarmDayIndex = intent.getIntExtra(BundleKeys.SESSION_ALARM_DAY_INDEX, -1)
             viewModel.saveSelectedDayIndex(sessionAlarmDayIndex)
-            viewModel.scrollToSession(sessionId, getNormalizedBoxHeight())
-            intent.removeExtra(BundleKeys.SESSION_ALARM_SESSION_ID) // jump to given sessionId only once
+            viewModel.scrollToSession(guid, getNormalizedBoxHeight())
+            intent.removeExtra(BundleKeys.SESSION_ALARM_GUID) // jump to given guid only once
         }
     }
 
@@ -476,7 +476,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         }
     }
 
-    private fun scrollTo(sessionId: String, verticalPosition: Int, roomIndex: Int) {
+    private fun scrollTo(guid: String, verticalPosition: Int, roomIndex: Int) {
         val layoutRootView = requireView()
         layoutRootView.requireViewByIdCompat<NestedScrollView>(R.id.verticalScrollView).apply {
             post { scrollTo(0, verticalPosition) }
@@ -486,7 +486,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         val activity = requireActivity()
         val sidePaneView = activity.findViewById<FragmentContainerView?>(R.id.detail)
         if (sidePaneView != null && onSessionClickListener != null) {
-            onSessionClickListener!!.onSessionClick(sessionId)
+            onSessionClickListener!!.onSessionClick(guid)
         }
     }
 
@@ -519,7 +519,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
             "A session must be assigned to the 'tag' attribute of the session view."
         } as Session
         logging.d(LOG_TAG, """Click on: "${session.title}"""")
-        onSessionClickListener?.onSessionClick(session.sessionId)
+        onSessionClickListener?.onSessionClick(session.guid)
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -238,7 +238,7 @@ internal class FahrplanViewModel(
             roomData.copy(sessions = roomData.sessions.map { session ->
                 session.copy(
                     hasAlarm = alarms.any { alarm ->
-                        alarm.sessionId == session.sessionId
+                        alarm.guid == session.guid
                     }
                 )
             })
@@ -367,18 +367,18 @@ internal class FahrplanViewModel(
         }
     }
 
-    fun scrollToSession(sessionId: String, boxHeight: Int) {
+    fun scrollToSession(guid: String, boxHeight: Int) {
         launch {
             val scheduleData = repository.loadUncanceledSessionsForDayIndex()
             val sessions = scheduleData.allSessions
             if (sessions.isNotEmpty()) {
-                val session = scheduleData.findSession(sessionId)
+                val session = scheduleData.findSession(guid)
                 if (session != null) {
                     val conference = Conference.ofSessions(sessions)
                     val verticalPosition = scrollAmountCalculator.calculateScrollAmount(conference, session, boxHeight)
                     val roomIndex = scheduleData.findRoomIndex(session)
                     val parameter = ScrollToSessionParameter(
-                        sessionId = sessionId,
+                        guid = guid,
                         verticalPosition = verticalPosition,
                         roomIndex = roomIndex
                     )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculator.kt
@@ -9,7 +9,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import org.threeten.bp.Duration
 import kotlin.collections.set
 
-private typealias SessionId = String
+private typealias Guid = String
 
 data class LayoutCalculator(
 
@@ -27,13 +27,13 @@ data class LayoutCalculator(
         return standardHeight * minutes / DIVISOR
     }
 
-    fun calculateLayoutParams(roomData: RoomData, conference: Conference): Map<SessionId, LinearLayout.LayoutParams> {
+    fun calculateLayoutParams(roomData: RoomData, conference: Conference): Map<Guid, LinearLayout.LayoutParams> {
         val sessions = roomData.sessions
         var previousSessionEndsAt: Int = conference.firstSessionStartsAt.minuteOfDay
         var startTime: Int
         var margin: Int
         var previousSession: Session? = null
-        val layoutParamsBySession = mutableMapOf<SessionId, LinearLayout.LayoutParams>()
+        val layoutParamsBySession = mutableMapOf<Guid, LinearLayout.LayoutParams>()
 
         for ((index, session) in sessions.withIndex()) {
             startTime = getStartTime(session, previousSessionEndsAt)
@@ -42,7 +42,7 @@ data class LayoutCalculator(
                 // consecutive session
                 margin = calculateDisplayDistance(startTime - previousSessionEndsAt)
                 if (previousSession != null) {
-                    layoutParamsBySession[previousSession.sessionId]!!.bottomMargin = margin
+                    layoutParamsBySession[previousSession.guid]!!.bottomMargin = margin
                     margin = 0
                 }
             } else {
@@ -57,12 +57,12 @@ data class LayoutCalculator(
                 session
             }
 
-            val sessionId = adjustedSession.sessionId
-            if (!layoutParamsBySession.containsKey(sessionId)) {
-                layoutParamsBySession[sessionId] = createLayoutParams(adjustedSession)
+            val guid = adjustedSession.guid
+            if (!layoutParamsBySession.containsKey(guid)) {
+                layoutParamsBySession[guid] = createLayoutParams(adjustedSession)
             }
 
-            layoutParamsBySession[sessionId]!!.topMargin = margin
+            layoutParamsBySession[guid]!!.topMargin = margin
             previousSessionEndsAt = startTime + adjustedSession.duration
             previousSession = adjustedSession
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -79,22 +79,22 @@ class MainActivity : BaseActivity(),
 
         /**
          * Returns a unique intent to be used to launch this activity.
-         * The given parameters [sessionId] and [dayIndex] are passed along as bundle extras.
-         * The [sessionId] is also used to ensure this intent is unique by definition of
+         * The given parameters [guid] and [dayIndex] are passed along as bundle extras.
+         * The [guid] is also used to ensure this intent is unique by definition of
          * [Intent.filterEquals].
          */
         fun createLaunchIntent(
             context: Context,
-            sessionId: String,
+            guid: String,
             dayIndex: Int,
             notificationId: Int
         ) = Intent(context, MainActivity::class.java)
             .apply {
-                data = "fake://$sessionId".toUri()
+                data = "fake://$guid".toUri()
                 flags = FLAG_ACTIVITY_CLEAR_TOP or FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
             }
             .withExtras(
-                BundleKeys.SESSION_ALARM_SESSION_ID to sessionId,
+                BundleKeys.SESSION_ALARM_GUID to guid,
                 BundleKeys.SESSION_ALARM_DAY_INDEX to dayIndex,
                 BundleKeys.SESSION_ALARM_NOTIFICATION_ID to notificationId
             )
@@ -336,12 +336,12 @@ class MainActivity : BaseActivity(),
         }
     }
 
-    override fun onSessionListClick(sessionId: String) {
-        viewModel.openSessionDetails(sessionId)
+    override fun onSessionListClick(guid: String) {
+        viewModel.openSessionDetails(guid)
     }
 
-    override fun onSessionClick(sessionId: String) {
-        viewModel.openSessionDetails(sessionId)
+    override fun onSessionClick(guid: String) {
+        viewModel.openSessionDetails(guid)
     }
 
     override fun onBackStackChanged() {
@@ -434,7 +434,7 @@ class MainActivity : BaseActivity(),
         shouldScrollToCurrent = true
     }
 
-    override fun onSessionItemClick(sessionId: String) {
-        viewModel.openSessionDetails(sessionId)
+    override fun onSessionItemClick(guid: String) {
+        viewModel.openSessionDetails(guid)
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -161,9 +161,9 @@ internal class MainViewModel(
         }
     }
 
-    fun openSessionDetails(sessionId: String) {
+    fun openSessionDetails(guid: String) {
         launch {
-            val isUpdated = repository.updateSelectedSessionId(sessionId)
+            val isUpdated = repository.updateSelectedGuid(guid)
             if (isUpdated) {
                 mutableOpenSessionDetails.sendOneTimeEvent(Unit)
             }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewColumnAdapter.kt
@@ -12,7 +12,7 @@ internal interface SessionViewEventsHandler : View.OnCreateContextMenuListener, 
 
 internal class SessionViewColumnAdapter(
         private val sessions: List<Session>,
-        private val layoutParamsBySession: Map</* sessionId */ String, LinearLayout.LayoutParams>,
+        private val layoutParamsBySession: Map</* guid */ String, LinearLayout.LayoutParams>,
         private val useDeviceTimeZone: Boolean,
         private val drawer: SessionViewDrawer,
         private val eventsHandler: SessionViewEventsHandler
@@ -21,7 +21,7 @@ internal class SessionViewColumnAdapter(
     override fun onBindViewHolder(viewHolder: SessionViewHolder, position: Int) {
         val session = sessions[position]
         viewHolder.itemView.tag = session
-        viewHolder.itemView.layoutParams = layoutParamsBySession[session.sessionId]
+        viewHolder.itemView.layoutParams = layoutParamsBySession[session.guid]
         drawer.updateSessionView(viewHolder.itemView, session, useDeviceTimeZone)
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToSessionParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/ScrollToSessionParameter.kt
@@ -9,7 +9,7 @@ import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
  */
 data class ScrollToSessionParameter(
 
-    val sessionId: String,
+    val guid: String,
     val verticalPosition: Int,
     val roomIndex: Int
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchActivity.kt
@@ -28,8 +28,8 @@ class SearchActivity :
         }
     }
 
-    override fun onSessionListClick(sessionId: String) {
-        if (AppRepository.updateSelectedSessionId(sessionId)) {
+    override fun onSessionListClick(guid: String) {
+        if (AppRepository.updateSelectedGuid(guid)) {
             SessionDetailsActivity.start(this)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
@@ -55,8 +55,8 @@ class SearchFragment : Fragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        viewModel.screenNavigation = ScreenNavigation { sessionId ->
-            onSessionListClickListener?.onSessionListClick(sessionId)
+        viewModel.screenNavigation = ScreenNavigation { guid ->
+            onSessionListClickListener?.onSessionListClick(guid)
         }
         if (context is OnSessionListClick) {
             onSessionListClickListener = context

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilter.kt
@@ -8,7 +8,7 @@ class SearchQueryFilter {
      * Filters all text fields of a session which are visible to the user, e.g. in the details screen.
      */
     fun filterAll(sessions: List<Session>, query: String): List<Session> = sessions.filter {
-        it.sessionId.contains(query, ignoreCase = true)
+        it.guid.contains(query, ignoreCase = true)
                 || it.title.contains(query, ignoreCase = true)
                 || it.subtitle.contains(query, ignoreCase = true)
                 || it.abstractt.contains(query, ignoreCase = true)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
@@ -31,7 +31,7 @@ class SearchResultParameterFactory(
         )
 
         return SearchResult(
-            id = session.sessionId,
+            id = session.guid,
             title = SearchResultProperty(
                 value = title,
                 contentDescription = contentDescriptionFormatter

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewEvent.kt
@@ -8,5 +8,5 @@ sealed interface SearchViewEvent {
     data class OnSearchHistoryItemClick(val searchQuery: String) : SearchViewEvent
     data object OnSearchHistoryClear : SearchViewEvent
     data class OnSearchQueryChange(val updatedQuery: String) : SearchViewEvent
-    data class OnSearchResultItemClick(val sessionId: String) : SearchViewEvent
+    data class OnSearchResultItemClick(val guid: String) : SearchViewEvent
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
@@ -90,7 +90,7 @@ class SearchViewModel(
             OnBackPress -> mutableNavigateBack.sendOneTimeEvent(Unit)
             OnBackIconClick -> searchQuery = ""
             OnSearchSubScreenBackPress -> searchQuery = ""
-            is OnSearchResultItemClick -> screenNavigation?.navigateToSessionDetails(viewEvent.sessionId)
+            is OnSearchResultItemClick -> screenNavigation?.navigateToSessionDetails(viewEvent.guid)
             is OnSearchHistoryItemClick -> searchQuery = viewEvent.searchQuery
             OnSearchHistoryClear -> searchHistoryManager.clear(viewModelScope)
             is OnSearchQueryChange -> searchQuery = viewEvent.updatedQuery

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChanges.kt
@@ -45,7 +45,7 @@ data class ScheduleChanges private constructor(
             var sessionIndex = 0
             while (sessionIndex < newSessions.size) {
                 val newSession = newSessions[sessionIndex]
-                val oldSession = oldNotCanceledSessions.singleOrNull { oldNotCanceledSession -> newSession.sessionId == oldNotCanceledSession.sessionId }
+                val oldSession = oldNotCanceledSessions.singleOrNull { oldNotCanceledSession -> newSession.guid == oldNotCanceledSession.guid }
                 if (oldSession == null) {
                     sessionsWithChangeFlags += newSession.copy(changedIsNew = true)
                     foundNoteworthyChanges = true

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
@@ -8,7 +8,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 @JsonClass(generateAdapter = true)
 data class SessionExport(
         @Json(name = "lecture_id") // Keep "lecture_id" key for Chaosflix export.
-        var sessionId: String,
+        var guid: String,
         var title: String,
         var subtitle: String = "",
         var day: Int = 0,
@@ -26,7 +26,7 @@ data class SessionExport(
         var startsAt: String? = null,
 ) {
     constructor(session: Session) : this(
-            sessionId = session.sessionId,
+            guid = session.guid,
             title = session.title,
             subtitle = session.subtitle,
             day = session.dayIndex,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -33,15 +33,15 @@ class FeedbackUrlComposer(
         return if (session.originatesFromPretalx) {
             session.pretalxScheduleFeedbackUrl
         } else {
-            getFrabScheduleFeedbackUrl(session.sessionId, frabScheduleFeedbackUrlFormatString)
+            getFrabScheduleFeedbackUrl(session.guid, frabScheduleFeedbackUrlFormatString)
         }
     }
 
-    private fun getFrabScheduleFeedbackUrl(sessionId: String, frabScheduleFeedbackUrlFormatString: String): String {
+    private fun getFrabScheduleFeedbackUrl(guid: String, frabScheduleFeedbackUrlFormatString: String): String {
         return if (frabScheduleFeedbackUrlFormatString.isEmpty()) {
             NO_URL
         } else {
-            String.format(frabScheduleFeedbackUrlFormatString, sessionId)
+            String.format(frabScheduleFeedbackUrlFormatString, guid)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -34,13 +34,13 @@ class SessionUrlComposer(
                 if (session.roomName in specialRoomNames) {
                     NO_URL
                 } else {
-                    getComposedSessionUrl(session.sessionId)
+                    getComposedSessionUrl(session.guid)
                 }
             }
         }
 
-    private fun getComposedSessionUrl(sessionIdentifier: String) =
-            String.format(sessionUrlTemplate, sessionIdentifier)
+    private fun getComposedSessionUrl(guid: String) =
+            String.format(sessionUrlTemplate, guid)
 
     private companion object {
         const val NO_URL = ""

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -56,7 +56,7 @@ class AlarmServicesTest {
         whenever(repository.readUseDeviceTimeZoneEnabled()) doReturn true
         whenever(formattingDelegate.getFormattedDateTimeShort(any(), any(), any())) doReturn "not relevant"
         val session = Session(
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             dayIndex = 1,
             title = "Title",
             dateUTC = 1536332400000L, // 2018-09-07T17:00:00+02:00
@@ -69,7 +69,7 @@ class AlarmServicesTest {
             alarmTimeInMin = 60,
             day = 1,
             displayTime = 1536332400000,
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             sessionTitle = "Title",
             startTime = 1536328800000,
             timeText = "not relevant"
@@ -82,7 +82,7 @@ class AlarmServicesTest {
         val pendingIntentDelegate = mock<PendingIntentDelegate>()
         val formattingDelegate = mock<FormattingDelegate>()
         val alarmServices = createAlarmServices(pendingIntentDelegate = pendingIntentDelegate, formattingDelegate = formattingDelegate)
-        val session = Session(sessionId = "S2", dateUTC = 1536332400000L) // 2018-09-07T17:00:00+02:00
+        val session = Session(guid = "11111111-1111-1111-1111-111111111112", dateUTC = 1536332400000L) // 2018-09-07T17:00:00+02:00
 
         try {
             alarmServices.addSessionAlarm(session, alarmTimesValues.size) // Out of bounds!
@@ -100,12 +100,12 @@ class AlarmServicesTest {
         val alarmServices = createAlarmServices(formattingDelegate = formattingDelegate)
         val alarm = Alarm(10, 2, 0, "S3", "Title", 1536332400000L, "Lorem ipsum")
         whenever(repository.readAlarms(any())) doReturn listOf(alarm)
-        val session = Session(sessionId = "S3", hasAlarm = true)
+        val session = Session(guid = "11111111-1111-1111-1111-111111111113", hasAlarm = true)
 
         alarmServices.deleteSessionAlarm(session)
         // AlarmServices invokes discardSessionAlarm() which is tested separately.
         verifyNoInteractions(formattingDelegate)
-        verifyInvokedOnce(repository).deleteAlarmForSessionId("S3")
+        verifyInvokedOnce(repository).deleteAlarmForGuid("11111111-1111-1111-1111-111111111113")
     }
 
     @Test
@@ -114,7 +114,7 @@ class AlarmServicesTest {
         val formattingDelegate = mock<FormattingDelegate>()
         val alarmServices = createAlarmServices(pendingIntentDelegate = pendingIntentDelegate, formattingDelegate = formattingDelegate)
         whenever(repository.readAlarms(any())) doReturn emptyList()
-        val session = Session(sessionId = "S4")
+        val session = Session(guid = "11111111-1111-1111-1111-111111111114")
 
         alarmServices.deleteSessionAlarm(session)
         verifyNoInteractions(pendingIntentDelegate)
@@ -193,12 +193,12 @@ class AlarmServicesTest {
     // TODO Move into a unit test for AlarmReceiver once it is written.
     private fun assertIntentExtras(intent: Intent, action: String) {
         assertThat(intent.getIntExtra(BundleKeys.ALARM_DAY, 9)).isEqualTo(alarm.day)
-        assertThat(intent.getStringExtra(BundleKeys.ALARM_SESSION_ID)).isEqualTo(alarm.sessionId)
+        assertThat(intent.getStringExtra(BundleKeys.ALARM_GUID)).isEqualTo(alarm.guid)
         assertThat(intent.getLongExtra(BundleKeys.ALARM_START_TIME, 0)).isEqualTo(alarm.startTime)
         assertThat(intent.getStringExtra(BundleKeys.ALARM_TITLE)).isEqualTo(alarm.sessionTitle)
         assertThat(intent.component!!.className).isEqualTo(AlarmReceiver::class.java.name)
         assertThat(intent.action).isEqualTo(action)
-        assertThat(intent.data).isEqualTo("alarm://${alarm.sessionId}".toUri())
+        assertThat(intent.data).isEqualTo("alarm://${alarm.guid}".toUri())
     }
 
     private fun createAlarmServices(

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -70,14 +70,14 @@ class AlarmsStateFactoryTest {
 
             val alarms = listOf(
                 createAlarm(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     alarmTimeInMin = alarmTimeInMin,
                     alarmStartsAt = alarmStartsAt,
                 )
             )
             val sessions = listOf(
                 Session(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     title = "Title",
                     subtitle = "Subtitle",
                     dateUTC = SESSION_STARTS_AT.toMilliseconds(),
@@ -88,7 +88,7 @@ class AlarmsStateFactoryTest {
 
             val expected = listOf(
                 SessionAlarmParameter(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     title = "Title",
                     titleContentDescription = "Title: Berlin stories",
                     subtitle = "Subtitle",
@@ -113,14 +113,14 @@ class AlarmsStateFactoryTest {
 
             val alarms = listOf(
                 createAlarm(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     alarmTimeInMin = alarmTimeInMin,
                     alarmStartsAt = alarmStartsAt,
                 )
             )
             val sessions = listOf(
                 Session(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     title = "Title",
                     subtitle = "Subtitle",
                     dateUTC = SESSION_STARTS_AT.toMilliseconds(),
@@ -131,7 +131,7 @@ class AlarmsStateFactoryTest {
 
             val expected = listOf(
                 SessionAlarmParameter(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     title = "Title",
                     titleContentDescription = "Title: Berlin stories",
                     subtitle = "Subtitle",
@@ -154,14 +154,14 @@ class AlarmsStateFactoryTest {
         AlarmsStateFactory(CompleteResourceResolver(alarmTimeInMin), DateFormatterDelegate)
 
     private fun createAlarm(
-        sessionId: String,
+        guid: String,
         alarmTimeInMin: Int = 10,
         alarmStartsAt: Long = 1620909000000,
     ) = Alarm(
         alarmTimeInMin = alarmTimeInMin,
         day = 2,
         displayTime = -1,
-        sessionId = sessionId,
+        guid = guid,
         sessionTitle = "Unused",
         startTime = alarmStartsAt,
         timeText = "Unused",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -52,7 +52,7 @@ class AlarmsViewModelTest {
         val repository = createRepository(
             alarmsList = listOf(
                 createAlarm(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     alarmTimeInMin = ALARM_TIME_IN_MIN,
                     alarmStartsAt = ALARM_STARTS_AT.toMilliseconds()
                 )
@@ -60,7 +60,7 @@ class AlarmsViewModelTest {
             sessionsFlow = flowOf(
                 listOf(
                     Session(
-                        sessionId = "s0",
+                        guid = "11111111-1111-1111-1111-111111111110",
                         title = "Title",
                         subtitle = "Subtitle",
                         dateUTC = SESSION_STARTS_AT.toMilliseconds(),
@@ -81,7 +81,7 @@ class AlarmsViewModelTest {
         val repository = createRepository(
             alarmsList = listOf(
                 createAlarm(
-                    sessionId = "s0",
+                    guid = "11111111-1111-1111-1111-111111111110",
                     alarmTimeInMin = ALARM_TIME_IN_MIN,
                     alarmStartsAt = ALARM_STARTS_AT.toMilliseconds()
                 )
@@ -89,7 +89,7 @@ class AlarmsViewModelTest {
             sessionsFlow = flowOf(
                 listOf(
                     Session(
-                        sessionId = "s0",
+                        guid = "11111111-1111-1111-1111-111111111110",
                         title = "Title",
                         subtitle = "Subtitle",
                         dateUTC = SESSION_STARTS_AT.toMilliseconds(),
@@ -116,7 +116,7 @@ class AlarmsViewModelTest {
             val repository = createRepository(
                 alarmsList = listOf(
                     createAlarm(
-                        sessionId = "s0",
+                        guid = "11111111-1111-1111-1111-111111111110",
                         alarmTimeInMin = ALARM_TIME_IN_MIN,
                         alarmStartsAt = ALARM_STARTS_AT.toMilliseconds()
                     )
@@ -124,7 +124,7 @@ class AlarmsViewModelTest {
                 sessionsFlow = flowOf(
                     listOf(
                         Session(
-                            sessionId = "s0",
+                            guid = "11111111-1111-1111-1111-111111111110",
                             title = "Title",
                             subtitle = "Subtitle",
                             dateUTC = SESSION_STARTS_AT.toMilliseconds(),
@@ -139,7 +139,7 @@ class AlarmsViewModelTest {
                 val success = state as Success
                 val sessionAlarmParameter = state.sessionAlarmParameters.first()
                 success.onDeleteItemClick(sessionAlarmParameter)
-                verifyInvokedOnce(repository).deleteAlarmForSessionId(any())
+                verifyInvokedOnce(repository).deleteAlarmForGuid(any())
                 verifyInvokedOnce(alarmServices).discardSessionAlarm(any())
             }
         }
@@ -181,7 +181,7 @@ class AlarmsViewModelTest {
         on { sessionsWithoutShifts } doReturn emptyFlow()
         on { readAlarms(any()) } doReturn alarmsList
         on { readUseDeviceTimeZoneEnabled() } doReturn true
-        on { deleteAlarmForSessionId(any()) } doReturn 0
+        on { deleteAlarmForGuid(any()) } doReturn 0
         on { deleteAllAlarms() } doReturn 0
     }
 
@@ -197,7 +197,7 @@ class AlarmsViewModelTest {
 
     private fun createAlarmsStateFactory(): AlarmsStateFactory {
         val parameter = mock<SessionAlarmParameter> {
-            on { sessionId } doReturn "not asserted in this test"
+            on { guid } doReturn "not asserted in this test"
             on { title } doReturn "not asserted in this test"
         }
         return mock<AlarmsStateFactory> {
@@ -207,14 +207,14 @@ class AlarmsViewModelTest {
     }
 
     private fun createAlarm(
-        sessionId: String,
+        guid: String,
         alarmTimeInMin: Int = 10,
         alarmStartsAt: Long = 1620909000000
     ) = Alarm(
         alarmTimeInMin = alarmTimeInMin,
         day = 2,
         displayTime = -1,
-        sessionId = sessionId,
+        guid = guid,
         sessionTitle = "Unused",
         startTime = alarmStartsAt,
         timeText = "Unused"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -120,7 +120,7 @@ class CalendarDescriptionComposerTest {
     private class FakeSessionUrlComposer : SessionUrlComposition {
 
         override fun getSessionUrl(session: Session): String {
-            return "https://events.ccc.de/congress/2021/Fahrplan/events/${session.sessionId}.html"
+            return "https://events.ccc.de/congress/2021/Fahrplan/events/${session.guid}.html"
         }
 
     }
@@ -132,7 +132,7 @@ class CalendarDescriptionComposerTest {
         description: String = "",
         links: String = ""
     ) = Session(
-        sessionId = "2342",
+        guid = "11111111-1111-1111-1111-111111112342",
         subtitle = subtitle,
         speakers = speakers,
         abstractt = abstract,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarSharingTest.kt
@@ -60,7 +60,7 @@ class CalendarSharingTest {
     }
 
     private fun createSession() = Session(
-        sessionId = "2342",
+        guid = "11111111-1111-1111-1111-111111112342",
         title = "Title",
         subtitle = "Subtitle",
         speakers = listOf("Speakers"),

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
@@ -54,7 +54,7 @@ class ChangeListViewModelTest {
     @Test
     fun `sessionChangesState emits Success state with converted sessions`() = runTest {
         val session = Session(
-            sessionId = "18",
+            guid = "11111111-1111-1111-1111-111111111118",
             title = "Title",
             subtitle = "Subtitle",
             recordingOptOut = false,
@@ -136,8 +136,8 @@ class ChangeListViewModelTest {
         val screenNavigation = mock<ScreenNavigation>()
         val viewModel = createViewModel(createRepository())
         viewModel.screenNavigation = screenNavigation
-        viewModel.onViewEvent(OnSessionChangeItemClick(sessionId = "42"))
-        verifyInvokedOnce(screenNavigation).navigateToSessionDetails(sessionId = "42")
+        viewModel.onViewEvent(OnSessionChangeItemClick(guid = "11111111-1111-1111-1111-111111111142"))
+        verifyInvokedOnce(screenNavigation).navigateToSessionDetails(guid = "11111111-1111-1111-1111-111111111142")
     }
 
     @Test
@@ -154,7 +154,7 @@ class ChangeListViewModelTest {
     private fun createFactory(sessions: List<Session>): SessionChangeParametersFactory {
         val parameters = sessions.map {
             SessionChangeParameter.SessionChange(
-                id = it.sessionId,
+                id = it.guid,
                 title = SessionChangeProperty(
                     value = it.title,
                     contentDescription = "",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatisticTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeStatisticTest.kt
@@ -11,12 +11,12 @@ class ChangeStatisticTest {
 
         private val unchangedSessions = listOf(
             Session(
-                sessionId = "1001",
+                guid = "11111111-1111-1111-1111-111111111001",
                 isHighlight = false,
                 changedTitle = false,
             ),
             Session(
-                sessionId = "1002",
+                guid = "11111111-1111-1111-1111-111111111002",
                 isHighlight = true,
                 changedTitle = false,
             )
@@ -24,12 +24,12 @@ class ChangeStatisticTest {
 
         private val changedSessions = listOf(
             Session(
-                sessionId = "1003",
+                guid = "11111111-1111-1111-1111-111111111003",
                 isHighlight = true,
                 changedTitle = true,
             ),
             Session(
-                sessionId = "1004",
+                guid = "11111111-1111-1111-1111-111111111004",
                 isHighlight = false,
                 changedTitle = true,
             )
@@ -37,12 +37,12 @@ class ChangeStatisticTest {
 
         private val oldSessions = listOf(
             Session(
-                sessionId = "2001",
+                guid = "11111111-1111-1111-1111-111111112001",
                 isHighlight = false,
                 changedIsNew = false,
             ),
             Session(
-                sessionId = "2002",
+                guid = "11111111-1111-1111-1111-111111112002",
                 isHighlight = true,
                 changedIsNew = false,
             )
@@ -50,12 +50,12 @@ class ChangeStatisticTest {
 
         private val newSessions = listOf(
             Session(
-                sessionId = "2003",
+                guid = "11111111-1111-1111-1111-111111112003",
                 isHighlight = true,
                 changedIsNew = true,
             ),
             Session(
-                sessionId = "2004",
+                guid = "11111111-1111-1111-1111-111111112004",
                 isHighlight = false,
                 changedIsNew = true,
             )
@@ -63,12 +63,12 @@ class ChangeStatisticTest {
 
         private val uncanceledSessions = listOf(
             Session(
-                sessionId = "3001",
+                guid = "11111111-1111-1111-1111-111111113001",
                 isHighlight = false,
                 changedIsCanceled = false,
             ),
             Session(
-                sessionId = "3002",
+                guid = "11111111-1111-1111-1111-111111113002",
                 isHighlight = true,
                 changedIsCanceled = false,
             )
@@ -76,12 +76,12 @@ class ChangeStatisticTest {
 
         private val canceledSessions = listOf(
             Session(
-                sessionId = "3003",
+                guid = "11111111-1111-1111-1111-111111113003",
                 isHighlight = true,
                 changedIsCanceled = true,
             ),
             Session(
-                sessionId = "3004",
+                guid = "11111111-1111-1111-1111-111111113004",
                 isHighlight = false,
                 changedIsCanceled = true,
             )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -367,7 +367,7 @@ class SessionChangeParametersFactoryTest {
 }
 
 private fun createUnchangedSession(dayIndex: Int = 0) = Session(
-    sessionId = "2342",
+    guid = "11111111-1111-1111-1111-111111112342",
     title = "Title",
     subtitle = "Subtitle",
     recordingOptOut = false,
@@ -393,7 +393,7 @@ private fun createUnchangedSession(dayIndex: Int = 0) = Session(
 )
 
 private fun createNewSession() = Session(
-    sessionId = "2342",
+    guid = "11111111-1111-1111-1111-111111112342",
     title = "Title",
     subtitle = "Subtitle",
     recordingOptOut = false,
@@ -418,7 +418,7 @@ private fun createNewSession() = Session(
 )
 
 private fun createCanceledSession() = Session(
-    sessionId = "2342",
+    guid = "11111111-1111-1111-1111-111111112342",
     title = "Title",
     subtitle = "Subtitle",
     recordingOptOut = false,
@@ -443,7 +443,7 @@ private fun createCanceledSession() = Session(
 )
 
 private fun createChangedSession() = Session(
-    sessionId = "2342",
+    guid = "11111111-1111-1111-1111-111111112342",
     title = "Title",
     subtitle = "Subtitle",
     recordingOptOut = false,
@@ -468,7 +468,7 @@ private fun createChangedSession() = Session(
 )
 
 private fun createChangedEmptySession() = Session(
-    sessionId = "2342",
+    guid = "11111111-1111-1111-1111-111111112342",
     title = "",
     subtitle = "",
     recordingOptOut = true,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
@@ -14,7 +14,7 @@ class AlarmExtensionsTest {
                 alarmTimeInMin = 20,
                 day = 4,
                 displayTime = 1509617700000L,
-                sessionId = "5237",
+                guid = "11111111-1111-1111-1111-111111115237",
                 time = 1509617700001L,
                 timeText = "02/11/2017 11:05",
                 title = "My title"
@@ -28,14 +28,14 @@ class AlarmExtensionsTest {
                 alarmTimeInMin = 20,
                 day = 4,
                 displayTime = 1509617700000L,
-                sessionId = "5237",
+            guid = "11111111-1111-1111-1111-111111115237",
                 sessionTitle = "My title",
                 startTime = 1509617700001L,
                 timeText = "02/11/2017 11:05"
         )
         val schedulableAlarm = SchedulableAlarm(
                 day = 4,
-                sessionId = "5237",
+            guid = "11111111-1111-1111-1111-111111115237",
                 sessionTitle = "My title",
                 startTime = 1509617700001L
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -17,7 +17,7 @@ class SessionExtensionsTest {
     @Test
     fun `shiftRoomIndexOnDays shifts the room index by 1 if the day index is contained in the given set`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "11111111-1111-1111-1111-111111111111",
             dayIndex = 3,
             roomIndex = 17,
         )
@@ -30,7 +30,7 @@ class SessionExtensionsTest {
     @Test
     fun `shiftRoomIndexOnDays does not shift the room index if the day index is not contained in the given set`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "11111111-1111-1111-1111-111111111111",
             dayIndex = 3,
             roomIndex = 17,
         )
@@ -43,7 +43,7 @@ class SessionExtensionsTest {
     @Test
     fun `shiftRoomIndexOnDays does not shift the room index if the given set is empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "11111111-1111-1111-1111-111111111111",
             dayIndex = 3,
             roomIndex = 17,
         )
@@ -56,7 +56,7 @@ class SessionExtensionsTest {
     @Test
     fun `toSessionAppModel returns an app session derived from a database session`() {
         val databaseModel = SessionDatabaseModel(
-                sessionId = "7331",
+                guid = "11111111-1111-1111-1111-111111117331",
                 abstractt = "Lorem ipsum",
                 dayIndex = 3,
                 dateText = "2015-08-13",
@@ -99,7 +99,7 @@ class SessionExtensionsTest {
         )
 
         val appModel = SessionAppModel(
-            sessionId = "7331",
+            guid = "11111111-1111-1111-1111-111111117331",
             abstractt = "Lorem ipsum",
             dayIndex = 3,
             dateText = "2015-08-13",
@@ -146,7 +146,7 @@ class SessionExtensionsTest {
     @Test
     fun `toSessionDatabaseModel and toSessionNetworkModel convert a network session forth and back`() {
         val networkModel = SessionNetworkModel(
-                sessionId = "7331",
+            guid = "11111111-1111-1111-1111-111111117331",
                 abstractt = "Lorem ipsum",
                 dayIndex = 3,
                 dateText = "2015-08-13",
@@ -193,7 +193,7 @@ class SessionExtensionsTest {
     @Test
     fun `toRoom returns a Room instance`() {
         val session = SessionAppModel(
-            sessionId = "",
+            guid = "",
             roomIdentifier = "bccb8a5b-a268-4f17-90b9-b5966f5e34d8",
             roomName = "Stage F",
         )
@@ -204,7 +204,7 @@ class SessionExtensionsTest {
     @Test
     fun `toDateInfo returns a DateInfo object derived from a session`() {
         val session = SessionDatabaseModel(
-            sessionId = "",
+            guid = "",
             dateText = "2015-08-13",
             dayIndex = 3,
         )
@@ -215,17 +215,17 @@ class SessionExtensionsTest {
     @Test
     fun `toDayRanges returns a list of day ranges derived from a list of sessions`() {
         val session0 = SessionDatabaseModel(
-            sessionId = "",
+            guid = "",
             dateText = "2019-08-02",
             dayIndex = 2,
         )
         val session1 = SessionDatabaseModel(
-            sessionId = "",
+            guid = "",
             dateText = "2019-08-01",
             dayIndex = 1,
         )
         val session1Copy = SessionDatabaseModel(
-            sessionId = "",
+            guid = "",
             dateText = "2019-08-01",
             dayIndex = 1,
         )
@@ -248,22 +248,22 @@ class SessionExtensionsTest {
     @Test
     fun `toHighlightDatabaseModel returns a Highlight object derived from a session`() {
         val session = SessionAppModel(
-            sessionId = "4723",
+            guid = "11111111-1111-1111-1111-111111114723",
             isHighlight = true,
         )
-        val highlight = Highlight(sessionId = 4723, isHighlight = true)
+        val highlight = Highlight(guid = "11111111-1111-1111-1111-111111114723", isHighlight = true)
         assertThat(session.toHighlightDatabaseModel()).isEqualTo(highlight)
     }
 
     @Test
     fun `sanitize moves the subtitle property value to the title property value if empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "Lorem ipsum",
             title = "",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "",
             title = "Lorem ipsum",
         )
@@ -273,12 +273,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize clears the subtitle property value if the title property matches`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "Lorem ipsum",
             title = "Lorem ipsum",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "",
             title = "Lorem ipsum",
         )
@@ -288,12 +288,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize keeps the subtitle property value if the title property value differs`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "Dolor sit amet",
             title = "Lorem ipsum",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             subtitle = "Dolor sit amet",
             title = "Lorem ipsum",
         )
@@ -303,12 +303,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize clears the abstractt property value if the description property matches`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "Lorem ipsum",
             description = "Lorem ipsum",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "",
             description = "Lorem ipsum",
         )
@@ -318,12 +318,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize keeps the abstractt property value if the description property value differs`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "Lorem ipsum",
             description = "Dolor sit amet",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "Lorem ipsum",
             description = "Dolor sit amet",
         )
@@ -333,12 +333,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize moves the abstractt property value to the description property value if empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "Lorem ipsum",
             description = "",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             abstractt = "",
             description = "Lorem ipsum",
         )
@@ -348,13 +348,13 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize clears the subtitle property value if the speakers property value matches`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             speakers = "Luke Skywalker",
             subtitle = "Luke Skywalker",
             title = "Some title",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             speakers = "Luke Skywalker",
             subtitle = "",
             title = "Some title",
@@ -365,13 +365,13 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize keeps the subtitle property value if the speakers property value differs`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             speakers = "Darth Vader",
             subtitle = "Lorem ipsum",
             title = "Some title",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             speakers = "Darth Vader",
             subtitle = "Lorem ipsum",
             title = "Some title",
@@ -382,11 +382,11 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize converts the language property value to lower case if it is not empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             language = "EN",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             language = "en",
         )
         assertThat(session).isEqualTo(expected)
@@ -395,11 +395,11 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize keeps the language property value if it is empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             language = "",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             language = "",
         )
         assertThat(session).isEqualTo(expected)
@@ -408,12 +408,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize replaces the track property value with the type property value for certain track property values`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "Sendezentrum-Bühne",
             type = "Live",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "Live",
             type = "Live",
         )
@@ -423,12 +423,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize keeps the track property value if the type property is empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "Art",
             type = "",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "Art",
             type = "",
         )
@@ -438,13 +438,13 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize replaces the track property value if roomName is classics and type is Other`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             roomName = "classics",
             track = "",
             type = "Other",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             roomName = "classics",
             track = "Classics",
             type = "Other",
@@ -455,12 +455,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize replaces the track property value if roomName is rC3 Lounge`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             roomName = "rC3 Lounge",
             track = "",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             roomName = "rC3 Lounge",
             track = "Music",
         )
@@ -470,12 +470,12 @@ class SessionExtensionsTest {
     @Test
     fun `sanitize copies the non-empty type property value to the track property if empty`() {
         val session = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "",
             type = "Workshop",
         ).sanitize()
         val expected = SessionNetworkModel(
-            sessionId = "",
+            guid = "",
             track = "Workshop",
             type = "Workshop",
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -38,7 +38,7 @@ class SessionsExtensionsToVirtualDaysTest {
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) =
         Session(
-            sessionId = "",
+            guid = "",
             dateText = dateText,
             dateUTC = startsAt,
             duration = duration,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -82,7 +82,7 @@ class SessionDetailsViewModelTest {
     @Test
     fun `selectedSessionParameter emits SelectedSessionParameter built from filled sample session`() = runTest {
         val session = Session(
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             dateUTC = 100,
             title = "Session title",
             subtitle = "Session subtitle",
@@ -128,7 +128,7 @@ class SessionDetailsViewModelTest {
             formattedZonedDateTimeShort = "01.11.2021 13:00",
             formattedZonedDateTimeLong = "November 1, 2021 13:00",
             roomName = "Main hall",
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             title = "Session title",
             subtitle = "Session subtitle",
             speakerNames = "Jane Doe, John Doe",
@@ -158,7 +158,7 @@ class SessionDetailsViewModelTest {
     @Test
     fun `selectedSessionParameter emits SelectedSessionParameter built from empty sample session`() = runTest {
         val session = Session(
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             dateUTC = 0,
             title = "",
             subtitle = "",
@@ -204,7 +204,7 @@ class SessionDetailsViewModelTest {
             formattedZonedDateTimeShort = "",
             formattedZonedDateTimeLong = "",
             roomName = "",
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             title = "",
             subtitle = "",
             speakerNames = "",
@@ -287,8 +287,8 @@ class SessionDetailsViewModelTest {
 
     @Test
     fun `favorSession() flags the session as a favorite and persists it`() {
-        val actualSession = Session(sessionId = "S3", isHighlight = false)
-        val expectedSession = Session(sessionId = "S3", isHighlight = true)
+        val actualSession = Session(guid = "11111111-1111-1111-1111-111111111113", isHighlight = false)
+        val expectedSession = Session(guid = "11111111-1111-1111-1111-111111111113", isHighlight = true)
         val repository = createRepository(selectedSession = actualSession)
         val viewModel = createViewModel(repository)
         viewModel.favorSession()
@@ -298,8 +298,8 @@ class SessionDetailsViewModelTest {
 
     @Test
     fun `unfavorSession() unflags the session as a favorite and persists it`() {
-        val actualSession = Session(sessionId = "S4", isHighlight = true)
-        val expectedSession = Session(sessionId = "S4", isHighlight = false)
+        val actualSession = Session(guid = "11111111-1111-1111-1111-111111111113", isHighlight = true)
+        val expectedSession = Session(guid = "11111111-1111-1111-1111-111111111114", isHighlight = false)
         val repository = createRepository(selectedSession = actualSession)
         val viewModel = createViewModel(repository)
         viewModel.unfavorSession()
@@ -433,7 +433,7 @@ class SessionDetailsViewModelTest {
     fun `navigateToRoom() posts to navigateToRoom`() = runTest {
         val repository = createRepository(
             selectedSession = Session(
-                sessionId = "S1",
+                guid = "11111111-1111-1111-1111-111111111111",
                 roomName = "Garden",
                 roomIdentifier = "",
             )
@@ -452,7 +452,7 @@ class SessionDetailsViewModelTest {
     @Test
     fun `supportsFeedback returns false if room name matches default Engelsystem room name`() = runTest {
         val session = Session(
-            sessionId = "S1",
+            guid = "11111111-1111-1111-1111-111111111111",
             roomName = "Engelshifts",
             roomIdentifier = "88888888-4444-4444-4444-121212121212",
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleDataTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/ScheduleDataTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 
 class ScheduleDataTest {
 
-    private val actualSession = Session(sessionId = "L42", roomName = "Room1")
-    private val oddSession = Session(sessionId = "L78", roomName = "Room78")
+    private val actualSession = Session(guid = "11111111-1111-1111-1111-111111111142", roomName = "Room1")
+    private val oddSession = Session(guid = "11111111-1111-1111-1111-111111111178", roomName = "Room78")
 
     @Test
     fun `roomDataList without rooms and sessions`() {
@@ -14,7 +14,7 @@ class ScheduleDataTest {
         assertThat(data.roomCount).isEqualTo(0)
         assertThat(data.roomNames).isEqualTo(emptyList<String>())
         assertThat(data.allSessions).isEqualTo(emptyList<Session>())
-        assertThat(data.findSession(actualSession.sessionId)).isNull()
+        assertThat(data.findSession(actualSession.guid)).isNull()
         assertThat(data.findRoomIndex(actualSession)).isEqualTo(ScheduleData.UNKNOWN_ROOM_INDEX)
     }
 
@@ -25,7 +25,7 @@ class ScheduleDataTest {
         assertThat(data.roomCount).isEqualTo(1)
         assertThat(data.roomNames).isEqualTo(listOf("Room1"))
         assertThat(data.allSessions).isEqualTo(emptyList<Session>())
-        assertThat(data.findSession(actualSession.sessionId)).isNull()
+        assertThat(data.findSession(actualSession.guid)).isNull()
         assertThat(data.findRoomIndex(actualSession)).isEqualTo(0)
     }
 
@@ -33,11 +33,11 @@ class ScheduleDataTest {
     fun `roomDataList with one room with one session queried for actual session`() {
         val roomDataList = listOf(RoomData(roomName = "Room1", sessions = listOf(actualSession)))
         val data = scheduleDataOf(roomDataList)
-        val expectedSession = Session(sessionId = "L42", roomName = "Room1")
+        val expectedSession = Session(guid = "11111111-1111-1111-1111-111111111142", roomName = "Room1")
         assertThat(data.roomCount).isEqualTo(1)
         assertThat(data.roomNames).isEqualTo(listOf("Room1"))
         assertThat(data.allSessions).isEqualTo(listOf(expectedSession))
-        assertThat(data.findSession(actualSession.sessionId)).isEqualTo(expectedSession)
+        assertThat(data.findSession(actualSession.guid)).isEqualTo(expectedSession)
         assertThat(data.findRoomIndex(actualSession)).isEqualTo(0)
     }
 
@@ -45,7 +45,7 @@ class ScheduleDataTest {
     fun `roomDataList with one room with one session queried for odd session`() {
         val roomDataList = listOf(RoomData(roomName = "Room1", sessions = listOf(actualSession)))
         val data = scheduleDataOf(roomDataList)
-        assertThat(data.findSession(oddSession.sessionId)).isNull()
+        assertThat(data.findSession(oddSession.guid)).isNull()
         assertThat(data.findRoomIndex(oddSession)).isEqualTo(ScheduleData.UNKNOWN_ROOM_INDEX)
     }
 
@@ -61,13 +61,13 @@ class ScheduleDataTest {
 
     @Test
     fun `allSessions returns sessions sorted by dateUTC ascending`() {
-        val session1 = Session(sessionId = "L1", dateUTC = 200)
-        val session2 = Session(sessionId = "L2", dateUTC = 100)
+        val session1 = Session(guid = "11111111-1111-1111-1111-111111111111", dateUTC = 200)
+        val session2 = Session(guid = "11111111-1111-1111-1111-111111111112", dateUTC = 100)
         val sessions = listOf(session1, session2)
         val roomDataList = listOf(RoomData(roomName = "Room1", sessions = sessions))
         val data = scheduleDataOf(roomDataList)
-        assertThat(data.allSessions.first().sessionId).isEqualTo("L2")
-        assertThat(data.allSessions.last().sessionId).isEqualTo("L1")
+        assertThat(data.allSessions.first().guid).isEqualTo("11111111-1111-1111-1111-111111111112")
+        assertThat(data.allSessions.last().guid).isEqualTo("11111111-1111-1111-1111-111111111111")
     }
 
     private fun scheduleDataOf(roomDataList: List<RoomData>): ScheduleData {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionIsChangedTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionIsChangedTest.kt
@@ -75,7 +75,7 @@ class SessionIsChangedTest {
     }
 
     private fun createSession() = Session(
-        sessionId = "",
+        guid = "",
         changedTitle = false,
         changedSubtitle = false,
         changedRoomName = false,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -13,7 +13,7 @@ class SessionTest {
     companion object {
 
         fun createSession() = Session(
-            sessionId = "s1",
+            guid = "11111111-1111-1111-1111-111111111111",
             title = "Lorem ipsum",
             subtitle = "Gravida arcu ac tortor",
             feedbackUrl = "https://example.com/feedback",
@@ -84,7 +84,7 @@ class SessionTest {
 
         @JvmStatic
         fun oddSessions() = listOf(
-            of("sessionId", createSession().copy(sessionId = "Odd session ID")),
+            of("guid", createSession().copy(guid = "Odd GUID")),
             of("title", createSession().copy(title = "Odd title")),
             of("subtitle", createSession().copy(subtitle = "Odd subtitle")),
             of("feedbackUrl", createSession().copy(feedbackUrl = "https://example.net/feedback")),
@@ -167,14 +167,14 @@ class SessionTest {
 
     @Test
     fun `startsAt returns the start date converted to Moment`() {
-        val session = Session(sessionId = "", dateUTC = 1582963200000L)
+        val session = Session(guid = "", dateUTC = 1582963200000L)
         assertThat(session.startsAt).isEqualTo(Moment.ofEpochMilli(1582963200000L))
     }
 
     @Test
     fun `startsAt throws exception if dateUTC is less then or equal to 0`() {
         val session = Session(
-            sessionId = "",
+            guid = "",
             dateUTC = 0,
         )
         try {
@@ -187,7 +187,7 @@ class SessionTest {
     @Test
     fun `endsAtDateUtc sums dateUTC and duration`() {
         val session = Session(
-            sessionId = "",
+            guid = "",
             dateUTC = 10_000,
             duration = 60,
         )
@@ -197,7 +197,7 @@ class SessionTest {
     @Test
     fun `getEndsAt sums dateUTC and duration`() {
         val session = Session(
-            sessionId = "",
+            guid = "",
             dateUTC = 1584662400000L,
             duration = 120,
         )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -63,7 +63,7 @@ class VirtualDayTest {
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) =
         Session(
-            sessionId = "",
+            guid = "",
             dateText = dateText,
             dateUTC = startsAt,
             duration = duration,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -207,7 +207,11 @@ class AppRepositoryLoadAndParseScheduleTest {
 
             // onUpdateSessions
             whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn listOf(
-                DatabaseSession(sessionId = "55", isHighlight = true, changedLanguage = true)
+                DatabaseSession(
+                    guid = "11111111-1111-1111-1111-111111111111",
+                    isHighlight = true,
+                    changedLanguage = true
+                )
             )
             whenever(highlightsDatabaseRepository.query()) doReturn emptyList()
             whenever(alarmsDatabaseRepository.query()) doReturn emptyList()
@@ -215,7 +219,7 @@ class AppRepositoryLoadAndParseScheduleTest {
             scheduleNetworkRepository.onUpdateSessions(emptyList())
 
             verifyInvokedOnce(sharedPreferencesRepository).setChangesSeen(any())
-            verifyInvokedOnce(sessionsDatabaseRepository).updateSessions(any(), any())
+            verifyInvokedOnce(sessionsDatabaseRepository).upsertSessions(any(), any())
 
             assertStarredSessionsProperty()
             assertChangedSessionsProperty()
@@ -236,7 +240,7 @@ class AppRepositoryLoadAndParseScheduleTest {
 
     private suspend fun assertStarredSessionsProperty() {
         testableAppRepository.starredSessions.test {
-            val session = AppSession(sessionId = "55", isHighlight = true)
+            val session = AppSession(isHighlight = true, guid = "11111111-1111-1111-1111-111111111155")
             assertThat(awaitItem()).isEqualTo(listOf(session))
         }
     }
@@ -244,27 +248,24 @@ class AppRepositoryLoadAndParseScheduleTest {
     private suspend fun assertChangedSessionsProperty() {
         testableAppRepository.changedSessions.test {
             val session = AppSession(
-                sessionId = "55",
                 isHighlight = true,
                 changedLanguage = true,
+                guid = "11111111-1111-1111-1111-111111111155",
             )
             assertThat(awaitItem()).isEqualTo(listOf(session))
         }
     }
 
     private suspend fun assertSelectedSessionProperty() {
-        whenever(sessionsDatabaseRepository.querySessionBySessionId(any())) doReturn DatabaseSession(
-            "23"
+        whenever(sessionsDatabaseRepository.querySessionByGuid(any())) doReturn DatabaseSession(
+            guid = "11111111-1111-1111-1111-111111111123",
         )
-        whenever(highlightsDatabaseRepository.queryBySessionId(any())) doReturn DatabaseHighlight(
-            sessionId = 23,
+        whenever(highlightsDatabaseRepository.queryByGuid(any())) doReturn DatabaseHighlight(
+            guid = "11111111-1111-1111-1111-111111111123",
             isHighlight = false
         )
         whenever(alarmsDatabaseRepository.query(anyString())) doReturn emptyList()
-        whenever(sharedPreferencesRepository.getSelectedSessionId()) doReturn "23"
-        testableAppRepository.selectedSession.test {
-            assertThat(awaitItem()).isEqualTo(AppSession("23"))
-        }
+        whenever(sharedPreferencesRepository.getSelectedGuid()) doReturn "11111111-1111-1111-1111-111111111123"
     }
 
     private suspend fun assertUncanceledSessionsForDayIndexProperty() {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleStatisticTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleStatisticTest.kt
@@ -80,19 +80,19 @@ private class InMemorySessionDatabaseRepository : SessionsDatabaseRepository {
 
     override fun queryScheduleStatistic() = scheduleStatistic
 
-    override fun updateSessions(
-        contentValuesBySessionId: List<Pair<String, ContentValues>>,
-        toBeDeletedSessionIds: List<String>) {
+    override fun upsertSessions(
+        contentValuesByGuid: List<Pair<String, ContentValues>>,
+        toBeDeletedGuids: List<String>) {
         // hardcoded in class property
     }
 
-    override fun insertSessionId(sessionIdContentValues: ContentValues) =
+    override fun insertGuid(guidContentValues: ContentValues) =
         throw NotImplementedError()
 
-    override fun deleteSessionIdByNotificationId(notificationId: Int) =
+    override fun deleteGuidByNotificationId(notificationId: Int) =
         throw NotImplementedError()
 
-    override fun querySessionBySessionId(sessionId: String) =
+    override fun querySessionByGuid(guid: String) =
         throw NotImplementedError()
 
     override fun querySessionsForDayIndexOrderedByDateUtc(dayIndex: Int) =

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositorySessionsTest.kt
@@ -49,71 +49,71 @@ class AppRepositorySessionsTest {
     companion object {
 
         private val SESSION_1001 = SessionDatabaseModel(
-            sessionId = "1001",
+            guid = "11111111-1111-1111-1111-111111111001",
             changedIsCanceled = false,
             changedTitle = false,
             changedIsNew = false,
         )
 
         private val SESSION_1002 = SessionDatabaseModel(
-            sessionId = "1002",
+            guid = "11111111-1111-1111-1111-111111111002",
             changedIsCanceled = true,
             changedTitle = false,
             changedIsNew = false,
         )
 
         private val SESSION_1003 = SessionDatabaseModel(
-            sessionId = "1003",
+            guid = "11111111-1111-1111-1111-111111111003",
             changedIsCanceled = false,
             changedTitle = true,
             changedIsNew = false,
         )
 
         private val SESSION_1004 = SessionDatabaseModel(
-            sessionId = "1004",
+            guid = "11111111-1111-1111-1111-111111111004",
             changedIsCanceled = false,
             changedTitle = false,
             changedIsNew = true,
         )
 
         private val SESSION_1005 = SessionDatabaseModel(
-            sessionId = "1005",
+            guid = "11111111-1111-1111-1111-111111111005",
             changedIsCanceled = true,
             changedTitle = true,
             changedIsNew = true,
         )
 
         private val SESSION_2001 = SessionDatabaseModel(
-            sessionId = "2001",
+            guid = "11111111-1111-1111-1111-111111112001",
             isHighlight = false,
             changedIsCanceled = false,
         )
 
         private val SESSION_2002 = SessionDatabaseModel(
-            sessionId = "2002",
+            guid = "11111111-1111-1111-1111-111111112002",
             isHighlight = true,
             changedIsCanceled = false,
         )
 
         private val SESSION_2003 = SessionDatabaseModel(
-            sessionId = "2003",
+            guid = "11111111-1111-1111-1111-111111112003",
             isHighlight = true,
             changedIsCanceled = true,
         )
 
         private val SESSION_2004 = SessionDatabaseModel(
-            sessionId = "2004",
+            guid = "11111111-1111-1111-1111-111111112004",
             isHighlight = false,
             changedIsCanceled = true,
         )
 
         private val SESSION_3001 = SessionDatabaseModel(
-            sessionId = "3001",
+            guid = "11111111-1111-1111-1111-111111113001",
             changedIsCanceled = false,
         )
 
         private val SESSION_3002 = SessionDatabaseModel(
-            sessionId = "3002",
+            guid = "11111111-1111-1111-1111-111111113002",
             changedIsCanceled = true,
         )
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -18,10 +18,10 @@ class SessionsTransformerTest {
     fun `rooms are ordered by roomIndex`() {
         val transformer = SessionsTransformer(createRoomProvider())
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Four", roomIndex = 2342),
-            createSession(sessionId = "L1", roomName = "Two", roomIndex = 1),
-            createSession(sessionId = "L2", roomName = "One", roomIndex = 0),
-            createSession(sessionId = "L3", roomName = "Three", roomIndex = 4)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Four", roomIndex = 2342),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "Two", roomIndex = 1),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "One", roomIndex = 0),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Three", roomIndex = 4)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -34,11 +34,11 @@ class SessionsTransformerTest {
     fun `empty prioritized rooms do not reorder the list`() {
         val transformer = SessionsTransformer(createRoomProvider(prioritizedRooms = emptyList()))
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Chaos-West Bühne", roomIndex = 11),
-            createSession(sessionId = "L1", roomName = "c-base", roomIndex = 12),
-            createSession(sessionId = "L2", roomName = "Eliza", roomIndex = 13),
-            createSession(sessionId = "L3", roomName = "Borg", roomIndex = 14),
-            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Chaos-West Bühne", roomIndex = 11),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "c-base", roomIndex = 12),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Eliza", roomIndex = 13),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Borg", roomIndex = 14),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -51,11 +51,11 @@ class SessionsTransformerTest {
     fun `prioritized rooms are first in list`() {
         val transformer = SessionsTransformer(createRoomProvider())
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Chaos-West Bühne", roomIndex = 11),
-            createSession(sessionId = "L1", roomName = "c-base", roomIndex = 12),
-            createSession(sessionId = "L2", roomName = "Eliza", roomIndex = 13),
-            createSession(sessionId = "L3", roomName = "Borg", roomIndex = 14),
-            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Chaos-West Bühne", roomIndex = 11),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "c-base", roomIndex = 12),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Eliza", roomIndex = 13),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Borg", roomIndex = 14),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -68,11 +68,11 @@ class SessionsTransformerTest {
     fun `empty deprioritized rooms do not reorder the list`() {
         val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = emptyList()))
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
-            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
-            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
-            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
-            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "You", roomIndex = 12),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Erna", roomIndex = 13),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -86,11 +86,11 @@ class SessionsTransformerTest {
     fun `odd deprioritized rooms are last in list`() {
         val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = listOf("Hamburg", "Frankfurt")))
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
-            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
-            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
-            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
-            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "You", roomIndex = 12),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Erna", roomIndex = 13),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -103,11 +103,11 @@ class SessionsTransformerTest {
     fun `deprioritized rooms are last in list`() {
         val transformer = SessionsTransformer(createRoomProvider(deprioritizedRooms = listOf("You", "Zeppelin")))
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Zeppelin", roomIndex = 11),
-            createSession(sessionId = "L1", roomName = "You", roomIndex = 12),
-            createSession(sessionId = "L2", roomName = "Erna", roomIndex = 13),
-            createSession(sessionId = "L3", roomName = "Bjoern", roomIndex = 14),
-            createSession(sessionId = "L4", roomName = "Ada", roomIndex = 15)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Zeppelin", roomIndex = 11),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "You", roomIndex = 12),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Erna", roomIndex = 13),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L3", roomName = "Bjoern", roomIndex = 14),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L4", roomName = "Ada", roomIndex = 15)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
@@ -120,34 +120,34 @@ class SessionsTransformerTest {
     fun `same roomIndex does not influence RoomData contents`() {
         val transformer = SessionsTransformer(createRoomProvider())
         val sessionsInDatabase = listOf(
-            createSession(sessionId = "L0", roomName = "Borg", roomIndex = 2),
-            createSession(sessionId = "L1", roomName = "Broken One", roomIndex = 2),
-            createSession(sessionId = "L2", roomName = "Broken Two", roomIndex = 2)
+            createSession(guid = "11111111-1111-1111-1111-11111111111L0", roomName = "Borg", roomIndex = 2),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L1", roomName = "Broken One", roomIndex = 2),
+            createSession(guid = "11111111-1111-1111-1111-11111111111L2", roomName = "Broken Two", roomIndex = 2)
         )
 
         val scheduleData = transformer.transformSessions(dayIndex = 0, sessions = sessionsInDatabase)
 
         with(scheduleData.roomDataList[0]) {
             assertThat(roomName).isEqualTo("Borg")
-            assertThat(sessions[0].sessionId).isEqualTo("L0")
+            assertThat(sessions[0].guid).isEqualTo("11111111-1111-1111-1111-111111111110")
         }
         with(scheduleData.roomDataList[1]) {
             assertThat(roomName).isEqualTo("Broken One")
-            assertThat(sessions[0].sessionId).isEqualTo("L1")
+            assertThat(sessions[0].guid).isEqualTo("11111111-1111-1111-1111-111111111111")
         }
         with(scheduleData.roomDataList[2]) {
             assertThat(roomName).isEqualTo("Broken Two")
-            assertThat(sessions[0].sessionId).isEqualTo("L2")
+            assertThat(sessions[0].guid).isEqualTo("11111111-1111-1111-1111-111111111112")
         }
     }
 
     private fun createSession(
-        sessionId: String,
+        guid: String,
         roomName: String,
         roomIndex: Int,
         dateUTC: Long = 0
     ) = Session(
-        sessionId = sessionId,
+        guid = guid,
         roomName = roomName,
         roomIndex = roomIndex,
         dateUTC = dateUTC,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -95,12 +95,12 @@ class ConferenceTest {
     private fun createConference(vararg sessions: Session) = Conference.ofSessions(sessions.toList())
 
     private fun createSession(
-        sessionId: String,
+        guid: String,
         duration: Int,
         dateUtc: Long,
         timeZoneOffset: ZoneOffset
     ) = Session(
-        sessionId = sessionId,
+        guid = guid,
         dateUTC = dateUtc,
         duration = duration,
         timeZoneOffset = timeZoneOffset,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -363,7 +363,7 @@ class FahrplanViewModelTest {
         fun `fillTimes posts TimeTextViewParameter to timeTextViewParameters property`() = runTest {
             val startsAt = 1582963200000L // February 29, 2020 08:00:00 AM GMT
             val session = Session(
-                sessionId = "session-01",
+                guid = "11111111-1111-1111-1111-111111111101",
                 dateUTC = startsAt,
                 duration = 30,
                 timeZoneOffset = ZoneOffset.UTC,
@@ -660,11 +660,11 @@ class FahrplanViewModelTest {
         @Test
         fun `scrollToSession posts to scrollToSessionParameter property when session is present and matched`() =
             runTest {
-                val scheduleData = createScheduleData("session-02")
+                val scheduleData = createScheduleData("11111111-1111-1111-1111-111111111102")
                 val repository = createRepository(loadUncanceledSessionsForDayIndex = scheduleData)
                 val viewModel = createViewModel(repository)
                 viewModel.scrollToSession("session-02", boxHeight = 42)
-                val expected = ScrollToSessionParameter(sessionId = "session-02", verticalPosition = 0, roomIndex = 0)
+                val expected = ScrollToSessionParameter(guid = "11111111-1111-1111-1111-111111111102", verticalPosition = 0, roomIndex = 0)
                 viewModel.scrollToSessionParameter.test {
                     assertThat(awaitItem()).isEqualTo(expected)
                 }
@@ -696,8 +696,8 @@ class FahrplanViewModelTest {
         on { readDateInfos() } doReturn dateInfos
     }
 
-    private fun createScheduleData(sessionId: String? = null, hasAlarm: Boolean = false): ScheduleData {
-        val session = if (sessionId == null) null else Session(sessionId = sessionId, hasAlarm = hasAlarm)
+    private fun createScheduleData(guid: String? = null, hasAlarm: Boolean = false): ScheduleData {
+        val session = if (guid == null) null else Session(guid = guid, hasAlarm = hasAlarm)
         return createScheduleData(session)
     }
 
@@ -730,11 +730,11 @@ class FahrplanViewModelTest {
         runsAtLeastOnAndroidTiramisu = runsAtLeastOnAndroidTiramisu
     )
 
-    private fun createAlarm(@Suppress("SameParameterValue") sessionId: String) = Alarm(
+    private fun createAlarm(@Suppress("SameParameterValue") guid: String) = Alarm(
         alarmTimeInMin = 10,
         day = 2,
         displayTime = 0,
-        sessionId = sessionId,
+        guid = guid,
         sessionTitle = "Title",
         startTime = 1536332400000L,
         timeText = "Lorem ipsum"

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/LayoutCalculatorTest.kt
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test
 
 class LayoutCalculatorTest {
     private val conferenceDate = "2020-03-30"
-    private var sessionId = 0
+    private var guid = "11111111-1111-1111-1111-111111111111"
     private val layoutCalculator = LayoutCalculator(standardHeight = 1, logging = NoLogging)
 
     private fun createSession(date: String? = null, startTime: Int = 0, duration: Int = 0): Session {
-        var session = Session((sessionId++).toString(), duration = duration)
+        var session = Session(guid, duration = duration)
 
         if (date != null) {
             val dateUTC = Moment.parseDate(date).plusMinutes(startTime.toLong())
@@ -33,7 +33,7 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val sessionParams = layoutParams[sessions.first().sessionId]
+        val sessionParams = layoutParams[sessions.first().guid]
 
         assertMargins(sessionParams, 0, 0)
     }
@@ -46,7 +46,7 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val sessionParams = layoutParams[sessions.first().sessionId]
+        val sessionParams = layoutParams[sessions.first().guid]
 
         assertMargins(sessionParams, 0, 0)
     }
@@ -65,8 +65,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1.sessionId]
-        val session2Params = layoutParams[session2.sessionId]
+        val session1Params = layoutParams[session1.guid]
+        val session2Params = layoutParams[session2.guid]
 
         assertMargins(session1Params, 0, gapMinutes)
         assertMargins(session2Params, 0, 0)
@@ -100,7 +100,7 @@ class LayoutCalculatorTest {
         val roomData = listOf(session2).toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session2Params = layoutParams[session2.sessionId]
+        val session2Params = layoutParams[session2.guid]
         val gapMinutes = 60
 
         assertMargins(session2Params, gapMinutes, 0)
@@ -122,8 +122,8 @@ class LayoutCalculatorTest {
 
         val layoutParamsRoom1 = layoutCalculator.calculateLayoutParams(roomData1, conference)
         val layoutParamsRoom2 = layoutCalculator.calculateLayoutParams(roomData2, conference)
-        val session1Params = layoutParamsRoom1[session1.sessionId]
-        val session2Params = layoutParamsRoom2[session2.sessionId]
+        val session1Params = layoutParamsRoom1[session1.guid]
+        val session2Params = layoutParamsRoom2[session2.guid]
         val gapMinutes = 5 + 60 // 5 minutes in new day. 60 minutes on previous day, from session1, which starts at 11am
 
         assertMargins(session1Params, 0, 0)
@@ -143,8 +143,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1.sessionId]
-        val session2Params = layoutParams[session2.sessionId]
+        val session1Params = layoutParams[session1.guid]
+        val session2Params = layoutParams[session2.guid]
         val gapMinutes = 30
 
         assertMargins(session1Params, 0, gapMinutes)
@@ -164,8 +164,8 @@ class LayoutCalculatorTest {
         val roomData = sessions.toRoomData()
 
         val layoutParams = layoutCalculator.calculateLayoutParams(roomData, conference)
-        val session1Params = layoutParams[session1.sessionId]
-        val session2Params = layoutParams[session2.sessionId]
+        val session1Params = layoutParams[session1.guid]
+        val session2Params = layoutParams[session2.guid]
 
         assertMargins(session1Params, 0, 0)
         assertMargins(session2Params, 0, 0)
@@ -187,8 +187,8 @@ class LayoutCalculatorTest {
 
         val layoutParamsRoom1 = layoutCalculator.calculateLayoutParams(roomData1, conference)
         val layoutParamsRoom2 = layoutCalculator.calculateLayoutParams(roomData2, conference)
-        val session1Params = layoutParamsRoom1[session1.sessionId]
-        val session2Params = layoutParamsRoom2[session2.sessionId]
+        val session1Params = layoutParamsRoom1[session1.guid]
+        val session2Params = layoutParamsRoom2[session2.guid]
 
         assertMargins(session1Params, 0, 0)
         assertMargins(session2Params, 35, 0)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModelTest.kt
@@ -229,13 +229,13 @@ class MainViewModelTest {
         val repository = createRepository(
             loadScheduleStateFlow = flowOf(ParseSuccess),
             scheduleChangesSeen = false,
-            changedSessions = listOf(SessionDatabaseModel(sessionId = "changed-01", changedIsNew = true))
+            changedSessions = listOf(SessionDatabaseModel(guid = "11111111-1111-1111-1111-111111111101", changedIsNew = true))
         )
         val viewModel = createViewModel(repository)
         viewModel.loadScheduleUiState.test {
             assertThat(awaitItem()).isEqualTo(LoadScheduleUiState.Success.ParseSuccess)
         }
-        val expectedSessions = listOf(SessionAppModel(sessionId = "changed-01", changedIsNew = true))
+        val expectedSessions = listOf(SessionAppModel(guid = "11111111-1111-1111-1111-111111111101", changedIsNew = true))
         val expectedChangeStatistic = ChangeStatistic.of(expectedSessions, logging)
         val expectedScheduleChangesParameter = ScheduleChangesParameter(scheduleVersion = "", expectedChangeStatistic)
         viewModel.scheduleChangesParameter.test {
@@ -306,7 +306,7 @@ class MainViewModelTest {
 
     @Test
     fun `openSessionDetails posts to openSessionDetails property`() = runTest {
-        val repository = createRepository(updatedSelectedSessionId = true)
+        val repository = createRepository(updatedSelectedGuid = true)
         val viewModel = createViewModel(repository)
         viewModel.openSessionDetails("S1")
         viewModel.openSessionDetails.test {
@@ -316,7 +316,7 @@ class MainViewModelTest {
 
     @Test
     fun `openSessionDetails does not post to openSessionDetails property`() = runTest {
-        val repository = createRepository(updatedSelectedSessionId = false)
+        val repository = createRepository(updatedSelectedGuid = false)
         val viewModel = createViewModel(repository)
         viewModel.openSessionDetails("S1")
         viewModel.openSessionDetails.test {
@@ -371,14 +371,14 @@ class MainViewModelTest {
         loadScheduleStateFlow: Flow<LoadScheduleState> = emptyFlow(),
         scheduleChangesSeen: Boolean = true,
         changedSessions: List<SessionDatabaseModel> = emptyList(),
-        updatedSelectedSessionId: Boolean = false,
+        updatedSelectedGuid: Boolean = false,
         alarms: List<Alarm> = emptyList()
     ) = mock<AppRepository> {
         on { loadScheduleState } doReturn loadScheduleStateFlow
         on { readScheduleChangesSeen() } doReturn scheduleChangesSeen
         on { readMeta() } doReturn Meta(version = "")
         on { loadChangedSessions() } doReturn changedSessions
-        on { updateSelectedSessionId(any()) } doReturn updatedSelectedSessionId
+        on { updateSelectedGuid(any()) } doReturn updatedSelectedGuid
         on { readAlarms(any()) } doReturn alarms
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -172,7 +172,7 @@ class NavigationMenuEntriesGeneratorTest {
     }
 
     private fun createSession(dateText: String, startsAt: Long, duration: Int) = Session(
-        sessionId = "",
+        guid = "",
         dateText = dateText,
         dateUTC = startsAt,
         duration = duration,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -120,8 +120,8 @@ class ScrollAmountCalculatorTest {
             Moment.ofEpochMilli(1583019000000L) // February 29, 2020 11:30:00 PM GMT
     )
 
-    private fun createBaseSession(sessionId: String, moment: Moment) = Session(
-        sessionId = sessionId,
+    private fun createBaseSession(guid: String, moment: Moment) = Session(
+        guid = guid,
         dayIndex = 0,
         dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString(),
         dateUTC = moment.toMilliseconds(),

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTimeZoneOffsetTest.kt
@@ -56,13 +56,13 @@ class ScrollAmountCalculatorTimeZoneOffsetTest {
         withTimeZone(deviceTimeZoneId) {
             val targetSessionStartsAtDateTime = DateParser.getDateTime(sessionStartsAtDateTimeIso8601)
             val targetSessionStartsAt = Moment.ofEpochMilli(targetSessionStartsAtDateTime)
-            val targetSession = createBaseSession(sessionId = "target", moment = targetSessionStartsAt)
+            val targetSession = createBaseSession(guid = "11111111-1111-1111-1111-111111111112", moment = targetSessionStartsAt)
 
             val sessions = if (conferenceStartedHoursAgo == 0) {
                 listOf(targetSession)
             } else {
                 val firstSessionStartsAt = targetSessionStartsAt.minusHours(conferenceStartedHoursAgo.toLong())
-                val firstSession = createBaseSession(sessionId = "first", moment = firstSessionStartsAt)
+                val firstSession = createBaseSession(guid = "11111111-1111-1111-1111-111111111111", moment = firstSessionStartsAt)
                 listOf(firstSession, targetSession)
             }
 
@@ -72,8 +72,8 @@ class ScrollAmountCalculatorTimeZoneOffsetTest {
         }
     }
 
-    private fun createBaseSession(sessionId: String, moment: Moment) = Session(
-        sessionId = sessionId,
+    private fun createBaseSession(guid: String, moment: Moment) = Session(
+        guid = guid,
         dayIndex = 0,
         dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString(),
         dateUTC = moment.toMilliseconds(),

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/TimeTextViewParameterTest.kt
@@ -142,7 +142,7 @@ class TimeTextViewParameterTest {
     }
 
     private fun createSession(moment: Moment, duration: Int = 60) = Session(
-        sessionId = "s1",
+        guid = "11111111-1111-1111-1111-111111111111",
         dayIndex = 0,
         dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString(),
         dateUTC = moment.toMilliseconds(),

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilterTest.kt
@@ -21,7 +21,7 @@ class SearchQueryFilterTest {
     }
 
     @Test
-    fun `filterAll returns list with session when query at least partially matches sessionId`() {
+    fun `filterAll returns list with session when query at least partially matches guid`() {
         val result = filter.filterAll(listOf(Session("1056")), "56")
         assertThat(result).isEqualTo(listOf(Session("1056")))
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -31,7 +31,7 @@ class SearchResultParameterFactoryTest {
         val factory = createFactory()
         val sessions = listOf(
             Session(
-                sessionId = "123",
+                guid  = "11111111-1111-1111-1111-111111111123",
                 title = "Session 123",
                 speakers = listOf("Jane Doe", "John Doe"),
                 dateUTC = 1683981000000,
@@ -55,7 +55,7 @@ class SearchResultParameterFactoryTest {
         val factory = createFactory()
         val sessions = listOf(
             Session(
-                sessionId = "123",
+                guid  = "11111111-1111-1111-1111-111111111123",
                 title = "",
                 speakers = emptyList(),
                 dateUTC = 1683981000000,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -76,7 +76,7 @@ class ScheduleChangesTest {
                 scenarioDescription = "Old and new sessions are the same",
                 oldSessions = listOf(
                     Session(
-                        sessionId = "",
+                        guid = "",
                         title = "title",
                         subtitle = "subtitle",
                         speakers = "speakers",
@@ -90,7 +90,7 @@ class ScheduleChangesTest {
                 ),
                 newSessions = listOf(
                     Session(
-                        sessionId = "",
+                        guid = "",
                         title = "title",
                         subtitle = "subtitle",
                         speakers = "speakers",
@@ -104,7 +104,7 @@ class ScheduleChangesTest {
                 ),
                 expectedSessions = listOf(
                     Session(
-                        sessionId = "",
+                        guid = "",
                         title = "title",
                         subtitle = "subtitle",
                         speakers = "speakers",
@@ -150,14 +150,14 @@ class ScheduleChangesTest {
             scenario1Of(
                 scenarioDescription = "Speakers differ in order",
                 oldSessions = listOf(
-                    Session(sessionId = "1", speakers = "speaker1, speaker2, speaker3")
+                    Session(guid = "11111111-1111-1111-1111-111111111111", speakers = "speaker1, speaker2, speaker3")
                 ),
                 newSessions = listOf(
-                    Session(sessionId = "1", speakers = "speaker3, speaker1, speaker2")
+                    Session(guid = "11111111-1111-1111-1111-111111111111", speakers = "speaker3, speaker1, speaker2")
                 ),
                 expectedSessions = listOf(
                     Session(
-                        sessionId = "1",
+                        guid = "11111111-1111-1111-1111-111111111111",
                         speakers = "speaker3, speaker1, speaker2",
                         changedSpeakers = true
                     )
@@ -229,11 +229,11 @@ class ScheduleChangesTest {
             ),
             scenario1Of(
                 scenarioDescription = "Old session is canceled, new session is added",
-                oldSessions = listOf(Session(sessionId = "s1")),
-                newSessions = listOf(Session(sessionId = "s2")),
+                oldSessions = listOf(Session(guid = "11111111-1111-1111-1111-111111111111")),
+                newSessions = listOf(Session(guid = "11111111-1111-1111-1111-111111111112")),
                 expectedSessions = listOf(
-                    Session(sessionId = "s2", changedIsNew = true),
-                    Session(sessionId = "s1", changedIsCanceled = true)
+                    Session(guid = "11111111-1111-1111-1111-111111111112", changedIsNew = true),
+                    Session(guid = "11111111-1111-1111-1111-111111111111", changedIsCanceled = true)
                 ),
                 expectedOldCanceledSessions = emptyList(),
                 expectedFoundNoteworthyChanges = true,
@@ -242,7 +242,7 @@ class ScheduleChangesTest {
                 scenarioDescription = "Multiple properties differ",
                 oldSessions = listOf(
                     Session(
-                        sessionId = "1",
+                        guid = "11111111-1111-1111-1111-111111111111",
                         title = "Old title",
                         subtitle = "Old subtitle",
                         speakers = "Old speakers",
@@ -267,7 +267,7 @@ class ScheduleChangesTest {
                 ),
                 newSessions = listOf(
                     Session(
-                        sessionId = "1",
+                        guid = "11111111-1111-1111-1111-111111111111",
                         title = "New title",
                         subtitle = "New subtitle",
                         speakers = "New speakers",
@@ -292,7 +292,7 @@ class ScheduleChangesTest {
                 ),
                 expectedSessions = listOf(
                     Session(
-                        sessionId = "1",
+                        guid = "11111111-1111-1111-1111-111111111111",
                         title = "New title",
                         subtitle = "New subtitle",
                         speakers = "New speakers",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -27,7 +27,7 @@ class SimpleSessionFormatTest {
     private val systemLocale = Locale.getDefault()
 
     private val session1 = Session(
-        sessionId = "S1",
+        guid = "11111111-1111-1111-1111-111111111111",
         title = "A talk which changes your life",
         roomName = "Yellow pavilion",
         dateText = "2019-12-27T11:00:00+01:00",
@@ -37,7 +37,7 @@ class SimpleSessionFormatTest {
     )
 
     private val session2 = Session(
-        sessionId = "S2",
+        guid = "11111111-1111-1111-1111-111111111112",
         title = "The most boring workshop ever",
         roomName = "Dark cellar",
         dateText = "2019-12-28T17:00:00+01:00",
@@ -47,7 +47,7 @@ class SimpleSessionFormatTest {
     )
 
     private val session3 = Session(
-        sessionId = "S3",
+        guid = "11111111-1111-1111-1111-111111111113",
         title = "Angel shifts planning",
         roomName = "Main hall",
         dateText = "2019-12-29T09:00:00+01:00",
@@ -58,7 +58,7 @@ class SimpleSessionFormatTest {
     )
 
     private val session4 = Session(
-        sessionId = "S4",
+        guid = "11111111-1111-1111-1111-111111111114",
         title = "Central european summer time",
         roomName = "Sunshine tent",
         dateText = "2019-09-01T16:00:00+02:00",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposerTest.kt
@@ -13,35 +13,35 @@ class FeedbackUrlComposerTest {
             "https://frab.cccv.de/en/35C3/public/events/%s/feedback/new"
 
         val HUB_PRETALX_SESSION = Session(
-            sessionId = "3723",
+            guid = "11111111-1111-1111-1111-111111113723",
             url = "https://fahrplan.events.ccc.de/congress/2023/hub/events/37c3_opening.html",
             slug = "37c3_opening",
             feedbackUrl = "https://talks.c3voc.de/2023/talk/7B2KMD/feedback/",
         )
 
         val HUB_SOS_SESSION = Session(
-            sessionId = "3724",
+            guid = "11111111-1111-1111-1111-111111113724",
             url = "https://fahrplan.events.ccc.de/congress/2023/hub/events/lockpicking_workshop.html",
             slug = "lockpicking_workshop",
             feedbackUrl = "",
         )
 
         val FRAB_SESSION = Session(
-            sessionId = "9985",
+            guid = "11111111-1111-1111-1111-111111119985",
             url = "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html",
             slug = "35c3-9985-opening_ceremony",
             feedbackUrl = null,
         )
 
         val PRETALX_SESSION = Session(
-            sessionId = "202",
+            guid = "11111111-1111-1111-1111-111111111202",
             url = "https://talks.mrmcd.net/2019/talk/9XL7SP/",
             slug = "2019-202-board-games-of-medieval-europe",
             feedbackUrl = null,
         )
 
         val WIKI_SESSION = Session(
-            sessionId = "1346",
+            guid = "11111111-1111-1111-1111-111111111346",
             track = WIKI_SESSION_TRACK_NAME,
             url = "https://events.ccc.de/congress/2019/wiki/index.php/Session:Mobile_Apps",
             feedbackUrl = null,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
@@ -118,7 +118,7 @@ class SessionPropertiesFormatterTest {
         track: String = "",
         language: String = "",
     ) = Session(
-        sessionId = "",
+        guid = "",
         speakers = speakers,
         track = track,
         language = language,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposerTest.kt
@@ -20,31 +20,31 @@ class SessionUrlComposerTest {
         const val NO_SERVER_BACKEND_TYPE = ""
 
         val PENTABARF_SESSION = Session(
-            sessionId = "7294",
+            guid = "11111111-1111-1111-1111-111111117294",
             url = NO_URL,
             slug = "keynotes_welcome",
         )
 
         val FRAB_SESSION = Session(
-            sessionId = "9985",
+            guid = "11111111-1111-1111-1111-111111119985",
             url = "https://fahrplan.events.ccc.de/congress/2018/Fahrplan/events/9985.html",
             slug = "35c3-9985-opening_ceremony",
         )
 
         val PRETALX_SESSION = Session(
-            sessionId = "32",
+            guid = "11111111-1111-1111-1111-111111111132",
             url = "https://fahrplan.chaos-west.de/35c3chaoswest/talk/KDYQEB",
             slug = "KDYQEB",
         )
 
         val ENGELSYSTEM_SHIFT_SESSION_WITHOUT_URL = Session(
-            sessionId = "7771",
+            guid = "11111111-1111-1111-1111-111111117771",
             roomName = AppRepository.ENGELSYSTEM_ROOM_NAME,
             url = NO_URL,
         )
 
         val ENGELSYSTEM_SHIFT_SESSION_WITH_URL = Session(
-            sessionId = "7772",
+            guid = "11111111-1111-1111-1111-111111117772",
             roomName = AppRepository.ENGELSYSTEM_ROOM_NAME,
             url = "https://helpful.to/the/angel",
         )
@@ -58,7 +58,7 @@ class SessionUrlComposerTest {
     }
 
     @Test
-    fun `getSessionUrl returns Pentabarf URL if sessionId property and Pentabarf backend are set`() {
+    fun `getSessionUrl returns Pentabarf URL if guid property and Pentabarf backend are set`() {
         assertThat(SessionUrlComposer(PENTABARF_SESSION_URL_TEMPLATE, ServerBackendType.PENTABARF.name)
                 .getSessionUrl(PENTABARF_SESSION)).isEqualTo("https://fosdem.org/2018/schedule/event/keynotes_welcome/")
     }

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
@@ -19,7 +19,7 @@ class AlarmExtensionsTest {
                 alarmTimeInMin = 20,
                 day = 4,
                 displayTime = 1509617700000L,
-                sessionId = "5237",
+                guid = "11111111-1111-1111-1111-111111115237",
                 time = 1509617700001L,
                 timeText = "02/11/2017 11:05",
                 title = "My title"
@@ -28,7 +28,7 @@ class AlarmExtensionsTest {
         assertThat(values.getAsInteger(ALARM_TIME_IN_MIN)).isEqualTo(20)
         assertThat(values.getAsInteger(DAY)).isEqualTo(4)
         assertThat(values.getAsLong(DISPLAY_TIME)).isEqualTo(1509617700000L)
-        assertThat(values.getAsString(SESSION_ID)).isEqualTo("5237")
+        assertThat(values.getAsString(GUID)).isEqualTo("5237")
         assertThat(values.getAsLong(TIME)).isEqualTo(1509617700001L)
         assertThat(values.getAsString(TIME_TEXT)).isEqualTo("02/11/2017 11:05")
         assertThat(values.getAsString(SESSION_TITLE)).isEqualTo("My title")

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
@@ -2,7 +2,7 @@ package info.metadude.android.eventfahrplan.database.extensions
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.HIGHLIGHT
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.models.Highlight
 import org.junit.jupiter.api.Test
 
@@ -11,11 +11,11 @@ class HighlightExtensionsTest {
     @Test
     fun toContentValues() {
         val highlight = Highlight(
-                sessionId = 2342,
+                guid = "11111111-1111-1111-1111-111111112342",
                 isHighlight = true
         )
         val values = highlight.toContentValues()
-        assertThat(values.getAsInteger(SESSION_ID)).isEqualTo(2342)
+        assertThat(values.getAsInteger(GUID)).isEqualTo(2342)
         assertThat(values.getAsBoolean(HIGHLIGHT)).isEqualTo(true)
     }
 

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
@@ -20,6 +20,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -28,7 +29,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_IDENTIFIER
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_NAME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SLUG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SPEAKERS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.START
@@ -45,7 +46,7 @@ class SessionExtensionsTest {
     @Test
     fun toContentValues() {
         val session = Session(
-                sessionId = "7331",
+                guid = "11111111-1111-1111-1111-111111117331",
                 abstractt = "Lorem ipsum",
                 dayIndex = 3,
                 dateText = "2015-08-13",
@@ -86,7 +87,8 @@ class SessionExtensionsTest {
                 changedTrack = true
         )
         val values = session.toContentValues()
-        assertThat(values.getAsInteger(SESSION_ID)).isEqualTo(7331)
+        assertThat(values.getAsInteger(GUID)).isEqualTo(7331)
+        assertThat(values.getAsString(GUID)).isEqualTo("11111111-1111-1111-1111-111111111111")
         assertThat(values.getAsString(ABSTRACT)).isEqualTo("Lorem ipsum")
         assertThat(values.getAsInteger(DAY)).isEqualTo(3)
         assertThat(values.getAsString(DATE_TEXT)).isEqualTo("2015-08-13")

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -39,9 +39,9 @@ public interface FahrplanContract {
             /* 1 */ String SESSION_TITLE = "title";
             /* 2 */ String ALARM_TIME_IN_MIN = "alarm_time_in_min";
             /* 3 */ String TIME = "time";
-            /* 4 */ String TIME_TEXT = "timeText";
-            /* 5 */ String SESSION_ID = "eventid"; // Keep column name to avoid database migration.
-            /* 6 */ String DISPLAY_TIME = "displayTime";
+            /* 4 */ String TIME_TEXT = "time_text";
+            /* 5 */ String GUID = "guid";
+            /* 6 */ String DISPLAY_TIME = "display_time";
             /* 7 */ String DAY = "day";
         }
 
@@ -55,11 +55,11 @@ public interface FahrplanContract {
 
     interface HighlightsTable {
 
-        String NAME = "highlight";
+        String NAME = "highlights";
 
         interface Columns {
 
-            /* 0 */ String SESSION_ID = "eventid"; // Keep column name to avoid database migration.
+            /* 0 */ String GUID = "guid";
             /* 1 */ String HIGHLIGHT = "highlight";
             /* 2 */ String ID = "_id";
         }
@@ -78,7 +78,7 @@ public interface FahrplanContract {
 
         interface Columns extends BaseColumns {
 
-            /* 00 */ String SESSION_ID = "session_id";
+            /* 00 */ String GUID = "guid";
 
         }
 
@@ -86,11 +86,10 @@ public interface FahrplanContract {
 
     interface SessionsTable {
 
-        String NAME = "lectures"; // Keep table name to avoid database migration.
+        String NAME = "sessions";
 
         interface Columns extends BaseColumns {
 
-            /* 00 */ String SESSION_ID = "event_id"; // Keep column name to avoid database migration.
             /* 01 */ String TITLE = "title";
             /* 02 */ String SUBTITLE = "subtitle";
             /* 03 */ String DAY = "day";
@@ -127,6 +126,7 @@ public interface FahrplanContract {
             /* 34 */ String TIME_ZONE_OFFSET = "time_zone_offset";
             /* 35 */ String ROOM_IDENTIFIER = "room_identifier";
             /* 36 */ String FEEDBACK_URL = "feedback_url";
+            /* 35 */ String GUID = "guid";
         }
 
         interface Defaults {

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
@@ -4,7 +4,7 @@ import androidx.core.content.contentValuesOf
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
@@ -14,7 +14,7 @@ fun Alarm.toContentValues() = contentValuesOf(
         ALARM_TIME_IN_MIN to alarmTimeInMin,
         DAY to day,
         DISPLAY_TIME to displayTime,
-        SESSION_ID to sessionId,
+        GUID to guid,
         SESSION_TITLE to title,
         TIME to time,
         TIME_TEXT to timeText

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensions.kt
@@ -1,13 +1,14 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
 import androidx.core.content.contentValuesOf
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.HIGHLIGHT
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Values.HIGHLIGHT_STATE_OFF
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Values.HIGHLIGHT_STATE_ON
 import info.metadude.android.eventfahrplan.database.models.Highlight
 
 fun Highlight.toContentValues() = contentValuesOf(
-        SESSION_ID to sessionId,
+        FahrplanContract.SessionsTable.Columns.GUID to guid,
         HIGHLIGHT to if (isHighlight) HIGHLIGHT_STATE_ON else HIGHLIGHT_STATE_OFF
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
@@ -22,6 +22,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -30,7 +31,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_IDENTIFIER
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_NAME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SLUG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SPEAKERS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.START
@@ -45,7 +46,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.models.Session
 
 fun Session.toContentValues() = contentValuesOf(
-        SESSION_ID to sessionId,
+        GUID to guid,
         ABSTRACT to abstractt,
         DAY to dayIndex,
         DATE_TEXT to dateText,
@@ -89,5 +90,5 @@ fun Session.toContentValues() = contentValuesOf(
  * Converts a session ID into [ContentValues].
  */
 fun String.toContentValues() = contentValuesOf(
-        SessionByNotificationIdTable.Columns.SESSION_ID to this
+        SessionByNotificationIdTable.Columns.GUID to this
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
@@ -9,7 +9,7 @@ data class Alarm(
         val alarmTimeInMin: Int = ALARM_TIME_IN_MIN_DEFAULT,
         val day: Int = -1,
         val displayTime: Long = -1, // will be stored as signed integer
-        val sessionId: String = "",
+        val guid: String = "",
         val time: Long = -1, // will be stored as signed integer
         val timeText: String = "",
         val title: String = ""

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
@@ -2,7 +2,7 @@ package info.metadude.android.eventfahrplan.database.models
 
 data class Highlight(
 
-        val sessionId: Int,
+        val guid: String,
         val isHighlight: Boolean
 
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Session.kt
@@ -5,7 +5,7 @@ package info.metadude.android.eventfahrplan.database.models
  */
 data class Session(
 
-        val sessionId: String,
+        val guid: String,
         val abstractt: String = "",
         val dayIndex: Int = 0,          // XML values start with 1
         val dateText: String = "",

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/AlarmsDatabaseRepository.kt
@@ -15,13 +15,13 @@ interface AlarmsDatabaseRepository {
             RealAlarmsDatabaseRepository(AlarmsDBOpenHelper(context), logging)
     }
 
-    fun update(values: ContentValues, sessionId: String): Long
+    fun update(values: ContentValues, guid: String): Long
     fun query(): List<Alarm>
-    fun query(sessionId: String): List<Alarm>
+    fun query(guid: String): List<Alarm>
     fun query(query: SQLiteDatabase.() -> Cursor): List<Alarm>
     fun deleteAll(): Int
     fun deleteForAlarmId(alarmId: Int): Int
-    fun deleteForSessionId(sessionId: String): Int
+    fun deleteForGuid(guid: String): Int
     fun delete(query: SQLiteDatabase.() -> Int): Int
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -12,10 +12,10 @@ interface HighlightsDatabaseRepository {
             RealHighlightsDatabaseRepository(HighlightDBOpenHelper(context))
     }
 
-    fun update(values: ContentValues, sessionId: String): Long
+    fun update(values: ContentValues, guid: String): Long
     fun query(): List<Highlight>
-    fun queryBySessionId(sessionId: Int): Highlight?
-    fun delete(sessionId: String): Int
+    fun queryByGuid(guid: String): Highlight?
+    fun delete(guid: String): Int
     fun deleteAll(): Int
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
@@ -5,10 +5,11 @@ import android.database.Cursor
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ID
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
 import info.metadude.android.eventfahrplan.database.extensions.delete
@@ -33,9 +34,9 @@ internal class RealAlarmsDatabaseRepository(
         const val LOG_TAG = "AlarmsDatabaseRepository"
     }
 
-    override fun update(values: ContentValues, sessionId: String) = with(sqLiteOpenHelper) {
+    override fun update(values: ContentValues, guid: String) = with(sqLiteOpenHelper) {
         writableDatabase.upsert({
-            delete(AlarmsTable.NAME, SESSION_ID, sessionId)
+            delete(AlarmsTable.NAME, GUID, guid)
         }, {
             insert(AlarmsTable.NAME, values)
         })
@@ -45,8 +46,8 @@ internal class RealAlarmsDatabaseRepository(
         read(AlarmsTable.NAME, orderBy = TIME)
     }
 
-    override fun query(sessionId: String): List<Alarm> = query {
-        read(AlarmsTable.NAME, selection = "$SESSION_ID=?", selectionArgs = arrayOf(sessionId))
+    override fun query(guid: String): List<Alarm> = query {
+        read(AlarmsTable.NAME, selection = "$GUID=?", selectionArgs = arrayOf(guid))
     }
 
     override fun query(query: SQLiteDatabase.() -> Cursor): List<Alarm> {
@@ -64,7 +65,7 @@ internal class RealAlarmsDatabaseRepository(
             Alarm(
                     id = cursor.getInt(ID),
                     day = cursor.getInt(DAY),
-                    sessionId = cursor.getString(SESSION_ID),
+                    guid = cursor.getString(GUID),
                     time = cursor.getLong(TIME),
                     title = cursor.getString(SESSION_TITLE)
             )
@@ -85,8 +86,8 @@ internal class RealAlarmsDatabaseRepository(
         delete(AlarmsTable.NAME, ID, "$alarmId")
     }
 
-    override fun deleteForSessionId(sessionId: String) = delete {
-        delete(AlarmsTable.NAME, SESSION_ID, sessionId)
+    override fun deleteForGuid(guid: String) = delete {
+        delete(AlarmsTable.NAME, GUID, guid)
     }
 
     override fun delete(query: SQLiteDatabase.() -> Int) =

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/SessionsDatabaseRepository.kt
@@ -14,15 +14,15 @@ interface SessionsDatabaseRepository {
             RealSessionsDatabaseRepository(SessionsDBOpenHelper(context), logging)
     }
 
-    fun insertSessionId(sessionIdContentValues: ContentValues): Int
-    fun deleteSessionIdByNotificationId(notificationId: Int): Int
+    fun insertGuid(guidContentValues: ContentValues): Int
+    fun deleteGuidByNotificationId(notificationId: Int): Int
 
-    fun updateSessions(
-        contentValuesBySessionId: List<Pair<String, ContentValues>>,
-        toBeDeletedSessionIds: List<String>
+    fun upsertSessions(
+        contentValuesByGuid: List<Pair<String, ContentValues>>,
+        toBeDeletedSessionGuids: List<String>
     )
 
-    fun querySessionBySessionId(sessionId: String): Session
+    fun querySessionByGuid(guid: String): Session
     fun querySessionsForDayIndexOrderedByDateUtc(dayIndex: Int): List<Session>
     fun querySessionsOrderedByDateUtc(): List<Session>
     fun querySessionsWithoutRoom(roomName: String): List<Session>

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
@@ -7,7 +7,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Al
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ID
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
@@ -24,7 +24,7 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
 ) {
 
     private companion object {
-        const val DATABASE_VERSION = 7
+        const val DATABASE_VERSION = 1
         const val DATABASE_NAME = "alarms"
 
         // language=sql
@@ -34,7 +34,7 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
                 "$ALARM_TIME_IN_MIN INTEGER DEFAULT $ALARM_TIME_IN_MIN_DEFAULT, " +
                 "$TIME INTEGER, " +
                 "$TIME_TEXT TEXT, " +
-                "$SESSION_ID INTEGER, " +
+                "$GUID INTEGER, " +
                 "$DISPLAY_TIME INTEGER, " +
                 "$DAY INTEGER" +
                 ");"
@@ -44,35 +44,8 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
         execSQL(ALARMS_TABLE_CREATE)
     }
 
-    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = with(db) {
-        if (oldVersion < 2 && newVersion >= 2) {
-            addIntegerColumn(tableName = NAME, columnName = ALARM_TIME_IN_MIN, default = ALARM_TIME_IN_MIN_DEFAULT)
-        }
-        if (oldVersion < 3) {
-            // Clear database from 34C3.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 4) {
-            // Clear database from 35C3 & Camp 2019.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 5) {
-            // Clear database from rC3 12/2020.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 6) {
-            // Clear database from rC3 NOWHERE 12/2021 & 36C3 2019.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 7) {
-            // Clear database from Camp 2023 & 37C3 2023.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+
     }
 
 }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/HighlightDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/HighlightDBOpenHelper.kt
@@ -5,7 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.HIGHLIGHT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.ID
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.HighlightsTable.NAME
 import info.metadude.android.eventfahrplan.database.extensions.dropTableIfExist
 
@@ -17,13 +17,13 @@ internal class HighlightDBOpenHelper(context: Context) : SQLiteOpenHelper(
 ) {
 
     private companion object {
-        const val DATABASE_VERSION = 6
-        const val DATABASE_NAME = "highlight"
+        const val DATABASE_VERSION = 1
+        const val DATABASE_NAME = "highlights"
 
         // language=sql
         const val HIGHLIGHT_TABLE_CREATE = "CREATE TABLE $NAME (" +
                 "$ID INTEGER PRIMARY KEY, " +
-                "$SESSION_ID INTEGER, " +
+                "$GUID INTEGER, " +
                 "$HIGHLIGHT INTEGER" +
                 ");"
     }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/MetaDBOpenHelper.kt
@@ -24,7 +24,7 @@ internal class MetaDBOpenHelper(context: Context) : SQLiteOpenHelper(
 ) {
 
     private companion object {
-        const val DATABASE_VERSION = 10
+        const val DATABASE_VERSION = 1
         const val DATABASE_NAME = "meta"
 
         // language=sql
@@ -44,43 +44,6 @@ internal class MetaDBOpenHelper(context: Context) : SQLiteOpenHelper(
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = with(db) {
-        if (oldVersion < 3 && newVersion >= 3) {
-            addTextColumn(ETAG, default = ETAG_DEFAULT)
-        }
-        if (oldVersion < 6 && newVersion >= 6) {
-            addTextColumn(TIME_ZONE_NAME, default = null)
-        }
-        if (oldVersion < 4) {
-            // Clear database from 34C3.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 5) {
-            // Clear database from 35C3 & Camp 2019.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 7) {
-            // Clear database from rC3 12/2020.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 8) {
-            // Clear database from rC3 NOWHERE 12/2021 & 36C3 2019.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 9) {
-            if (!columnExists(NAME, SCHEDULE_LAST_MODIFIED)) {
-                addTextColumn(SCHEDULE_LAST_MODIFIED, default = "")
-            }
-        }
-        if (oldVersion < 10) {
-            // Clear database from Camp 2023 & 37C3 2023.
-            dropTableIfExist(NAME)
-            onCreate(this)
-        }
-
     }
 }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
@@ -26,6 +26,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LANG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.LINKS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.REC_LICENSE
@@ -34,7 +35,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_IDENTIFIER
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.ROOM_NAME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SESSION_ID
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.GUID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SLUG
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.SPEAKERS
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.START
@@ -109,12 +110,12 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
 ) {
 
     private companion object {
-        const val DATABASE_VERSION = 17
-        const val DATABASE_NAME = "lectures" // Keep table name to avoid database migration.
+        const val DATABASE_VERSION = 1
+        const val DATABASE_NAME = "sessions"
 
         // language=sql
         const val SESSIONS_TABLE_CREATE = "CREATE TABLE ${SessionsTable.NAME} (" +
-                "$SESSION_ID TEXT, " +
+                "$GUID TEXT NOT NULL UNIQUE, " +
                 "$TITLE TEXT, " +
                 "$SUBTITLE TEXT, " +
                 "$DAY INTEGER, " +
@@ -160,7 +161,7 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
         // language=sql
         const val SESSION_BY_NOTIFICATION_ID_TABLE_CREATE =
             "CREATE TABLE IF NOT EXISTS ${SessionByNotificationIdTable.NAME} (" +
-                    "$_ID INTEGER PRIMARY KEY AUTOINCREMENT, ${SessionByNotificationIdTable.Columns.SESSION_ID} TEXT)"
+                    "$_ID INTEGER PRIMARY KEY AUTOINCREMENT, ${SessionByNotificationIdTable.Columns.GUID} TEXT)"
 
         // language=sql
         const val SCHEDULE_STATISTIC_VIEW_CREATE =
@@ -225,85 +226,6 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = with(db) {
-        if (oldVersion < 2 && newVersion >= 2) {
-            addIntegerColumn(DATE_UTC, default = DATE_UTC_DEFAULT)
-        }
-        if (oldVersion < 3 && newVersion >= 3) {
-            addIntegerColumn(ROOM_INDEX, default = ROOM_IDX_DEFAULT)
-        }
-        if (oldVersion < 4 && newVersion >= 4) {
-            addTextColumn(REC_LICENSE, default = "")
-            addIntegerColumn(REC_OPTOUT, default = REC_OPT_OUT_OFF)
-        }
-        if (oldVersion < 5 && newVersion >= 5) {
-            addIntegerColumn(CHANGED_TITLE, default = 0)
-            addIntegerColumn(CHANGED_SUBTITLE, default = 0)
-            addIntegerColumn(CHANGED_ROOM_NAME, default = 0)
-            addIntegerColumn(CHANGED_DAY_INDEX, default = 0)
-            addIntegerColumn(CHANGED_SPEAKERS, default = 0)
-            addIntegerColumn(CHANGED_RECORDING_OPTOUT, default = 0)
-            addIntegerColumn(CHANGED_LANGUAGE, default = 0)
-            addIntegerColumn(CHANGED_TRACK, default = 0)
-            addIntegerColumn(CHANGED_IS_NEW, default = 0)
-            addIntegerColumn(CHANGED_START_TIME, default = 0)
-            addIntegerColumn(CHANGED_DURATION, default = 0)
-            addIntegerColumn(CHANGED_IS_CANCELED, default = 0)
-        }
-        if (oldVersion < 6 && newVersion >= 6) {
-            addTextColumn(SLUG, default = "")
-        }
-        if (oldVersion < 7 && newVersion >= 7) {
-            addTextColumn(URL, default = "")
-        }
-        if (oldVersion < 8) {
-            // Clear database from 34C3.
-            dropTableIfExist(SessionsTable.NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 9) {
-            // Clear database from 35C3 & Camp 2019.
-            dropTableIfExist(SessionsTable.NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 10 && newVersion >= 10) {
-            execSQL(SESSION_BY_NOTIFICATION_ID_TABLE_CREATE)
-        }
-        if (oldVersion < 11 && newVersion >= 11) {
-            if (!columnExists(SessionsTable.NAME, TIME_ZONE_OFFSET)) {
-                addIntegerColumn(TIME_ZONE_OFFSET, default = null)
-            }
-        }
-        if (oldVersion < 12) {
-            // Clear database from rC3 12/2020.
-            dropTableIfExist(SessionsTable.NAME)
-            dropTableIfExist(SessionByNotificationIdTable.NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 13) {
-            // Clear database from rC3 NOWHERE 12/2021 & 36C3 2019.
-            dropTableIfExist(SessionsTable.NAME)
-            dropTableIfExist(SessionByNotificationIdTable.NAME)
-            onCreate(this)
-        }
-        if (oldVersion < 14) {
-            if (!columnExists(SessionsTable.NAME, ROOM_IDENTIFIER)) {
-                addTextColumn(ROOM_IDENTIFIER, default = "")
-            }
-        }
-        if (oldVersion < 15) {
-            if (!columnExists(SessionsTable.NAME, FEEDBACK_URL)) {
-                addTextColumn(FEEDBACK_URL, default = null)
-            }
-        }
-        if (oldVersion < 16) {
-            execSQL(SCHEDULE_STATISTIC_VIEW_CREATE)
-        }
-        if (oldVersion < 17) {
-            // Clear database from Camp 2023 & 37C3 2023.
-            dropTableIfExist(SessionsTable.NAME)
-            dropTableIfExist(SessionByNotificationIdTable.NAME)
-            onCreate(this)
-        }
     }
 
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/models/Session.kt
@@ -8,7 +8,8 @@ import info.metadude.android.eventfahrplan.network.serialization.FahrplanParser
  */
 data class Session(
 
-        var sessionId: String = "",
+        var guid: String = "",
+
         var abstractt: String = "",
         var dayIndex: Int = 0, // XML values start with 1
         var dateText: String = "",

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -190,9 +190,9 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                             roomGuid = parser.getAttributeValue(null, "guid");
                         }
                         if (name.equalsIgnoreCase("event")) {
-                            String id = parser.getAttributeValue(null, "id");
+                            String guid = parser.getAttributeValue(null, "guid");
                             Session session = new Session();
-                            session.setSessionId(id);
+                            session.setGuid(guid);
                             session.setDayIndex(day);
                             session.setRoomName(Objects.requireNonNullElse(roomName, ""));
                             session.setRoomGuid(Objects.requireNonNullElse(roomGuid, ""));

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidation.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidation.kt
@@ -51,8 +51,8 @@ internal class DateFieldValidation(
         val dateUtcInMilliseconds = session.dateUTC
         val sessionDate = Moment.ofEpochMilli(dateUtcInMilliseconds).toZonedDateTime(ZoneOffset.UTC)
         if (!dateRange.contains(sessionDate)) {
-            val sessionId = session.sessionId
-            val errorMessage = ("Field <date> '$sessionDate' of session '$sessionId' exceeds range: [ ${dateRange.startsAt} : ${dateRange.endsAt} ]")
+            val guid = session.guid
+            val errorMessage = ("Field <date> '$sessionDate' of session '$guid' exceeds range: [ ${dateRange.startsAt} : ${dateRange.endsAt} ]")
             val error = ValidationError(errorMessage)
             validationErrors.add(error)
         }

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/models/SessionTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/models/SessionTest.kt
@@ -8,7 +8,7 @@ class SessionTest {
     @Test
     fun `cancel marks a session as canceled and resets all change other flags`() {
         val session = Session(
-            sessionId = "0",
+            guid = "11111111-1111-1111-1111-111111111111",
             changedTitle = true,
             changedSubtitle = true,
             changedRoomName = true,
@@ -23,7 +23,7 @@ class SessionTest {
             changedIsCanceled = false,
         )
         val comparableCanceledSession = Session(
-            sessionId = "0",
+            guid = "11111111-1111-1111-1111-111111111111",
             changedTitle = false,
             changedSubtitle = false,
             changedRoomName = false,

--- a/network/src/test/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidationTest.kt
+++ b/network/src/test/java/info/metadude/android/eventfahrplan/network/validation/DateFieldValidationTest.kt
@@ -17,8 +17,8 @@ class DateFieldValidationTest {
 
         val sessions = listOf(
                 // date and dateUTC do not represent the same
-                Session(dateText = "2019-01-02", dateUTC = start.toMilliseconds(), sessionId = "1"),
-                Session(dateText = "2019-01-01", dateUTC = end.toMilliseconds(), sessionId = "2")
+                Session(dateText = "2019-01-02", dateUTC = start.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111111",),
+                Session(dateText = "2019-01-01", dateUTC = end.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111112",)
         )
 
         val isValid = validation.validate(sessions)
@@ -38,10 +38,10 @@ class DateFieldValidationTest {
         val sessions = listOf(
                 // date=jan 2 does not correspond to dateUTC field value
                 // since session 1 defines range start, this leads to a problem, if another session has valid data, but is before session 1.
-                Session(dateText = "2019-01-02", dateUTC = start.toMilliseconds(), sessionId = "1"),
+                Session(dateText = "2019-01-02", dateUTC = start.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111111"),
                 // range starts with session 1 => session 2 is outside of the range
-                Session(dateText = "2019-01-01", dateUTC = Moment.parseDate("2019-01-01").toMilliseconds(), sessionId = "2"),
-                Session(dateText = "2019-01-03", dateUTC = end.toMilliseconds(), sessionId = "3")
+                Session(dateText = "2019-01-01", dateUTC = Moment.parseDate("2019-01-01").toMilliseconds(), guid = "11111111-1111-1111-1111-111111111112"),
+                Session(dateText = "2019-01-03", dateUTC = end.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111113")
         )
 
         val isValid = validation.validate(sessions)
@@ -59,9 +59,9 @@ class DateFieldValidationTest {
         val end = Moment.parseDate("2019-01-03")
 
         val sessions = listOf(
-                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), sessionId = "1"),
-                Session(dateText = "2019-01-02", dateUTC = Moment.parseDate("2019-01-02").toMilliseconds(), sessionId = "2"),
-                Session(dateText = "2019-01-03", dateUTC = end.toMilliseconds(), sessionId = "3")
+                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111111",),
+                Session(dateText = "2019-01-02", dateUTC = Moment.parseDate("2019-01-02").toMilliseconds(), guid = "11111111-1111-1111-1111-111111111112",),
+                Session(dateText = "2019-01-03", dateUTC = end.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111113",)
         )
 
         val isValid = validation.validate(sessions)
@@ -92,8 +92,8 @@ class DateFieldValidationTest {
         val end = Moment.parseDate("2019-01-01")
 
         val sessions = listOf(
-                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), sessionId = "1"),
-                Session(dateText = "2019-01-01", dateUTC = end.toMilliseconds(), sessionId = "2")
+                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111111",),
+                Session(dateText = "2019-01-01", dateUTC = end.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111112",)
         )
 
         val isValid = validation.validate(sessions)
@@ -111,8 +111,8 @@ class DateFieldValidationTest {
         val end = Moment.parseDate("2019-01-02")
 
         val sessions = listOf(
-                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), sessionId = "1"),
-                Session(dateText = "2019-01-02", dateUTC = end.toMilliseconds(), sessionId = "2")
+                Session(dateText = "2019-01-01", dateUTC = start.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111111",),
+                Session(dateText = "2019-01-02", dateUTC = end.toMilliseconds(), guid = "11111111-1111-1111-1111-111111111112",)
         )
 
         val isValid = validation.validate(sessions)


### PR DESCRIPTION
This PR takes a step further than #350 and replaces all "session ID" references with "GUID" ones.

Of course the databases are not compatible with this change.