### PR TITLE
Random housekeeping (crash report, headline flickering, identical texts, schedule changes color contrast).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.kt
@@ -21,8 +21,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentResultListener
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
 
-import java.lang.NullPointerException
-
 class AlarmTimePickerFragment : DialogFragment() {
 
     companion object {
@@ -87,7 +85,7 @@ class AlarmTimePickerFragment : DialogFragment() {
     private fun passBackAlarmTimesIndex() {
         val alarmTimesIndex = spinner.selectedItemPosition
         val requestKey = requireArguments().getString(REQUEST_KEY_BUNDLE_KEY)
-            ?: throw NullPointerException("Request key must be passed via fragment arguments.")
+            ?: throw MissingRequestKeyException()
         val result = bundleOf(
             ALARM_TIMES_INDEX_BUNDLE_KEY to alarmTimesIndex
         )
@@ -95,3 +93,7 @@ class AlarmTimePickerFragment : DialogFragment() {
     }
 
 }
+
+private class MissingRequestKeyException : NullPointerException(
+    "Request key must be passed via fragment arguments."
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -86,22 +86,20 @@ abstract class SessionsAdapter protected constructor(
                     viewHolderSeparator.text = rowView.requireViewByIdCompat(R.id.session_list_separator_title_view)
                     rowView.tag = viewHolderSeparator
                 }
-                else -> {
-                    error("Unknown type: $type")
-                }
+                else -> throw UnknownViewTypeException(type)
             }
         } else {
             rowView = convertView
             when (type) {
                 TYPE_ITEM -> viewHolder = rowView.tag as ViewHolder
                 TYPE_SEPARATOR -> viewHolderSeparator = rowView.tag as ViewHolderSeparator
-                else -> error("Unknown type: $type")
+                else -> throw UnknownViewTypeException(type)
             }
         }
         when (type) {
             TYPE_ITEM -> setItemContent(position, viewHolder!!)
             TYPE_SEPARATOR -> setSeparatorContent(position, viewHolderSeparator!!)
-            else -> error("Unknown type: $type")
+            else -> throw UnknownViewTypeException(type)
         }
         return rowView
     }
@@ -193,3 +191,7 @@ abstract class SessionsAdapter protected constructor(
     }
 
 }
+
+private class UnknownViewTypeException(type: Int) : IllegalStateException(
+    "Unknown view type: $type."
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -211,12 +211,12 @@ fun SessionNetworkModel.sanitize(): SessionNetworkModel {
         tempTrack = type
     }
     return this.copy(
-        title = tempTitle,
-        subtitle = tempSubtitle,
-        abstractt = tempAbstract,
-        description = tempDescription,
-        track = tempTrack,
-        language = tempLanguage,
+        title = tempTitle.trim(),
+        subtitle = tempSubtitle.trim(),
+        abstractt = tempAbstract.trim(),
+        description = tempDescription.trim(),
+        track = tempTrack.trim(),
+        language = tempLanguage.trim(),
     )
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -188,6 +188,10 @@ fun SessionNetworkModel.sanitize(): SessionNetworkModel {
     if (tempAbstract == tempDescription) {
         tempAbstract = ""
     }
+    if (tempDescription.startsWith(tempAbstract)) {
+        tempDescription = tempDescription
+            .substring(tempAbstract.length)
+    }
     if (speakers == tempSubtitle) {
         tempSubtitle = ""
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -189,7 +189,7 @@ internal class SessionDetailsViewModel(
 
     fun unfavorSession() {
         loadSelectedSession { session ->
-            val unfavoredSession = session.copy (
+            val unfavoredSession = session.copy(
                 isHighlight = false // Required: Update property because updateHighlight refers to its value!
             )
             repository.updateHighlight(unfavoredSession)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/DateInfos.kt
@@ -2,8 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.models
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 
-import java.util.ArrayList
-
 class DateInfos : ArrayList<DateInfo>() {
 
     fun sameDay(timestamp: Moment, sessionListDay: Int): Boolean {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/ValidateableEditTextPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/ValidateableEditTextPreference.kt
@@ -90,7 +90,7 @@ class ValidateableEditTextPreference : StyleableEditTextPreference {
                 Url.value -> Url
                 EngelsystemUrl.value -> EngelsystemUrl
                 // Fail at instantiation time not until when users input their data.
-                else -> throw NotImplementedError("Unknown validation type: $type.")
+                else -> throw UnknownUrlTypeException(type)
             }
         }
     }
@@ -99,7 +99,15 @@ class ValidateableEditTextPreference : StyleableEditTextPreference {
         ValidationType.Url -> UrlValidator(url)
         ValidationType.EngelsystemUrl -> EngelsystemUrlValidator(url)
         // Fails once the user submits their input. Late, but still good to know.
-        else -> throw NotImplementedError("Unknown validation type: $this.")
+        else -> throw UnknownValidationTypeException(this)
     }
 
 }
+
+private class UnknownUrlTypeException(type: Int) : IllegalArgumentException(
+    "Unknown url type: $type."
+)
+
+private class UnknownValidationTypeException(type: ValidationType) : IllegalArgumentException(
+    "Unknown validation type: $type."
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -553,7 +553,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
     private fun onAlarmTimesIndexPicked(alarmTimesIndex: Int) {
         if (lastSelectedSession == null) {
             logging.e(LOG_TAG, "onAlarmTimesIndexPicked: session: null. alarmTimesIndex: $alarmTimesIndex")
-            throw NullPointerException("Session is null.")
+            throw MissingLastSelectedSessionException(alarmTimesIndex)
         } else {
             viewModel.addAlarm(lastSelectedSession!!, alarmTimesIndex)
             updateMenuItems()
@@ -684,3 +684,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
     }
 
 }
+
+private class MissingLastSelectedSessionException(alarmTimesIndex: Int) : NullPointerException(
+    "Last selected session is null for alarm times index = $alarmTimesIndex."
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -88,7 +88,7 @@ internal class SessionViewDrawer(
         @ColorInt val backgroundColor = try {
             ContextCompat.getColor(context, backgroundColorResId)
         } catch (e: NotFoundException) {
-            throw NotFoundException("Missing color for track \"$track\". Entries in track_resource_names.xml must be present in track_background_* colors.")
+            throw MissingTrackColorException(track)
         }
         val sessionDrawable = if (isFavored && isAlternativeHighlightingEnabled()) {
             SessionDrawable(
@@ -144,3 +144,8 @@ internal class SessionViewDrawer(
         }
     }
 }
+
+private class MissingTrackColorException(trackName: String) : NotFoundException(
+    """Missing color for track "$trackName". Entries in track_resource_names.xml
+        | must be present in track_background_* colors.""".trimMargin()
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -185,6 +185,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
      * if none can be found. Uses [findPreference].
      */
     private fun <T : Preference> requirePreference(key: CharSequence): T = findPreference(key)
-        ?: throw NullPointerException("Cannot find preference for '$key' key.")
+        ?: throw MissingPreferenceException("$key")
 
 }
+
+private class MissingPreferenceException(key: String) : NullPointerException(
+    """Cannot find preference for "$key" key."""
+)

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -57,7 +57,7 @@
     <color name="schedule_change_on_dark">#F57C00</color>
     <color name="schedule_change_on_light">#E65100</color>
     <color name="schedule_change_new_on_dark">#689F38</color>
-    <color name="schedule_change_new_on_light">#33691E</color>
+    <color name="schedule_change_new_on_light">#27a22d</color>
     <color name="schedule_change_canceled_on_dark">#D32F2F</color>
     <color name="schedule_change_canceled_on_light">#B71C1C</color>
 

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -158,6 +158,7 @@
     <style name="SessionDetailsSection.Header" parent="SessionDetailsSection">
         <item name="android:textStyle">bold</item>
         <item name="android:paddingBottom">@dimen/session_details_section_margin_bottom</item>
+        <item name="android:visibility">invisible</item>
     </style>
 
     <style name="SessionDetailsSection.Header.Long" parent="SessionDetailsSection.Header">

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -331,6 +331,36 @@ class SessionExtensionsTest {
     }
 
     @Test
+    fun `sanitize keeps the description property value if the abstractt property value does not match the start of the former`() {
+        val session = SessionNetworkModel(
+            sessionId = "",
+            abstractt = "Lorem ipsum",
+            description = "Dolor sit amet. Lorem ipsum.",
+        ).sanitize()
+        val expected = SessionNetworkModel(
+            sessionId = "",
+            abstractt = "Lorem ipsum",
+            description = "Dolor sit amet. Lorem ipsum.",
+        )
+        assertThat(session).isEqualTo(expected)
+    }
+
+    @Test
+    fun `sanitize trims the start of the description property value if the abstractt property value does match the start of the former`() {
+        val session = SessionNetworkModel(
+            sessionId = "",
+            abstractt = "Lorem ipsum.",
+            description = "Lorem ipsum. Dolor sit amet.",
+        ).sanitize()
+        val expected = SessionNetworkModel(
+            sessionId = "",
+            abstractt = "Lorem ipsum.",
+            description = "Dolor sit amet.",
+        )
+        assertThat(session).isEqualTo(expected)
+    }
+
+    @Test
     fun `sanitize moves the abstractt property value to the description property value if empty`() {
         val session = SessionNetworkModel(
             sessionId = "",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -482,4 +482,29 @@ class SessionExtensionsTest {
         assertThat(session).isEqualTo(expected)
     }
 
+    @Test
+    fun `sanitize trims each property value`() {
+        val session = SessionNetworkModel(
+            sessionId = "",
+            title = " My title ",
+            subtitle = " My subtitle ",
+            abstractt = " Lorem ipsum ",
+            description = " Dolor sit amet ",
+            track = "",
+            type = "Workshop",
+            language = " EN ",
+        ).sanitize()
+        val expected = SessionNetworkModel(
+            sessionId = "",
+            title = "My title",
+            subtitle = "My subtitle",
+            abstractt = "Lorem ipsum",
+            description = "Dolor sit amet",
+            track = "Workshop",
+            type = "Workshop",
+            language = "en",
+        )
+        assertThat(session).isEqualTo(expected)
+    }
+
 }

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateParser.kt
@@ -1,5 +1,6 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
+import androidx.annotation.VisibleForTesting
 import org.threeten.bp.Instant
 import org.threeten.bp.ZoneOffset
 import org.threeten.bp.ZonedDateTime
@@ -31,9 +32,14 @@ object DateParser {
         val zonedDateTime = try {
             ZonedDateTime.parse(text, DateTimeFormatter.ISO_DATE_TIME)
         } catch (e: DateTimeParseException) {
-            throw IllegalArgumentException("Error parsing time zone offset from: '$text'.")
+            throw TimeZoneOffsetParsingException(text)
         }
         return zonedDateTime.offset.totalSeconds
     }
 
 }
+
+@VisibleForTesting
+internal class TimeZoneOffsetParsingException(text: String) : IllegalArgumentException(
+    """Error parsing time zone offset from: "$text"."""
+)

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateParserTest.kt
@@ -81,8 +81,8 @@ class DateParserTest {
         try {
             DateParser.parseTimeZoneOffset("1970-01-01T03:00:00")
             fail("Failure expected because malformed date string should not be parsed.")
-        } catch (e: IllegalArgumentException) {
-            assertThat(e.message).startsWith("Error parsing time zone offset from: '1970-01-01T03:00:00'.")
+        } catch (e: TimeZoneOffsetParsingException) {
+            assertThat(e.message).startsWith("""Error parsing time zone offset from: "1970-01-01T03:00:00".""")
         }
     }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
@@ -202,7 +202,7 @@ internal class RealSessionsDatabaseRepository(
             }.first()
         } catch (e: NoSuchElementException) {
             logging.report(LOG_TAG, "Sessions table does not contain a session with ID '$sessionId'. ${e.message}")
-            throw e
+            throw NoSuchSessionException(sessionId, e.message)
         }
     }
 
@@ -444,3 +444,7 @@ internal class RealSessionsDatabaseRepository(
         get() = this != 0
 
 }
+
+private class NoSuchSessionException(sessionId: String, exceptionMessage: String?) : IllegalArgumentException(
+    """Sessions table does not contain a session with ID "$sessionId". $exceptionMessage"""
+)

--- a/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/utils/UriParser.kt
+++ b/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/utils/UriParser.kt
@@ -49,16 +49,19 @@ class UriParser {
         val queryPart = query ?: throw ParsingException("Query is missing")
         val keyValuePairs = queryPart.split("=")
         if (keyValuePairs.size % 2 != 0) {
-            throw ParsingException("API key is missing: $query")
+            throw ApiKeyMissingException(query)
         }
         keyValuePairs.last()
     } catch (e: NoSuchElementException) {
-        throw ParsingException("API key is missing: $query")
+        throw ApiKeyMissingException(query)
     } catch (e: IllegalArgumentException) {
-        throw ParsingException("API key is missing: $query")
+        throw ApiKeyMissingException(query)
     }
 
-    internal class ParsingException(messageSuffix: String)
-        : URISyntaxException(messageSuffix, "Parsing failure")
-
 }
+
+private class ApiKeyMissingException(query: String?)
+    : ParsingException("API key is missing: $query")
+
+private open class ParsingException(messageSuffix: String)
+    : URISyntaxException(messageSuffix, "Parsing failure")

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/fetching/FetchFahrplan.kt
@@ -79,7 +79,7 @@ internal class FetchFahrplanTask(
         val url = args[0]!!
         val eTag = args[1]!!
         val lastModified = args[2]!!
-        host = Uri.parse(url).host ?: throw NullPointerException("Host is null for url = '$url'")
+        host = Uri.parse(url).host ?: throw MissingHostException(url)
         return fetch(url, eTag, lastModified)
     }
 
@@ -206,3 +206,7 @@ internal class FetchFahrplanTask(
     }
 
 }
+
+private class MissingHostException(url: String) : NullPointerException(
+    """Host is null for url = "$url"."""
+)

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DurationParser.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/temporal/DurationParser.kt
@@ -18,7 +18,7 @@ object DurationParser {
                 minutesString = parts[2]
             )
 
-            else -> error("Unknown duration format: $durationString")
+            else -> throw UnknownDurationFormatException(durationString)
         }
     }
 
@@ -44,3 +44,7 @@ object DurationParser {
             .toInt()
     }
 }
+
+private class UnknownDurationFormatException(durationString: String) : IllegalStateException(
+    """Unknown duration format: "$durationString"."""
+)


### PR DESCRIPTION
# Description
+ Apply automatic formatting.
+ Use implicit Kotlin import.
+ Increase informative value shown in crash report.
+ Prevent headline flickering when session content loads slowly.
+ Remove leading and trailing whitespace.
+ Protect users from reading identical texts twice.
+ Improve color contrast of new session items in schedule changes screen.

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)