### PR TITLE
Update project setup (room-states-repositories 1.0.1, kotlin 2.1.10, ksp 2.1.10-1.0.29, Jetpack Compose UI 2025.01.01).

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,7 @@
     <string name="about_libraries_names" translatable="false">
 		Kotlin, Google AndroidX, Jetpack Compose, BetterLinkMovementMethod,
 		Email Intent Builder, Engelsystem, Espresso, Markwon, Material Components,
-		Moshi, OkHttp, Retrofit, SnackEngage, ThreeTenBp, TraceDroid
+		Moshi, OkHttp, Retrofit, Room states, SnackEngage, ThreeTenBp, TraceDroid
 	</string>
     <string name="about_data_privacy_statement_german">Data privacy statement (German)</string>
     <string name="about_f_droid_listing">F-Droid listing</string>

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -33,8 +33,8 @@ object Plugins {
     private object Versions {
         const val android = "8.8.0"
         const val dexcount = "4.0.0"
-        const val kotlin = "2.1.0"
-        const val ksp = "2.1.0-1.0.29"
+        const val kotlin = "2.1.10"
+        const val ksp = "2.1.10-1.0.29"
         const val sonarQube = "5.1.0.4882" // Breaks CI build as of 6.x. See https://community.sonarsource.com/t/sonarqube-gradle-plugin-6-0-breaks-android-tasks/130863
         const val unMock = "0.9.0"
         const val versions = "0.52.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -53,7 +53,7 @@ object Plugins {
 object Libs {
 
     private object Versions {
-        const val activityCompose = "1.9.3"
+        const val activityCompose = "1.9.3" // compileSdk 35 is required as of 1.10.0
         const val androidTest = "1.6.0"
         const val annotation = "1.9.1"
         const val appCompat = "1.7.0"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -18,7 +18,7 @@ object Android {
 object Compose {
 
     private object Versions {
-        const val bom = "2024.12.01"
+        const val bom = "2025.01.01"
     }
 
     const val bom = "androidx.compose:compose-bom:${Versions.bom}"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -76,7 +76,7 @@ object Libs {
         const val preference = "1.2.1"
         const val retrofit = "2.11.0"
         const val robolectric = "4.3_r2-robolectric-0"
-        const val roomStates = "1.0.0"
+        const val roomStates = "1.0.1"
         const val snackengage = "0.30"
         const val threeTenBp = "1.7.0"
         const val tracedroid = "3.1"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -37,7 +37,7 @@ object Plugins {
         const val ksp = "2.1.0-1.0.29"
         const val sonarQube = "5.1.0.4882" // Breaks CI build as of 6.x. See https://community.sonarsource.com/t/sonarqube-gradle-plugin-6-0-breaks-android-tasks/130863
         const val unMock = "0.9.0"
-        const val versions = "0.51.0"
+        const val versions = "0.52.0"
     }
 
     const val android = "com.android.tools.build:gradle:${Versions.android}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionSha256Sum=296742a352f0b20ec14b143fb684965ad66086c7810b7b255dee216670716175
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Description
+ Add missing library name.
+ Use room-states-repositories v.1.0.1.
+ Use Gradle wrapper v.8.12.1.
+ Document compileSdk requirement for activity-compose.
+ Use gradle-versions-plugin v.0.52.0.
+ Use kotlin v.2.1.10 & ksp v.2.1.10-1.0.29.
+ Use Jetpack Compose UI 2025.01.01.

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)