### PR TITLE
Fix crash at reboot (OnBootReceiver).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
@@ -27,7 +27,12 @@ class OnBootReceiver : BroadcastReceiver() {
 
         logging.report(LOG_TAG, "onReceive (reboot)")
         val nowMoment = Moment.now().plusSeconds(15)
-        val appRepository = AppRepository
+        val appRepository = AppRepository.apply {
+            initialize(
+                context = context.applicationContext,
+                logging = logging,
+            )
+        }
         val alarmServices = AlarmServices.newInstance(context, appRepository)
         val alarms = appRepository.readAlarms()
         for (alarm in alarms) {


### PR DESCRIPTION
# Environment
- Android 15 emulator
- Not reproducible

# Stacktrace
``` java
java.lang.RuntimeException: Unable to start receiver nerd.tuxmobil.fahrplan.congress.system.OnBootReceiver:
kotlin.UninitializedPropertyAccessException: lateinit property alarmsDatabaseRepository has not been initialized
  at android.app.ActivityThread.handleReceiver(ActivityThread.java:4781)
  at android.app.ActivityThread.-$$Nest$mhandleReceiver(Unknown Source:0)
  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2436)
  at android.os.Handler.dispatchMessage(Handler.java:107)
  at android.os.Looper.loopOnce(Looper.java:232)
  at android.os.Looper.loop(Looper.java:317)
  at android.app.ActivityThread.main(ActivityThread.java:8705)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)

Caused by: kotlin.UninitializedPropertyAccessException: lateinit property alarmsDatabaseRepository has not been initialized
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.readAlarms(SourceFile:710)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.readAlarms$default(SourceFile:708)
  at nerd.tuxmobil.fahrplan.congress.system.OnBootReceiver.onReceive(SourceFile:32)
  at android.app.ActivityThread.handleReceiver(ActivityThread.java:4772)
  at android.app.ActivityThread.-$$Nest$mhandleReceiver(Unknown Source:0) 
  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2436) 
  at android.os.Handler.dispatchMessage(Handler.java:107) 
  at android.os.Looper.loopOnce(Looper.java:232) 
  at android.os.Looper.loop(Looper.java:317) 
  at android.app.ActivityThread.main(ActivityThread.java:8705) 
  at java.lang.reflect.Method.invoke(Native Method) 
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580) 
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886) 
```

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)