### PR TITLE
Random housekeeping (ease maintenance, default colors, extend Compose theme, handle Windows line endings, alarm minutes text formatting).

### DIFF
--- a/app/src/ccc38c3/res/values/colors.xml
+++ b/app/src/ccc38c3/res/values/colors.xml
@@ -8,10 +8,8 @@
     <color name="windowBackground">#aa0f000a</color>
     <color name="window_background_inverted">#E7BFBDDB</color>
     <color name="multi_choice_background">#80181A</color>
+    <color name="outline_variant">#33ff5053</color>
     <color name="session_alarm_item_bell_icon_text">#fef2ff</color>
-
-    <!-- About -->
-    <color name="about_horizontal_line">#33ff5053</color>
 
     <!-- Alarm dialogs -->
     <color name="alert_dialog_button_text">#fef2ff</color>

--- a/app/src/ccc38c3/res/values/colors.xml
+++ b/app/src/ccc38c3/res/values/colors.xml
@@ -5,7 +5,6 @@
     <color name="colorPrimary">#ff5053</color>
     <color name="colorPrimaryDark">#FF5D5F</color>
     <color name="colorAccent">#6a5fdb</color>
-    <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#aa0f000a</color>
     <color name="window_background_inverted">#E7BFBDDB</color>
     <color name="multi_choice_background">#80181A</color>

--- a/app/src/cccamp2023/res/values/colors.xml
+++ b/app/src/cccamp2023/res/values/colors.xml
@@ -7,7 +7,6 @@
     <color name="colorPrimary">#FB48C4</color>
     <color name="colorPrimaryDark">#CC3BA1</color>
     <color name="colorAccent">#3FFF21</color>
-    <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#1a1a1a</color>
     <color name="text_link_on_light">#32CC1B</color>
     <color name="multi_choice_background">#ffc600</color>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
@@ -172,9 +173,9 @@ private fun AlarmIcon(alarmOffset: Int, alarmIconContentDescription: String) {
     ) {
         Text(
             "$alarmOffset",
-            modifier = Modifier.padding(end = 2.dp), // to center text
             color = colorResource(R.color.session_alarm_item_bell_icon_text),
             textAlign = TextAlign.Center,
+            fontWeight = Bold,
             fontSize = 12.sp,
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/AbstractListFragment.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.annotation.CallSuper
 import androidx.annotation.MainThread
 import androidx.fragment.app.ListFragment
-import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
 /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Themes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Themes.kt
@@ -20,10 +20,14 @@ fun EventFahrplanTheme(
 
 @Composable
 private fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
-    primary = colorResource(R.color.text_primary),
+    primary = colorResource(R.color.text_primary), // used by CircularProgressIndicator, OutlinedButton -> Text, SearchBarDefaults.InputField cursor
     background = colorResource(R.color.windowBackground),
+    onBackground = colorResource(R.color.text_primary), // used by LazyColumn -> Text header
     surface = colorResource(android.R.color.transparent), // used by ListItem background
+    onSurface = colorResource(R.color.text_primary), // used by ListItem -> headlineContent
+    onSurfaceVariant = colorResource(R.color.text_secondary), // used by SearchBarDefaults.InputField placeholder, ListItem -> overlineContent
     outline = colorResource(R.color.colorAccent), // used by SearchBarDefaults.InputField divider
+    outlineVariant = colorResource(R.color.outline_variant), // used by HorizontalDivider
     surfaceContainerHigh = colorResource(android.R.color.transparent), // used by SearchBarDefaults.InputField container background
 )
 
@@ -31,7 +35,11 @@ private fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
 private fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     primary = colorResource(R.color.text_primary_inverted),
     background = colorResource(R.color.window_background_inverted),
+    onBackground = colorResource(R.color.text_primary_inverted),
     surface = colorResource(android.R.color.transparent),
+    onSurface = colorResource(R.color.text_primary_inverted),
+    onSurfaceVariant = colorResource(R.color.text_secondary_inverted),
     outline = colorResource(R.color.colorAccent),
+    outlineVariant = colorResource(R.color.outline_variant),
     surfaceContainerHigh = colorResource(android.R.color.transparent),
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Themes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/Themes.kt
@@ -20,18 +20,18 @@ fun EventFahrplanTheme(
 
 @Composable
 private fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
+    primary = colorResource(R.color.text_primary),
     background = colorResource(R.color.windowBackground),
     surface = colorResource(android.R.color.transparent), // used by ListItem background
-    surfaceContainerHigh = colorResource(android.R.color.transparent), // used by SearchBarDefaults.InputField container background
     outline = colorResource(R.color.colorAccent), // used by SearchBarDefaults.InputField divider
-    primary = colorResource(R.color.text_primary),
+    surfaceContainerHigh = colorResource(android.R.color.transparent), // used by SearchBarDefaults.InputField container background
 )
 
 @Composable
 private fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
+    primary = colorResource(R.color.text_primary_inverted),
     background = colorResource(R.color.window_background_inverted),
     surface = colorResource(android.R.color.transparent),
-    surfaceContainerHigh = colorResource(android.R.color.transparent),
     outline = colorResource(R.color.colorAccent),
-    primary = colorResource(R.color.text_primary_inverted),
+    surfaceContainerHigh = colorResource(android.R.color.transparent),
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -126,7 +126,11 @@ internal class SessionDetailsViewModel(
     }
 
     private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
-        roomName = if (roomName == defaultEngelsystemRoomName) customEngelsystemRoomName else roomName
+        roomName = sessionPropertiesFormatter.getRoomName(
+            roomName = roomName,
+            defaultEngelsystemRoomName = defaultEngelsystemRoomName,
+            customEngelsystemRoomName = customEngelsystemRoomName,
+        )
     )
 
     private fun Session.toSelectedSessionParameter(): SelectedSessionParameter {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppExecutionContext.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppExecutionContext.kt
@@ -1,13 +1,13 @@
 package nerd.tuxmobil.fahrplan.congress.repositories
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
+import kotlin.coroutines.CoroutineContext
 
 object AppExecutionContext : ExecutionContext {
 
-    override val ui: CoroutineDispatcher = Main
-    override val network: CoroutineDispatcher = IO
-    override val database: CoroutineDispatcher = IO
+    override val ui: CoroutineContext = Main
+    override val network: CoroutineContext = IO
+    override val database: CoroutineContext = IO
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/ExecutionContext.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/ExecutionContext.kt
@@ -1,14 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress.repositories
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 
 interface ExecutionContext {
 
-    val ui: CoroutineDispatcher
-    val network: CoroutineDispatcher
-    val database: CoroutineDispatcher
+    val ui: CoroutineContext
+    val network: CoroutineContext
+    val database: CoroutineContext
 
     suspend fun <T> withUiContext(block: suspend CoroutineScope.() -> T) =
             withContext(context = ui, block = block)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
@@ -53,4 +53,13 @@ class SessionPropertiesFormatter {
                 .replace("englisch", "en")
         }
 
+    fun getRoomName(
+        roomName: String,
+        defaultEngelsystemRoomName: String,
+        customEngelsystemRoomName: String,
+    ) = when (roomName == defaultEngelsystemRoomName) {
+        true -> customEngelsystemRoomName
+        false -> roomName
+    }
+
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,7 +4,9 @@
     <color name="text_primary">@android:color/primary_text_dark</color>
     <color name="text_primary_inverted">@android:color/primary_text_light</color>
     <color name="text_secondary">@android:color/secondary_text_dark</color>
+    <color name="text_secondary_inverted">@android:color/secondary_text_light</color>
     <color name="text_tertiary">@android:color/tertiary_text_dark</color>
+    <color name="text_tertiary_inverted">@android:color/tertiary_text_light</color>
     <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#003339</color>
     <color name="window_background_inverted">#fff</color>
@@ -14,6 +16,7 @@
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
     <color name="text_link_pressed_background_on_light">#aafec700</color>
+    <color name="outline_variant">#88ffffff</color>
 
     <!-- Scrollbar -->
     <color name="scrollbar_background">@color/colorAccent</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="text_tertiary">@android:color/tertiary_text_dark</color>
     <color name="windowBackground">#003339</color>
     <color name="window_background_inverted">#fff</color>
+    <color name="multi_choice_background">@color/colorAccent</color>
     <color name="popupBackground">@color/colorPrimaryDark</color>
     <color name="foreground">#888</color>
     <color name="text_link_on_light">@color/colorAccent</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,6 +5,7 @@
     <color name="text_primary_inverted">@android:color/primary_text_light</color>
     <color name="text_secondary">@android:color/secondary_text_dark</color>
     <color name="text_tertiary">@android:color/tertiary_text_dark</color>
+    <color name="colorActionBar">@color/colorPrimary</color>
     <color name="windowBackground">#003339</color>
     <color name="window_background_inverted">#fff</color>
     <color name="multi_choice_background">@color/colorAccent</color>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/TestExecutionContext.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/TestExecutionContext.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers.Unconfined
 import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 
+// TODO Replace Unconfined with EmptyCoroutineContext? Ref: https://code.cash.app/dispatchers-unconfined
 object TestExecutionContext : ExecutionContext {
     override val ui: CoroutineDispatcher = Unconfined
     override val network: CoroutineDispatcher = Unconfined

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -29,7 +29,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns empty list when sessions is empty`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             ContentDescriptionFormatter(mock()),
             DateFormatterCallback,
         )
@@ -41,7 +41,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns UNCHANGED parameter when session is unchanged`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -103,7 +103,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns NEW parameter when session is new`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -165,7 +165,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns CANCELED parameter when session is canceled`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -227,7 +227,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns CHANGED parameter when session is changed`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -289,7 +289,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns CHANGED parameter with dashes when session is changed and empty`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -351,7 +351,7 @@ class SessionChangeParametersFactoryTest {
     fun `createSessionChangeParameters returns day separator when session span two days`() {
         val factory = SessionChangeParametersFactory(
             CompleteResourceResolver,
-            SessionPropertiesFormatter(),
+            createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
             DateFormatterCallback,
         )
@@ -491,6 +491,10 @@ private fun createChangedEmptySession() = Session(
     changedIsNew = false,
     changedIsCanceled = false,
 )
+
+private fun createSessionPropertiesFormatter(): SessionPropertiesFormatter {
+    return SessionPropertiesFormatter()
+}
 
 private fun createContentDescriptionFormatter() = mock<ContentDescriptionFormatter> {
     on { getDurationContentDescription(anyOrNull()) } doReturn ""

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -100,6 +100,7 @@ class SessionDetailsViewModelTest {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn """<a href="$SAMPLE_SESSION_URL">$SAMPLE_SESSION_URL</a>"""
             on { getFormattedSpeakers(any()) } doReturn "Jane Doe, John Doe"
+            on { getRoomName(any(), any(), any()) } doReturn "Main hall"
         }
         val fakeSessionUrlComposition = mock<SessionUrlComposition> {
             on { getSessionUrl(any()) } doReturn SAMPLE_SESSION_URL
@@ -176,6 +177,7 @@ class SessionDetailsViewModelTest {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn ""
             on { getFormattedSpeakers(any()) } doReturn ""
+            on { getRoomName(any(), any(), any()) } doReturn ""
         }
         val fakeSessionUrlComposition = mock<SessionUrlComposition> {
             on { getSessionUrl(any()) } doReturn ""
@@ -461,6 +463,7 @@ class SessionDetailsViewModelTest {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn ""
             on { getFormattedSpeakers(any()) } doReturn "not relevant"
+            on { getRoomName(any(), any(), any()) } doReturn "Zengelshifts"
         }
         val fakeSessionUrlComposition = mock<SessionUrlComposition> {
             on { getSessionUrl(any()) } doReturn ""

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
@@ -11,6 +11,9 @@ class SessionPropertiesFormatterTest {
 
     private companion object {
 
+        const val DEFAULT_ENGELSYSTEM_ROOM_NAME = "Engelshifts"
+        const val CUSTOM_ENGELSYSTEM_ROOM_NAME = "Trollshifts"
+
         @JvmStatic
         fun getLanguageTextData() = listOf(
             of("-formal", ""),
@@ -113,15 +116,53 @@ class SessionPropertiesFormatterTest {
         assertThat(formatter.getLanguageText(session)).isEqualTo(expected)
     }
 
+    @Test
+    fun `getRoomName returns empty string if room name is empty`() {
+        val session = createSession(roomName = "")
+        assertThat(
+            formatter.getRoomName(
+                roomName = session.roomName,
+                defaultEngelsystemRoomName = DEFAULT_ENGELSYSTEM_ROOM_NAME,
+                customEngelsystemRoomName = CUSTOM_ENGELSYSTEM_ROOM_NAME,
+            )
+        ).isEmpty()
+    }
+
+    @Test
+    fun `getRoomName returns original room name if room name does not match default Engelsystem room name`() {
+        val session = createSession(roomName = "Hall 1")
+        assertThat(
+            formatter.getRoomName(
+                roomName = session.roomName,
+                defaultEngelsystemRoomName = DEFAULT_ENGELSYSTEM_ROOM_NAME,
+                customEngelsystemRoomName = CUSTOM_ENGELSYSTEM_ROOM_NAME,
+            )
+        ).isEqualTo("Hall 1")
+    }
+
+    @Test
+    fun `getRoomName returns custom Engelsystem room name if room name matches default Engelsystem room name`() {
+        val session = createSession(roomName = DEFAULT_ENGELSYSTEM_ROOM_NAME)
+        assertThat(
+            formatter.getRoomName(
+                roomName = session.roomName,
+                defaultEngelsystemRoomName = DEFAULT_ENGELSYSTEM_ROOM_NAME,
+                customEngelsystemRoomName = CUSTOM_ENGELSYSTEM_ROOM_NAME,
+            )
+        ).isEqualTo(CUSTOM_ENGELSYSTEM_ROOM_NAME)
+    }
+
     private fun createSession(
         speakers: List<String> = emptyList(),
         track: String = "",
         language: String = "",
+        roomName: String = "",
     ) = Session(
         sessionId = "",
         speakers = speakers,
         track = track,
         language = language,
+        roomName = roomName,
     )
 
 }

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/XmlPullParsers.kt
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/XmlPullParsers.kt
@@ -6,4 +6,8 @@ import org.xmlpull.v1.XmlPullParser
 
 private const val ZERO_WIDTH_NO_BREAK_SPACE = '\uFEFF'
 
-fun XmlPullParser.getSanitizedText(): String = text?.trim()?.trim(ZERO_WIDTH_NO_BREAK_SPACE) ?: ""
+fun XmlPullParser.getSanitizedText(): String = text
+    ?.trim()
+    ?.trim(ZERO_WIDTH_NO_BREAK_SPACE)
+    ?.replace("\r\n", "\n")
+    ?: ""


### PR DESCRIPTION
# Description
+ Remove unused import.
+ Ease maintaining `SessionChangeParametersFactoryTest`.
+ Prefer `CoroutineContext` over `CoroutineDispatcher` in the public API.
+ Add default color for `multi_choice_background`.
+ Add default color for `colorActionBar`.
+ Ease browsing Material3 color scheme properties.
+ Wire more theme properties used by Material3 components within the app.
+ Reduce double empty lines to single empty line.
+ Encapsulate room name customization details within `SessionPropertiesFormatter`.
+ Make alarm minutes text on bell icon more readable.

# Screenshots of updated alarm minutes text formatting, before & after
![alarms-1before](https://github.com/user-attachments/assets/fc14aba6-1dd3-47d8-b528-8044eec673e3) ![alarms-1after](https://github.com/user-attachments/assets/9505bc38-2f97-4462-b843-e56102a644d2)

![alarms-2before](https://github.com/user-attachments/assets/845573e8-bdb3-47f8-b1c4-d381afabeb63) ![alarms-2after](https://github.com/user-attachments/assets/acbb97d1-f1f3-4daf-9e08-a347029bf4a3)

# Successfully tested on
with `ccc38c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)