### PR TITLE
Random housekeeping (Favorites padding, session details name, add interfaces, room state unit tests).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         <activity
                 android:name=".details.SessionDetailsActivity"
                 android:configChanges="keyboardHidden|orientation"
-                android:label="@string/fahrplan"
+                android:label="@string/session_details_screen_name"
                 android:uiOptions="splitActionBarWhenNarrow"
                 android:resizeableActivity="true"
                 android:parentActivityName="nerd.tuxmobil.fahrplan.congress.schedule.MainActivity">

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposer.kt
@@ -4,6 +4,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
@@ -16,7 +17,7 @@ import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 class CalendarDescriptionComposer(
 
     private val sessionOnlineText: String,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter = SessionPropertiesFormatter(),
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting = SessionPropertiesFormatter(),
     private val markdownConversion: MarkdownConversion = MarkdownConverter,
     private val sessionUrlComposition: SessionUrlComposition = SessionUrlComposer()
 
@@ -46,7 +47,7 @@ class CalendarDescriptionComposer(
     }
 
     private fun StringBuilder.appendSpeakers(session: Session) {
-        appendParagraphIfNotEmpty(sessionPropertiesFormatter.getFormattedSpeakers(session))
+        appendParagraphIfNotEmpty(sessionPropertiesFormatting.getFormattedSpeakers(session))
     }
 
     private fun StringBuilder.appendAbstract(session: Session) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.changes
 
 import android.app.Activity
 import android.content.Intent
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
@@ -11,6 +10,7 @@ import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListCl
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import androidx.core.graphics.drawable.toDrawable
 
 class ChangeListActivity :
     BaseActivity(),
@@ -39,7 +39,7 @@ class ChangeListActivity :
         val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
-        supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
+        supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())
     }
 
     override fun onSessionListClick(sessionId: String) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -7,12 +7,12 @@ import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
 class ChangeListViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
 ) : Factory {
 
@@ -23,7 +23,7 @@ class ChangeListViewModelFactory(
             executionContext = AppExecutionContext,
             sessionChangeParametersFactory = SessionChangeParametersFactory(
                 resourceResolving = resourceResolving,
-                sessionPropertiesFormatter = sessionPropertiesFormatter,
+                sessionPropertiesFormatting = sessionPropertiesFormatting,
                 contentDescriptionFormatting = contentDescriptionFormatting,
                 onDateFormatter = { useDeviceTimeZone -> DateFormatter.newInstance(useDeviceTimeZone) }
             )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -6,14 +6,14 @@ import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class ChangeListViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-    private val contentDescriptionFormatter: ContentDescriptionFormatter,
+    private val contentDescriptionFormatting: ContentDescriptionFormatting,
 ) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -24,7 +24,7 @@ class ChangeListViewModelFactory(
             sessionChangeParametersFactory = SessionChangeParametersFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatter = sessionPropertiesFormatter,
-                contentDescriptionFormatter = contentDescriptionFormatter,
+                contentDescriptionFormatting = contentDescriptionFormatting,
                 onDateFormatter = { useDeviceTimeZone -> DateFormatter.newInstance(useDeviceTimeZone) }
             )
         ) as T

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -13,13 +13,13 @@ import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Avai
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.None
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class SessionChangeParametersFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-    private val contentDescriptionFormatter: ContentDescriptionFormatter,
+    private val contentDescriptionFormatting: ContentDescriptionFormatting,
     private val onDateFormatter: (useDeviceTimeZone: Boolean) -> DateFormatter,
 ) {
 
@@ -71,7 +71,7 @@ class SessionChangeParametersFactory(
             ),
             subtitle = SessionChangeProperty(
                 value = if (session.changedSubtitle && session.subtitle.isEmpty()) dash else session.subtitle,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getSubtitleContentDescription(session.subtitle),
                 changeState = changeStateOf(session, session.changedSubtitle),
             ),
@@ -82,7 +82,7 @@ class SessionChangeParametersFactory(
             ),
             speakerNames = SessionChangeProperty(
                 value = if (session.changedSpeakers && session.speakers.isEmpty()) dash else speakerNames,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getSpeakersContentDescription(session.speakers.size, speakerNames),
                 changeState = changeStateOf(session, session.changedSpeakers),
             ),
@@ -93,19 +93,19 @@ class SessionChangeParametersFactory(
             ),
             startsAt = SessionChangeProperty(
                 value = startsAt,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getStartTimeContentDescription(startsAt),
                 changeState = changeStateOf(session, session.changedStartTime),
             ),
             duration = SessionChangeProperty(
                 value = duration,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getDurationContentDescription(session.duration),
                 changeState = changeStateOf(session, session.changedDuration),
             ),
             roomName = SessionChangeProperty(
                 value = session.roomName,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getRoomNameContentDescription(session.roomName),
                 changeState = changeStateOf(session, session.changedRoomName),
             ),
@@ -114,7 +114,7 @@ class SessionChangeParametersFactory(
                 contentDescription = if (session.changedLanguage && session.language.isEmpty()) {
                     resourceResolving.getString(R.string.session_list_item_language_removed_content_description)
                 } else {
-                    contentDescriptionFormatter.getLanguageContentDescription(languages)
+                    contentDescriptionFormatting.getLanguageContentDescription(languages)
                 },
                 changeState = changeStateOf(session, session.changedLanguage),
             ),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -14,11 +14,11 @@ import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unav
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.None
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
 class SessionChangeParametersFactory(
     private val resourceResolving: ResourceResolving,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
     private val onDateFormatter: (useDeviceTimeZone: Boolean) -> DateFormatter,
 ) {
@@ -50,7 +50,7 @@ class SessionChangeParametersFactory(
     private fun sessionChangeOf(session: Session, dayText: String, dash: String, useDeviceTimeZone: Boolean): SessionChange {
         val startsAt = onDateFormatter(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
         val duration = resourceResolving.getString(R.string.session_list_item_duration_text, session.duration)
-        val languages = sessionPropertiesFormatter.getLanguageText(session)
+        val languages = sessionPropertiesFormatting.getLanguageText(session)
         val videoState = when {
             session.changedRecordingOptOut -> when {
                 session.recordingOptOut -> Unavailable
@@ -59,7 +59,7 @@ class SessionChangeParametersFactory(
 
             else -> None
         }
-        val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+        val speakerNames = sessionPropertiesFormatting.getFormattedSpeakers(session)
         val title = if (session.changedTitle && session.title.isEmpty()) dash else session.title
 
         return SessionChange(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
@@ -12,18 +12,18 @@ object DateFormatterDelegate : FormattingDelegate {
 
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
-        alarmTime: Long,
+        dateUtc: Long,
         timeZoneOffset: ZoneOffset?,
     ) = DateFormatter
         .newInstance(useDeviceTimeZone)
-        .getFormattedDateTimeShort(alarmTime, timeZoneOffset)
+        .getFormattedDateTimeShort(dateUtc, timeZoneOffset)
 
     override fun getFormattedDateTimeLong(
         useDeviceTimeZone: Boolean,
         dateUtc: Long,
-        sessionTimeZoneOffset: ZoneOffset?,
+        timeZoneOffset: ZoneOffset?,
     ) = DateFormatter
         .newInstance(useDeviceTimeZone)
-        .getFormattedDateTimeLong(dateUtc, sessionTimeZoneOffset)
+        .getFormattedDateTimeLong(dateUtc, timeZoneOffset)
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
@@ -9,14 +9,14 @@ interface FormattingDelegate {
 
     fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
-        alarmTime: Long,
+        dateUtc: Long,
         timeZoneOffset: ZoneOffset?,
     ): String
 
     fun getFormattedDateTimeLong(
         useDeviceTimeZone: Boolean,
         dateUtc: Long,
-        sessionTimeZoneOffset: ZoneOffset?,
+        timeZoneOffset: ZoneOffset?,
     ): String
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
+import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
 import androidx.core.graphics.drawable.toDrawable
 
@@ -36,6 +37,7 @@ class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        supportActionBar!!.title = if (isLandscape()) getString(R.string.session_details_screen_name) else ""
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
         supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -2,13 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.details
 
 import android.app.Activity
 import android.content.Intent
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
+import androidx.core.graphics.drawable.toDrawable
 
 class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
 
@@ -38,7 +38,7 @@ class SessionDetailsActivity : BaseActivity(R.layout.detail_frame) {
         super.onCreate(savedInstanceState)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
-        supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
+        supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())
 
         val intent = this.intent
         if (intent == null) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -58,6 +58,7 @@ import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.SessionSharer
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.LinkMovementMethodCompat
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -121,7 +122,7 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
         )
     }
     private lateinit var model: SelectedSessionParameter
-    private lateinit var contentDescriptionFormatter: ContentDescriptionFormatter
+    private lateinit var contentDescriptionFormatting: ContentDescriptionFormatting
     private lateinit var markwon: Markwon
     private var sidePane = false
     private var hasArguments = false
@@ -147,7 +148,7 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
         appRepository = AppRepository
         alarmServices = AlarmServices.newInstance(context, appRepository)
         notificationHelper = NotificationHelper(context)
-        contentDescriptionFormatter = ContentDescriptionFormatter(ResourceResolver(context))
+        contentDescriptionFormatting = ContentDescriptionFormatter(ResourceResolver(context))
         markwon = Markwon.builder(context)
             .usePlugin(HEADINGS_PLUGIN)
             .usePlugin(createListItemsPlugin(context))
@@ -290,13 +291,13 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
         var textView: TextView = view.requireViewByIdCompat(R.id.session_detailbar_date_time_view)
         textView.text = if (model.hasDateUtc) model.formattedZonedDateTimeShort else ""
         if (model.hasDateUtc) {
-            textView.contentDescription = contentDescriptionFormatter
+            textView.contentDescription = contentDescriptionFormatting
                 .getStartTimeContentDescription(model.formattedZonedDateTimeLong)
         }
 
         textView = view.requireViewByIdCompat(R.id.session_detailbar_location_view)
         textView.text = model.roomName
-        textView.contentDescription = contentDescriptionFormatter
+        textView.contentDescription = contentDescriptionFormatting
             .getRoomNameContentDescription(model.roomName)
         textView = view.requireViewByIdCompat(R.id.session_detailbar_session_id_view)
         textView.text = if (model.sessionId.isEmpty()) "" else textView.context.getString(R.string.session_details_session_id, model.sessionId)
@@ -312,7 +313,7 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
             textView.isVisible = false
         } else {
             typeface = typefaceFactory.getTypeface(viewModel.subtitleFont)
-            textView.applyText(typeface, model.subtitle, contentDescriptionFormatter
+            textView.applyText(typeface, model.subtitle, contentDescriptionFormatting
                 .getSubtitleContentDescription(model.subtitle))
         }
 
@@ -322,7 +323,7 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
             textView.isVisible = false
         } else {
             typeface = typefaceFactory.getTypeface(viewModel.speakersFont)
-            val speakerNamesContentDescription = contentDescriptionFormatter
+            val speakerNamesContentDescription = contentDescriptionFormatting
                 .getSpeakersContentDescription(model.speakersCount, model.speakerNames)
             textView.applyText(typeface, model.speakerNames, speakerNamesContentDescription)
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -115,7 +115,6 @@ internal class SessionDetailsViewModel(
     val showAlarmTimePicker = sessionAlarmViewModelDelegate
         .showAlarmTimePicker
 
-    // TODO Cover by tests
     private val mutableRoomStateMessage = MutableStateFlow(roomStateFormatting.getText(null))
     val roomStateMessage = mutableRoomStateMessage.asStateFlow()
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -34,7 +34,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import nerd.tuxmobil.fahrplan.congress.wiki.containsWikiLink
 
@@ -46,7 +46,7 @@ internal class SessionDetailsViewModel(
     buildConfigProvision: BuildConfigProvision,
     alarmServices: AlarmServices,
     notificationHelper: NotificationHelper,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
     private val feedbackUrlComposition: FeedbackUrlComposition,
@@ -126,7 +126,7 @@ internal class SessionDetailsViewModel(
     }
 
     private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
-        roomName = sessionPropertiesFormatter.getRoomName(
+        roomName = sessionPropertiesFormatting.getRoomName(
             roomName = roomName,
             defaultEngelsystemRoomName = defaultEngelsystemRoomName,
             customEngelsystemRoomName = customEngelsystemRoomName,
@@ -139,10 +139,10 @@ internal class SessionDetailsViewModel(
         val formattedZonedDateTimeLong = formattingDelegate.getFormattedDateTimeLong(useDeviceTimeZone, dateUTC, timeZoneOffset)
         val formattedAbstract = markdownConversion.markdownLinksToHtmlLinks(abstractt)
         val formattedDescription = markdownConversion.markdownLinksToHtmlLinks(description)
-        val linksHtml = sessionPropertiesFormatter.getFormattedLinks(links)
+        val linksHtml = sessionPropertiesFormatting.getFormattedLinks(links)
         val formattedLinks = markdownConversion.markdownLinksToHtmlLinks(linksHtml)
         val sessionUrl = sessionUrlComposition.getSessionUrl(this)
-        val sessionLink = sessionPropertiesFormatter.getFormattedUrl(sessionUrl)
+        val sessionLink = sessionPropertiesFormatting.getFormattedUrl(sessionUrl)
         val isFeedbackUrlEmpty = feedbackUrlComposition.getFeedbackUrl(this).isEmpty()
         val supportsIndoorNavigation = indoorNavigation.isSupported(this.toRoom())
         val isEngelshift = roomName == defaultEngelsystemRoomName
@@ -156,7 +156,7 @@ internal class SessionDetailsViewModel(
             formattedZonedDateTimeLong = formattedZonedDateTimeLong,
             title = title,
             subtitle = subtitle,
-            speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(this),
+            speakerNames = sessionPropertiesFormatting.getFormattedSpeakers(this),
             speakersCount = speakers.size,
             abstract = abstractt,
             formattedAbstract = formattedAbstract,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -31,7 +31,7 @@ import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 import nerd.tuxmobil.fahrplan.congress.roomstates.RoomStateFormatting
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
-import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
+import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
@@ -49,7 +49,7 @@ internal class SessionDetailsViewModel(
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
     private val simpleSessionFormat: SimpleSessionFormat,
     private val jsonSessionFormat: JsonSessionFormat,
-    private val feedbackUrlComposer: FeedbackUrlComposer,
+    private val feedbackUrlComposition: FeedbackUrlComposition,
     private val sessionUrlComposition: SessionUrlComposition,
     private val indoorNavigation: IndoorNavigation,
     private val markdownConversion: MarkdownConversion,
@@ -143,7 +143,7 @@ internal class SessionDetailsViewModel(
         val formattedLinks = markdownConversion.markdownLinksToHtmlLinks(linksHtml)
         val sessionUrl = sessionUrlComposition.getSessionUrl(this)
         val sessionLink = sessionPropertiesFormatter.getFormattedUrl(sessionUrl)
-        val isFeedbackUrlEmpty = feedbackUrlComposer.getFeedbackUrl(this).isEmpty()
+        val isFeedbackUrlEmpty = feedbackUrlComposition.getFeedbackUrl(this).isEmpty()
         val supportsIndoorNavigation = indoorNavigation.isSupported(this.toRoom())
         val isEngelshift = roomName == defaultEngelsystemRoomName
         val supportsFeedback = !isFeedbackUrlEmpty && !isEngelshift
@@ -178,7 +178,7 @@ internal class SessionDetailsViewModel(
 
     fun openFeedback() {
         loadSelectedSession { session ->
-            val uri = feedbackUrlComposer.getFeedbackUrl(session).toUri()
+            val uri = feedbackUrlComposition.getFeedbackUrl(session).toUri()
             mutableOpenFeedBack.sendOneTimeEvent(uri)
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -17,7 +17,6 @@ import nerd.tuxmobil.fahrplan.congress.roomstates.RoomStateFormatter
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
-import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
@@ -43,7 +42,7 @@ internal class SessionDetailsViewModelFactory(
             buildConfigProvision = BuildConfigProvider(),
             alarmServices = alarmServices,
             notificationHelper = notificationHelper,
-            sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            sessionPropertiesFormatting = SessionPropertiesFormatter(),
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),
             feedbackUrlComposition = FeedbackUrlComposer(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelFactory.kt
@@ -17,6 +17,7 @@ import nerd.tuxmobil.fahrplan.congress.roomstates.RoomStateFormatter
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
+import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConverter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposer
@@ -45,7 +46,7 @@ internal class SessionDetailsViewModelFactory(
             sessionPropertiesFormatter = SessionPropertiesFormatter(),
             simpleSessionFormat = SimpleSessionFormat(),
             jsonSessionFormat = JsonSessionFormat(),
-            feedbackUrlComposer = FeedbackUrlComposer(),
+            feedbackUrlComposition = FeedbackUrlComposer(),
             sessionUrlComposition = SessionUrlComposer(),
             indoorNavigation = C3nav(BuildConfig.C3NAV_URL, RoomForC3NavConverter()),
             markdownConversion = MarkdownConverter,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.favorites
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
@@ -13,6 +12,7 @@ import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog.OnConfirmationDialogClicked
+import androidx.core.graphics.drawable.toDrawable
 
 class StarredListActivity :
     BaseActivity(),
@@ -37,7 +37,7 @@ class StarredListActivity :
         val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
-        supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
+        supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())
         if (savedInstanceState == null) {
             addFragment(R.id.container, StarredListFragment(), StarredListFragment.FRAGMENT_TAG)
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -11,7 +11,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class StarredListAdapter internal constructor(
@@ -21,7 +21,7 @@ class StarredListAdapter internal constructor(
         numDays: Int,
         useDeviceTimeZone: Boolean,
         private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-        private val contentDescriptionFormatter: ContentDescriptionFormatter,
+        private val contentDescriptionFormatting: ContentDescriptionFormatting,
 
 ) : SessionsAdapter(
 
@@ -55,30 +55,30 @@ class StarredListAdapter internal constructor(
 
             title.textOrHide = session.title
             subtitle.textOrHide = session.subtitle
-            subtitle.contentDescription = contentDescriptionFormatter
+            subtitle.contentDescription = contentDescriptionFormatting
                 .getSubtitleContentDescription(session.subtitle)
 
             val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
             speakers.textOrHide = speakerNames
-            speakers.contentDescription = contentDescriptionFormatter
+            speakers.contentDescription = contentDescriptionFormatting
                 .getSpeakersContentDescription(session.speakers.size, speakerNames)
             val languageText = sessionPropertiesFormatter.getLanguageText(session)
             lang.textOrHide = languageText
-            lang.contentDescription = contentDescriptionFormatter
+            lang.contentDescription = contentDescriptionFormatting
                 .getLanguageContentDescription(languageText)
 
             day.isVisible = false
             val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.dateUTC, session.timeZoneOffset)
             time.textOrHide = timeText
-            time.contentDescription = contentDescriptionFormatter
+            time.contentDescription = contentDescriptionFormatting
                 .getStartTimeContentDescription(timeText)
 
             room.textOrHide = session.roomName
-            room.contentDescription = contentDescriptionFormatter
+            room.contentDescription = contentDescriptionFormatting
                 .getRoomNameContentDescription(session.roomName)
             val durationText = duration.context.getString(R.string.session_list_item_duration_text, session.duration)
             duration.textOrHide = durationText
-            duration.contentDescription = contentDescriptionFormatter
+            duration.contentDescription = contentDescriptionFormatting
                 .getDurationContentDescription(session.duration)
 
             withoutVideoRecording.isVisible = session.recordingOptOut

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -12,7 +12,7 @@ import nerd.tuxmobil.fahrplan.congress.base.SessionsAdapter
 import nerd.tuxmobil.fahrplan.congress.extensions.textOrHide
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
 class StarredListAdapter internal constructor(
 
@@ -20,7 +20,7 @@ class StarredListAdapter internal constructor(
         list: List<Session>,
         numDays: Int,
         useDeviceTimeZone: Boolean,
-        private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+        private val sessionPropertiesFormatting: SessionPropertiesFormatting,
         private val contentDescriptionFormatting: ContentDescriptionFormatting,
 
 ) : SessionsAdapter(
@@ -58,11 +58,11 @@ class StarredListAdapter internal constructor(
             subtitle.contentDescription = contentDescriptionFormatting
                 .getSubtitleContentDescription(session.subtitle)
 
-            val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+            val speakerNames = sessionPropertiesFormatting.getFormattedSpeakers(session)
             speakers.textOrHide = speakerNames
             speakers.contentDescription = contentDescriptionFormatting
                 .getSpeakersContentDescription(session.speakers.size, speakerNames)
-            val languageText = sessionPropertiesFormatter.getLanguageText(session)
+            val languageText = sessionPropertiesFormatting.getLanguageText(session)
             lang.textOrHide = languageText
             lang.contentDescription = contentDescriptionFormatting
                 .getLanguageContentDescription(languageText)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -30,7 +30,6 @@ import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment
-import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -146,7 +146,7 @@ class StarredListFragment :
                 numDays = numDays,
                 useDeviceTimeZone = useDeviceTimeZone,
                 sessionPropertiesFormatter = SessionPropertiesFormatter(),
-                contentDescriptionFormatter = ContentDescriptionFormatter(ResourceResolver(activity)),
+                contentDescriptionFormatting = ContentDescriptionFormatter(ResourceResolver(activity)),
             )
             currentListView.adapter = adapter
             activity.invalidateOptionsMenu()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -145,7 +145,7 @@ class StarredListFragment :
                 list = sessions,
                 numDays = numDays,
                 useDeviceTimeZone = useDeviceTimeZone,
-                sessionPropertiesFormatter = SessionPropertiesFormatter(),
+                sessionPropertiesFormatting = SessionPropertiesFormatter(),
                 contentDescriptionFormatting = ContentDescriptionFormatter(ResourceResolver(activity)),
             )
             currentListView.adapter = adapter

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -187,7 +187,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         roomTitleTypeFace = TypefaceFactory.getNewInstance(context).getTypeface(Font.Roboto.Light)
         sessionViewDrawer = SessionViewDrawer(
             context = context,
-            sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            sessionPropertiesFormatting = SessionPropertiesFormatter(),
             contentDescriptionFormatting = ContentDescriptionFormatter(ResourceResolver((context))),
             getSessionPadding = { sessionPadding },
         )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -188,7 +188,7 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
         sessionViewDrawer = SessionViewDrawer(
             context = context,
             sessionPropertiesFormatter = SessionPropertiesFormatter(),
-            contentDescriptionFormatter = ContentDescriptionFormatter(ResourceResolver((context))),
+            contentDescriptionFormatting = ContentDescriptionFormatter(ResourceResolver((context))),
             getSessionPadding = { sessionPadding },
         )
         errorMessageFactory = ErrorMessage.Factory(context)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.Intent.FLAG_ACTIVITY_CLEAR_TOP
 import android.content.Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuInflater
@@ -61,6 +60,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsActivity
 import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
 import nerd.tuxmobil.fahrplan.congress.utils.ConfirmationDialog.OnConfirmationDialogClicked
 import nerd.tuxmobil.fahrplan.congress.utils.showWhenLockedCompat
+import androidx.core.graphics.drawable.toDrawable
 
 class MainActivity : BaseActivity(),
     MenuProvider,
@@ -138,7 +138,7 @@ class MainActivity : BaseActivity(),
         supportActionBar!!.setDisplayShowHomeEnabled(true)
         supportActionBar!!.setDefaultDisplayHomeAsUpEnabled(true)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
-        supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
+        supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())
 
         TraceDroidEmailSender.sendStackTraces(this)
         resetProgressDialog()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -64,9 +64,9 @@ internal class SessionViewDrawer(
         textView.contentDescription = contentDescriptionFormatter
             .getSpeakersContentDescription(session.speakers.size, speakerNames)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
-        textView.text = sessionPropertiesFormatter.getFormattedTrackLanguageText(session)
+        textView.text = sessionPropertiesFormatter.getFormattedTrackNameAndLanguageText(session)
         textView.contentDescription = contentDescriptionFormatter
-            .getFormattedTrackContentDescription(session.track, sessionPropertiesFormatter.getLanguageText(session))
+            .getTrackNameAndLanguageContentDescription(session.track, sessionPropertiesFormatter.getLanguageText(session))
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -15,7 +15,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.Font
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
@@ -24,7 +24,7 @@ internal class SessionViewDrawer(
 
         context: Context,
         private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-        private val contentDescriptionFormatter: ContentDescriptionFormatter,
+        private val contentDescriptionFormatting: ContentDescriptionFormatting,
         private val getSessionPadding: () -> Int,
         private val isAlternativeHighlightingEnabled: () -> Boolean = {
             // Must load the latest alternative highlighting value every time a session is redrawn.
@@ -52,26 +52,26 @@ internal class SessionViewDrawer(
         var textView = sessionView.requireViewByIdCompat<TextView>(R.id.session_title_view)
         textView.typeface = boldCondensed
         textView.text = session.title
-        textView.contentDescription = contentDescriptionFormatter
+        textView.contentDescription = contentDescriptionFormatting
             .getTitleContentDescription(session.title)
         textView = sessionView.requireViewByIdCompat(R.id.session_subtitle_view)
         textView.text = session.subtitle
-        textView.contentDescription = contentDescriptionFormatter
+        textView.contentDescription = contentDescriptionFormatting
             .getSubtitleContentDescription(session.subtitle)
         textView = sessionView.requireViewByIdCompat(R.id.session_speakers_view)
         val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
         textView.text = speakerNames
-        textView.contentDescription = contentDescriptionFormatter
+        textView.contentDescription = contentDescriptionFormatting
             .getSpeakersContentDescription(session.speakers.size, speakerNames)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
         textView.text = sessionPropertiesFormatter.getFormattedTrackNameAndLanguageText(session)
-        textView.contentDescription = contentDescriptionFormatter
+        textView.contentDescription = contentDescriptionFormatting
             .getTrackNameAndLanguageContentDescription(session.track, sessionPropertiesFormatter.getLanguageText(session))
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut
         }
-        ViewCompat.setStateDescription(sessionView, contentDescriptionFormatter
+        ViewCompat.setStateDescription(sessionView, contentDescriptionFormatting
             .getStateContentDescription(session, useDeviceTimeZone))
         setSessionBackground(session.isHighlight, session.track, sessionView)
         setSessionTextColor(session.isHighlight, sessionView)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionViewDrawer.kt
@@ -17,13 +17,13 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.Font
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.TypefaceFactory
 
 internal class SessionViewDrawer(
 
         context: Context,
-        private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+        private val sessionPropertiesFormatting: SessionPropertiesFormatting,
         private val contentDescriptionFormatting: ContentDescriptionFormatting,
         private val getSessionPadding: () -> Int,
         private val isAlternativeHighlightingEnabled: () -> Boolean = {
@@ -59,14 +59,14 @@ internal class SessionViewDrawer(
         textView.contentDescription = contentDescriptionFormatting
             .getSubtitleContentDescription(session.subtitle)
         textView = sessionView.requireViewByIdCompat(R.id.session_speakers_view)
-        val speakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+        val speakerNames = sessionPropertiesFormatting.getFormattedSpeakers(session)
         textView.text = speakerNames
         textView.contentDescription = contentDescriptionFormatting
             .getSpeakersContentDescription(session.speakers.size, speakerNames)
         textView = sessionView.requireViewByIdCompat(R.id.session_track_view)
-        textView.text = sessionPropertiesFormatter.getFormattedTrackNameAndLanguageText(session)
+        textView.text = sessionPropertiesFormatting.getFormattedTrackNameAndLanguageText(session)
         textView.contentDescription = contentDescriptionFormatting
-            .getTrackNameAndLanguageContentDescription(session.track, sessionPropertiesFormatter.getLanguageText(session))
+            .getTrackNameAndLanguageContentDescription(session.track, sessionPropertiesFormatting.getLanguageText(session))
         val recordingOptOut = sessionView.findViewById<View>(R.id.session_no_video_view)
         if (recordingOptOut != null) {
             recordingOptOut.isVisible = session.recordingOptOut

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
@@ -46,7 +46,7 @@ class SearchFragment : Fragment() {
         SearchViewModelFactory(
             appRepository = AppRepository,
             resourceResolving = resourceResolving,
-            sessionPropertiesFormatter = SessionPropertiesFormatter(),
+            sessionPropertiesFormatting = SessionPropertiesFormatter(),
             contentDescriptionFormatting = ContentDescriptionFormatter(resourceResolving),
         )
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFragment.kt
@@ -47,7 +47,7 @@ class SearchFragment : Fragment() {
             appRepository = AppRepository,
             resourceResolving = resourceResolving,
             sessionPropertiesFormatter = SessionPropertiesFormatter(),
-            contentDescriptionFormatter = ContentDescriptionFormatter(resourceResolving),
+            contentDescriptionFormatting = ContentDescriptionFormatter(resourceResolving),
         )
 
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
@@ -5,13 +5,13 @@ import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.SearchResult
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class SearchResultParameterFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-    private val contentDescriptionFormatter: ContentDescriptionFormatter,
+    private val contentDescriptionFormatting: ContentDescriptionFormatting,
     private val formattingDelegate: FormattingDelegate
 ) : FormattingDelegate by formattingDelegate {
 
@@ -34,17 +34,17 @@ class SearchResultParameterFactory(
             id = session.sessionId,
             title = SearchResultProperty(
                 value = title,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getTitleContentDescription(session.title),
             ),
             speakerNames = SearchResultProperty(
                 value = speakers,
-                contentDescription = contentDescriptionFormatter
+                contentDescription = contentDescriptionFormatting
                     .getSpeakersContentDescription(session.speakers.size, formattedSpeakerNames),
             ),
             startsAt = SearchResultProperty(
                 value = startsAtText,
-                contentDescription = contentDescriptionFormatter.getStartTimeContentDescription(startsAtText),
+                contentDescription = contentDescriptionFormatting.getStartTimeContentDescription(startsAtText),
             ),
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
@@ -6,11 +6,11 @@ import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.SearchResult
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
 class SearchResultParameterFactory(
     private val resourceResolving: ResourceResolving,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
     private val formattingDelegate: FormattingDelegate
 ) : FormattingDelegate by formattingDelegate {
@@ -22,7 +22,7 @@ class SearchResultParameterFactory(
     private fun createSearchResult(session: Session, useDeviceTimeZone: Boolean): SearchResult {
         val dash = resourceResolving.getString(R.string.dash)
         val title = session.title.ifEmpty { dash }
-        val formattedSpeakerNames = sessionPropertiesFormatter.getFormattedSpeakers(session)
+        val formattedSpeakerNames = sessionPropertiesFormatting.getFormattedSpeakers(session)
         val speakers = if (session.speakers.isEmpty()) dash else formattedSpeakerNames
         val startsAtText = formattingDelegate.getFormattedDateTimeLong(
             useDeviceTimeZone,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
@@ -5,14 +5,14 @@ import androidx.lifecycle.ViewModelProvider.Factory
 import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 
 class SearchViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatter: SessionPropertiesFormatter,
-    private val contentDescriptionFormatter: ContentDescriptionFormatter,
+    private val contentDescriptionFormatting: ContentDescriptionFormatting,
 ) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -24,7 +24,7 @@ class SearchViewModelFactory(
             searchResultParameterFactory = SearchResultParameterFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatter = sessionPropertiesFormatter,
-                contentDescriptionFormatter = contentDescriptionFormatter,
+                contentDescriptionFormatting = contentDescriptionFormatting,
                 formattingDelegate = DateFormatterDelegate,
             ),
         ) as T

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
@@ -6,12 +6,12 @@ import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
 class SearchViewModelFactory(
     private val appRepository: AppRepository,
     private val resourceResolving: ResourceResolving,
-    private val sessionPropertiesFormatter: SessionPropertiesFormatter,
+    private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
 ) : Factory {
 
@@ -23,7 +23,7 @@ class SearchViewModelFactory(
             searchHistoryManager = SearchHistoryManager(appRepository),
             searchResultParameterFactory = SearchResultParameterFactory(
                 resourceResolving = resourceResolving,
-                sessionPropertiesFormatter = sessionPropertiesFormatter,
+                sessionPropertiesFormatting = sessionPropertiesFormatting,
                 contentDescriptionFormatting = contentDescriptionFormatting,
                 formattingDelegate = DateFormatterDelegate,
             ),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsActivity.kt
@@ -2,13 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.settings
 
 import android.app.Activity
 import android.content.Intent
-import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.commit
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
+import androidx.core.graphics.drawable.toDrawable
 
 class SettingsActivity : BaseActivity(R.layout.settings) {
 
@@ -28,7 +28,7 @@ class SettingsActivity : BaseActivity(R.layout.settings) {
         val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)
         val actionBarColor = ContextCompat.getColor(this, R.color.colorActionBar)
-        supportActionBar!!.setBackgroundDrawable(ColorDrawable(actionBarColor))
+        supportActionBar!!.setBackgroundDrawable(actionBarColor.toDrawable())
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -5,26 +5,26 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
 
-class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
+class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) : ContentDescriptionFormatting {
 
-    fun getDurationContentDescription(duration: Int) =
+    override fun getDurationContentDescription(duration: Int) =
         resourceResolving.getString(R.string.session_list_item_duration_content_description, duration)
 
-    fun getTitleContentDescription(title: String) =
+    override fun getTitleContentDescription(title: String) =
         if (title.isEmpty()) "" else resourceResolving.getString(
             R.string.session_list_item_title_content_description, title
         )
 
-    fun getSubtitleContentDescription(subtitle: String): String =
+    override fun getSubtitleContentDescription(subtitle: String): String =
         if (subtitle.isEmpty()) "" else resourceResolving.getString(
             R.string.session_list_item_subtitle_content_description, subtitle
         )
 
-    fun getRoomNameContentDescription(roomName: String): String {
+    override fun getRoomNameContentDescription(roomName: String): String {
         return resourceResolving.getString(R.string.session_list_item_room_content_description, roomName)
     }
 
-    fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String): String =
+    override fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String): String =
         if (speakersCount == 0 || formattedSpeakerNames.isEmpty()) {
             resourceResolving.getString(R.string.session_list_item_zero_speakers_content_description)
         } else {
@@ -35,7 +35,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
             )
         }
 
-    fun getTrackNameAndLanguageContentDescription(trackName: String, languageCode: String) =
+    override fun getTrackNameAndLanguageContentDescription(trackName: String, languageCode: String) =
         buildString {
             append(
                 resourceResolving.getString(
@@ -49,7 +49,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
             }
         }
 
-    fun getLanguageContentDescription(languageCode: String): String {
+    override fun getLanguageContentDescription(languageCode: String): String {
         if (languageCode.isEmpty()) {
             return resourceResolving.getString(R.string.session_list_item_language_unknown_content_description)
         }
@@ -65,7 +65,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
         )
     }
 
-    fun getStartTimeContentDescription(startTimeText: String) =
+    override fun getStartTimeContentDescription(startTimeText: String) =
         resourceResolving.getString(R.string.session_list_item_start_time_content_description, startTimeText)
 
     private fun getHighlightContentDescription(isHighlighted: Boolean): String {
@@ -76,7 +76,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
         return resourceResolving.getString(stringResource)
     }
 
-    fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean): String {
+    override fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean): String {
         val roomNameContentDescription: String = getRoomNameContentDescription(session.roomName)
         val startsAtText = DateFormatter
             .newInstance(useDeviceTimeZone)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -35,7 +35,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) {
             )
         }
 
-    fun getFormattedTrackContentDescription(trackName: String, languageCode: String) =
+    fun getTrackNameAndLanguageContentDescription(trackName: String, languageCode: String) =
         buildString {
             append(
                 resourceResolving.getString(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatting.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatting.kt
@@ -1,0 +1,24 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+interface ContentDescriptionFormatting {
+
+    fun getDurationContentDescription(duration: Int): String
+
+    fun getTitleContentDescription(title: String): String
+
+    fun getSubtitleContentDescription(subtitle: String): String
+
+    fun getRoomNameContentDescription(roomName: String): String
+
+    fun getSpeakersContentDescription(speakersCount: Int, formattedSpeakerNames: String): String
+
+    fun getTrackNameAndLanguageContentDescription(trackName: String, languageCode: String): String
+
+    fun getLanguageContentDescription(languageCode: String): String
+
+    fun getStartTimeContentDescription(startTimeText: String): String
+
+    fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean): String
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposer.kt
@@ -9,7 +9,7 @@ class FeedbackUrlComposer(
 
         private val frabScheduleFeedbackUrlFormatString: String = BuildConfig.SCHEDULE_FEEDBACK_URL
 
-) {
+) : FeedbackUrlComposition {
 
     /**
      * Returns the feedback URL for the [session] if it is available or can be composed otherwise
@@ -22,7 +22,7 @@ class FeedbackUrlComposer(
      * For sessions extracted from the wiki of the Chaos Communication Congress aka. "self organized
      * sessions" an empty string is returned because there is no feedback system for them.
      */
-    fun getFeedbackUrl(session: Session): String {
+    override fun getFeedbackUrl(session: Session): String {
         if (session.originatesFromWiki) {
             return NO_URL
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposition.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/FeedbackUrlComposition.kt
@@ -1,0 +1,7 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+fun interface FeedbackUrlComposition {
+    fun getFeedbackUrl(session: Session): String
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
@@ -24,7 +24,7 @@ class SessionPropertiesFormatter {
     fun getFormattedSpeakers(session: Session) =
         session.speakers.joinToString(", ")
 
-    fun getFormattedTrackLanguageText(session: Session) =
+    fun getFormattedTrackNameAndLanguageText(session: Session) =
         buildString {
             append(session.track)
             if (session.track.isNotEmpty() && session.language.isNotEmpty()) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatter.kt
@@ -2,13 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.utils
 
 import nerd.tuxmobil.fahrplan.congress.models.Session
 
-class SessionPropertiesFormatter {
+class SessionPropertiesFormatter : SessionPropertiesFormatting {
 
     /**
      * Returns the given [links] separated by HTML `br` entities.
      * The original string is returned if no link separator is detected.
      */
-    fun getFormattedLinks(links: String): String {
+    override fun getFormattedLinks(links: String): String {
         // language=regex
         return links.replace("\\),".toRegex(), ")<br>")
     }
@@ -17,14 +17,14 @@ class SessionPropertiesFormatter {
      * Returns the given [url] formatted as an HTML weblink.
      * An empty string is returned if the [url] is empty itself.
      */
-    fun getFormattedUrl(url: String): String {
+    override fun getFormattedUrl(url: String): String {
         return if (url.isEmpty()) "" else "<a href=\"$url\">$url</a>"
     }
 
-    fun getFormattedSpeakers(session: Session) =
+    override fun getFormattedSpeakers(session: Session) =
         session.speakers.joinToString(", ")
 
-    fun getFormattedTrackNameAndLanguageText(session: Session) =
+    override fun getFormattedTrackNameAndLanguageText(session: Session) =
         buildString {
             append(session.track)
             if (session.track.isNotEmpty() && session.language.isNotEmpty()) {
@@ -37,7 +37,7 @@ class SessionPropertiesFormatter {
             }
         }
 
-    fun getLanguageText(session: Session) =
+    override fun getLanguageText(session: Session) =
         if (session.language.isEmpty()) {
             ""
         } else {
@@ -53,7 +53,7 @@ class SessionPropertiesFormatter {
                 .replace("englisch", "en")
         }
 
-    fun getRoomName(
+    override fun getRoomName(
         roomName: String,
         defaultEngelsystemRoomName: String,
         customEngelsystemRoomName: String,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatting.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatting.kt
@@ -1,0 +1,18 @@
+package nerd.tuxmobil.fahrplan.congress.utils
+
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+interface SessionPropertiesFormatting {
+
+    fun getFormattedLinks(links: String): String
+
+    fun getFormattedUrl(url: String): String
+
+    fun getFormattedSpeakers(session: Session): String
+
+    fun getFormattedTrackNameAndLanguageText(session: Session): String
+
+    fun getLanguageText(session: Session): String
+
+    fun getRoomName(roomName: String, defaultEngelsystemRoomName: String, customEngelsystemRoomName: String): String
+}

--- a/app/src/main/res/layout/session_list_separator_land_large.xml
+++ b/app/src/main/res/layout/session_list_separator_land_large.xml
@@ -4,6 +4,7 @@
               android:orientation="vertical"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
+              android:paddingHorizontal="16dp"
               android:paddingVertical="16dp">
 
     <TextView

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,6 +92,7 @@
         Der Fahrplan wurde aktualisiert.
     </string>
     <string name="settings">Einstellungen</string>
+    <string name="session_details_screen_name">Details</string>
     <string name="session_details_section_title_track">Themenfeld</string>
     <string name="session_details_section_title_session_online">Event online</string>
     <string name="session_details_section_title_links">Links</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
         The schedule has been updated.
     </string>
     <string name="settings">Settings</string>
+    <string name="session_details_screen_name">Details</string>
     <string name="session_details_session_id" translatable="false">
         ID: <xliff:g example="5001a" id="id">%s</xliff:g>
     </string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/calendar/CalendarDescriptionComposerTest.kt
@@ -113,7 +113,7 @@ class CalendarDescriptionComposerTest {
             """.trimIndent())
     }
 
-    private fun createComposer(): CalendarDescriptionComposer {
+    private fun createComposer(): CalendarDescriptionComposition {
         return CalendarDescriptionComposer("Session online", sessionUrlComposition = FakeSessionUrlComposer())
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -502,7 +502,7 @@ private fun createContentDescriptionFormatter() = mock<ContentDescriptionFormatt
     on { getSubtitleContentDescription(anyOrNull()) } doReturn ""
     on { getRoomNameContentDescription(anyOrNull()) } doReturn ""
     on { getSpeakersContentDescription(anyOrNull(), anyOrNull()) } doReturn ""
-    on { getFormattedTrackContentDescription(anyOrNull(), anyOrNull()) } doReturn ""
+    on { getTrackNameAndLanguageContentDescription(anyOrNull(), anyOrNull()) } doReturn ""
     on { getLanguageContentDescription(anyOrNull()) } doReturn ""
     on { getStartTimeContentDescription(anyOrNull()) } doReturn ""
     on { getStateContentDescription(anyOrNull(), anyOrNull()) } doReturn ""

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -14,6 +14,7 @@ import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.None
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.mockito.kotlin.anyOrNull
@@ -492,7 +493,7 @@ private fun createChangedEmptySession() = Session(
     changedIsCanceled = false,
 )
 
-private fun createSessionPropertiesFormatter(): SessionPropertiesFormatter {
+private fun createSessionPropertiesFormatter(): SessionPropertiesFormatting {
     return SessionPropertiesFormatter()
 }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -26,6 +26,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -46,7 +47,7 @@ class SessionDetailsViewModelTest {
     @Test
     fun `selectedSessionParameter does not emit SelectedSessionParameter`() = runTest {
         val repository = createRepository(selectedSessionFlow = emptyFlow())
-        val fakePropertiesFormatter = mock<SessionPropertiesFormatter> {
+        val fakePropertiesFormatting = mock<SessionPropertiesFormatting> {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn """<a href="$SAMPLE_SESSION_URL">$SAMPLE_SESSION_URL</a>"""
         }
@@ -65,7 +66,7 @@ class SessionDetailsViewModelTest {
         }
         val viewModel = createViewModel(
             repository = repository,
-            sessionPropertiesFormatter = fakePropertiesFormatter,
+            sessionPropertiesFormatting = fakePropertiesFormatting,
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
@@ -96,7 +97,7 @@ class SessionDetailsViewModelTest {
             isHighlight = true,
         )
         val repository = createRepository(selectedSessionFlow = flowOf(session))
-        val fakeSessionPropertiesFormatter = mock<SessionPropertiesFormatter> {
+        val fakeSessionPropertiesFormatting = mock<SessionPropertiesFormatting> {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn """<a href="$SAMPLE_SESSION_URL">$SAMPLE_SESSION_URL</a>"""
             on { getFormattedSpeakers(any()) } doReturn "Jane Doe, John Doe"
@@ -117,7 +118,7 @@ class SessionDetailsViewModelTest {
         }
         val viewModel = createViewModel(
             repository = repository,
-            sessionPropertiesFormatter = fakeSessionPropertiesFormatter,
+            sessionPropertiesFormatting = fakeSessionPropertiesFormatting,
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
@@ -173,7 +174,7 @@ class SessionDetailsViewModelTest {
             isHighlight = false,
         )
         val repository = createRepository(selectedSessionFlow = flowOf(session))
-        val fakeSessionPropertiesFormatter = mock<SessionPropertiesFormatter> {
+        val fakeSessionPropertiesFormatting = mock<SessionPropertiesFormatting> {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn ""
             on { getFormattedSpeakers(any()) } doReturn ""
@@ -194,7 +195,7 @@ class SessionDetailsViewModelTest {
         }
         val viewModel = createViewModel(
             repository = repository,
-            sessionPropertiesFormatter = fakeSessionPropertiesFormatter,
+            sessionPropertiesFormatting = fakeSessionPropertiesFormatting,
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
@@ -459,7 +460,7 @@ class SessionDetailsViewModelTest {
             roomIdentifier = "88888888-4444-4444-4444-121212121212",
         )
         val repository = createRepository(selectedSessionFlow = flowOf(session))
-        val fakeSessionPropertiesFormatter = mock<SessionPropertiesFormatter> {
+        val fakeSessionPropertiesFormatting = mock<SessionPropertiesFormatting> {
             on { getFormattedLinks(any()) } doReturn "not relevant"
             on { getFormattedUrl(any()) } doReturn ""
             on { getFormattedSpeakers(any()) } doReturn "not relevant"
@@ -480,7 +481,7 @@ class SessionDetailsViewModelTest {
         }
         val viewModel = createViewModel(
             repository = repository,
-            sessionPropertiesFormatter = fakeSessionPropertiesFormatter,
+            sessionPropertiesFormatting = fakeSessionPropertiesFormatting,
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
@@ -513,7 +514,7 @@ class SessionDetailsViewModelTest {
         repository: AppRepository,
         alarmServices: AlarmServices = mock(),
         notificationHelper: NotificationHelper = mock(),
-        sessionPropertiesFormatter: SessionPropertiesFormatter = SessionPropertiesFormatter(),
+        sessionPropertiesFormatting: SessionPropertiesFormatting = SessionPropertiesFormatter(),
         simpleSessionFormat: SimpleSessionFormat = mock(),
         jsonSessionFormat: JsonSessionFormat = mock(),
         feedbackUrlComposition: FeedbackUrlComposition = mock(),
@@ -531,7 +532,7 @@ class SessionDetailsViewModelTest {
         buildConfigProvision = mock(),
         alarmServices = alarmServices,
         notificationHelper = notificationHelper,
-        sessionPropertiesFormatter = sessionPropertiesFormatter,
+        sessionPropertiesFormatting = sessionPropertiesFormatting,
         simpleSessionFormat = simpleSessionFormat,
         jsonSessionFormat = jsonSessionFormat,
         feedbackUrlComposition = feedbackUrlComposition,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -23,7 +23,7 @@ import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
 import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
-import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposer
+import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 import nerd.tuxmobil.fahrplan.congress.utils.MarkdownConversion
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionUrlComposition
@@ -60,7 +60,7 @@ class SessionDetailsViewModelTest {
         val fakeMarkdownConversion = mock<MarkdownConversion> {
             on { markdownLinksToHtmlLinks(any()) } doReturn "Markdown"
         }
-        val fakeFeedbackUrlComposer = mock<FeedbackUrlComposer> {
+        val fakeFeedbackUrlComposition = mock<FeedbackUrlComposition> {
             on { getFeedbackUrl(any()) } doReturn SAMPLE_FEEDBACK_URL
         }
         val viewModel = createViewModel(
@@ -69,7 +69,7 @@ class SessionDetailsViewModelTest {
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
-            feedbackUrlComposer = fakeFeedbackUrlComposer,
+            feedbackUrlComposition = fakeFeedbackUrlComposition,
             indoorNavigation = SupportedIndoorNavigation,
         )
         viewModel.selectedSessionParameter.test {
@@ -112,7 +112,7 @@ class SessionDetailsViewModelTest {
         val fakeMarkdownConversion = mock<MarkdownConversion> {
             on { markdownLinksToHtmlLinks(any()) } doReturn "Markdown"
         }
-        val fakeFeedbackUrlComposer = mock<FeedbackUrlComposer> {
+        val fakeFeedbackUrlComposition = mock<FeedbackUrlComposition> {
             on { getFeedbackUrl(any()) } doReturn SAMPLE_FEEDBACK_URL
         }
         val viewModel = createViewModel(
@@ -121,7 +121,7 @@ class SessionDetailsViewModelTest {
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
-            feedbackUrlComposer = fakeFeedbackUrlComposer,
+            feedbackUrlComposition = fakeFeedbackUrlComposition,
             indoorNavigation = SupportedIndoorNavigation,
         )
         val selectedSessionParameter = SelectedSessionParameter(
@@ -189,7 +189,7 @@ class SessionDetailsViewModelTest {
         val fakeMarkdownConversion = mock<MarkdownConversion> {
             on { markdownLinksToHtmlLinks(any()) } doReturn ""
         }
-        val fakeFeedbackUrlComposer = mock<FeedbackUrlComposer> {
+        val fakeFeedbackUrlComposition = mock<FeedbackUrlComposition> {
             on { getFeedbackUrl(any()) } doReturn ""
         }
         val viewModel = createViewModel(
@@ -198,7 +198,7 @@ class SessionDetailsViewModelTest {
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
-            feedbackUrlComposer = fakeFeedbackUrlComposer,
+            feedbackUrlComposition = fakeFeedbackUrlComposition,
             indoorNavigation = UnsupportedIndoorNavigation,
         )
         val selectedSessionParameter = SelectedSessionParameter(
@@ -236,10 +236,10 @@ class SessionDetailsViewModelTest {
     @Test
     fun `openFeedback() posts to openFeedback`() = runTest {
         val repository = createRepository()
-        val fakeFeedbackUrlComposer = mock<FeedbackUrlComposer> {
+        val fakeFeedbackUrlComposition = mock<FeedbackUrlComposition> {
             on { getFeedbackUrl(any()) } doReturn SAMPLE_FEEDBACK_URL
         }
-        val viewModel = createViewModel(repository, feedbackUrlComposer = fakeFeedbackUrlComposer)
+        val viewModel = createViewModel(repository, feedbackUrlComposition = fakeFeedbackUrlComposition)
         viewModel.openFeedback()
         viewModel.openFeedBack.test {
             assertThat(awaitItem()).isEqualTo(SAMPLE_FEEDBACK_URL.toUri())
@@ -475,7 +475,7 @@ class SessionDetailsViewModelTest {
         val fakeMarkdownConversion = mock<MarkdownConversion> {
             on { markdownLinksToHtmlLinks(any()) } doReturn ""
         }
-        val fakeFeedbackUrlComposer = mock<FeedbackUrlComposer> {
+        val fakeFeedbackUrlComposition = mock<FeedbackUrlComposition> {
             on { getFeedbackUrl(any()) } doReturn ""
         }
         val viewModel = createViewModel(
@@ -484,7 +484,7 @@ class SessionDetailsViewModelTest {
             sessionUrlComposition = fakeSessionUrlComposition,
             formattingDelegate = fakeFormattingDelegate,
             markdownConversion = fakeMarkdownConversion,
-            feedbackUrlComposer = fakeFeedbackUrlComposer,
+            feedbackUrlComposition = fakeFeedbackUrlComposition,
             indoorNavigation = UnsupportedIndoorNavigation,
             defaultEngelsystemRoomName = "Engelshifts",
             customEngelsystemRoomName = "Zengelshifts",
@@ -516,7 +516,7 @@ class SessionDetailsViewModelTest {
         sessionPropertiesFormatter: SessionPropertiesFormatter = SessionPropertiesFormatter(),
         simpleSessionFormat: SimpleSessionFormat = mock(),
         jsonSessionFormat: JsonSessionFormat = mock(),
-        feedbackUrlComposer: FeedbackUrlComposer = mock(),
+        feedbackUrlComposition: FeedbackUrlComposition = mock(),
         sessionUrlComposition: SessionUrlComposition = mock(),
         markdownConversion: MarkdownConversion = mock(),
         formattingDelegate: FormattingDelegate = mock(),
@@ -534,7 +534,7 @@ class SessionDetailsViewModelTest {
         sessionPropertiesFormatter = sessionPropertiesFormatter,
         simpleSessionFormat = simpleSessionFormat,
         jsonSessionFormat = jsonSessionFormat,
-        feedbackUrlComposer = feedbackUrlComposer,
+        feedbackUrlComposition = feedbackUrlComposition,
         sessionUrlComposition = sessionUrlComposition,
         indoorNavigation = indoorNavigation,
         markdownConversion = markdownConversion,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -6,7 +6,7 @@ import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
-import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatter
+import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import org.mockito.kotlin.anyOrNull
@@ -77,13 +77,13 @@ class SearchResultParameterFactoryTest {
     private fun createFactory(): SearchResultParameterFactory {
         return SearchResultParameterFactory(
             resourceResolving = CompleteResourceResolver,
-            sessionPropertiesFormatter = sessionPropertiesFormatter,
+            sessionPropertiesFormatting = sessionPropertiesFormatting,
             contentDescriptionFormatting = ContentDescriptionFormatter(CompleteResourceResolver),
             formattingDelegate = formattingDelegate,
         )
     }
 
-    private val sessionPropertiesFormatter = mock<SessionPropertiesFormatter> {
+    private val sessionPropertiesFormatting = mock<SessionPropertiesFormatting> {
         on { getFormattedSpeakers(anyOrNull()) } doReturn "Jane Doe; John Doe"
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -78,7 +78,7 @@ class SearchResultParameterFactoryTest {
         return SearchResultParameterFactory(
             resourceResolving = CompleteResourceResolver,
             sessionPropertiesFormatter = sessionPropertiesFormatter,
-            contentDescriptionFormatter = ContentDescriptionFormatter(CompleteResourceResolver),
+            contentDescriptionFormatting = ContentDescriptionFormatter(CompleteResourceResolver),
             formattingDelegate = formattingDelegate,
         )
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/SessionPropertiesFormatterTest.kt
@@ -86,21 +86,21 @@ class SessionPropertiesFormatterTest {
     }
 
     @Test
-    fun `getFormattedTrackLanguageText returns track name if language is empty`() {
+    fun `getFormattedTrackNameAndLanguageText returns track name if language is empty`() {
         val session = createSession(track = "Track", language = "")
-        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("Track")
+        assertThat(formatter.getFormattedTrackNameAndLanguageText(session)).isEqualTo("Track")
     }
 
     @Test
-    fun `getFormattedTrackLanguageText returns track name and language if track and language is not empty`() {
+    fun `getFormattedTrackNameAndLanguageText returns track name and language if track and language is not empty`() {
         val session = createSession(track = "Track", language = "de-formal")
-        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("Track [de]")
+        assertThat(formatter.getFormattedTrackNameAndLanguageText(session)).isEqualTo("Track [de]")
     }
 
     @Test
-    fun `getFormattedTrackLanguageText returns language if track is empty and language is not empty`() {
+    fun `getFormattedTrackNameAndLanguageText returns language if track is empty and language is not empty`() {
         val session = createSession(track = "", language = "de-formal")
-        assertThat(formatter.getFormattedTrackLanguageText(session)).isEqualTo("[de]")
+        assertThat(formatter.getFormattedTrackNameAndLanguageText(session)).isEqualTo("[de]")
     }
 
     @Test


### PR DESCRIPTION
# Description
+ Use `Int#toDrawable` convenience function.
+ Add missing padding for favorites screen when shown on tablet in portrait mode.
+ Customize name of "Session Details" screen.
+ Clean up code.
+ Facilitate simpler testing by introducing `ContentDescriptionFormatter` interface.
+ Use `ContentDescriptionFormatting` interface.
+ Facilitate simpler testing by introducing `FeedbackUrlComposition` interface.
+ Use `FeedbackUrlComposition` interface.
+ Facilitate simpler testing by introducing `SessionPropertiesFormatting` interface.
+ Use `SessionPropertiesFormatting` interface.
+ Cover `SessionDetailsViewModel#roomStateMessage` with unit tests.

# Screenshots favorites padding
![favs-before](https://github.com/user-attachments/assets/15119c1a-eb3f-424b-b005-edc37d4dc41c) ![favs-after](https://github.com/user-attachments/assets/b8e7edd7-d459-4bf6-8e72-425be7a5fcfc)

# Screenshots details screen name
![details-before](https://github.com/user-attachments/assets/8a5f8624-15f8-4906-987d-fcc3c248b226) ![details-after](https://github.com/user-attachments/assets/c3757a2f-7433-40fa-b7ce-c2857e71a573)

![details-before-landscape](https://github.com/user-attachments/assets/5f79eaad-8691-4924-9ed9-1868db236725) ![details-after-landscape](https://github.com/user-attachments/assets/a8085428-6dec-42c8-8752-1a54f954428b)



# Successfully tested on
with `fossgis2025` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
