### PR TITLE
Create new activity task when launching navigation

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -240,7 +240,10 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
             showAlarmTimePicker()
         }
         viewModel.navigateToRoom.observe(viewLifecycleOwner) { uri ->
-            startActivity(Intent(Intent.ACTION_VIEW, uri))
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            startActivity(intent)
         }
         viewModel.closeDetails.observe(viewLifecycleOwner) {
             val activity = requireActivity()


### PR DESCRIPTION
Creates a new activity task when the "navigate" option is selected from the menu of a session.