### PR TITLE
Show in the "settings" screen when the next schedule update happens.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,7 +81,7 @@ jobs:
           emulator-options: -metrics-collection -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script:
-            ./gradlew :database:connectedAndroidTest && killall -INT crashpad_handler || true
+            ./gradlew :app:connectedCcc38c3DebugAndroidTest :database:connectedAndroidTest && killall -INT crashpad_handler || true
 
       - name: Publish unit-test results
         uses: EnricoMi/publish-unit-test-result-action/linux@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,9 @@ android {
 
         vectorDrawables.useSupportLibrary = true // allows using fillColor, fillType, strokeColor functionalities below Android 7.0 (API 24)
 
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments runnerBuilder: "de.mannodermaus.junit5.AndroidJUnit5Builder"
+
         // Build information
         resValue("string", "build_time", "\"${buildTime()}\"")
         resValue("string", "git_sha", "\"${gitSha()}\"")
@@ -154,6 +157,16 @@ android {
                 "-opt-in=kotlin.RequiresOptIn"
         ]
     }
+
+    packagingOptions {
+        resources {
+            excludes += [
+                    "META-INF/LICENSE.md",
+                    "META-INF/LICENSE-notice.md",
+            ]
+        }
+    }
+
 }
 
 unMock {
@@ -228,6 +241,12 @@ dependencies {
     testImplementation Libs.turbine
 
     unmock Libs.robolectric
+
+    androidTestImplementation Libs.androidTestCore
+    androidTestRuntimeOnly Libs.androidTestRunner
+    androidTestImplementation Libs.junitJupiterApi
+    androidTestImplementation Libs.junitJupiterParams
+    androidTestImplementation Libs.truth
 }
 
 def gitSha() {

--- a/app/src/androidTest/kotlin/nerd/tuxmobil/fahrplan/congress/settings/IntervalFormatterTest.kt
+++ b/app/src/androidTest/kotlin/nerd/tuxmobil/fahrplan/congress/settings/IntervalFormatterTest.kt
@@ -1,0 +1,99 @@
+package nerd.tuxmobil.fahrplan.congress.settings
+
+import android.content.res.Configuration
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_DAY
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_HOUR
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
+import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments.of
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Locale
+
+class IntervalFormatterTest {
+
+    private companion object {
+
+        @JvmStatic
+        fun englishData() = listOf(
+            of(MILLISECONDS_OF_ONE_DAY, "every day"),
+            of((1.3 * MILLISECONDS_OF_ONE_DAY).toLong(), "every 1.3 days"),
+            of(2 * MILLISECONDS_OF_ONE_DAY, "every 2 days"),
+
+            of(MILLISECONDS_OF_ONE_HOUR, "every hour"),
+            of(2 * MILLISECONDS_OF_ONE_HOUR, "every 2 hours"),
+            of((2.2 * MILLISECONDS_OF_ONE_HOUR).toLong(), "every 2.2 hours"),
+
+            of(MILLISECONDS_OF_ONE_MINUTE.toLong(), "every minute"),
+            of((1.5 * MILLISECONDS_OF_ONE_MINUTE).toLong(), "every 1.5 minutes"),
+            of(2 * MILLISECONDS_OF_ONE_MINUTE.toLong(), "every 2 minutes"),
+
+            of(MILLISECONDS_OF_ONE_SECOND.toLong(), "every second"),
+            of(2 * MILLISECONDS_OF_ONE_SECOND.toLong(), "every 2 seconds"),
+        )
+
+        @JvmStatic
+        fun germanData() = listOf(
+            of(MILLISECONDS_OF_ONE_DAY, "jeden Tag"),
+            of((1.3 * MILLISECONDS_OF_ONE_DAY).toLong(), "jede 1,3 Tage"),
+            of(2 * MILLISECONDS_OF_ONE_DAY, "jede 2 Tage"),
+
+            of(MILLISECONDS_OF_ONE_HOUR, "jede Stunde"),
+            of(2 * MILLISECONDS_OF_ONE_HOUR, "jede 2 Stunden"),
+            of((2.2 * MILLISECONDS_OF_ONE_HOUR).toLong(), "jede 2,2 Stunden"),
+
+            of(MILLISECONDS_OF_ONE_MINUTE.toLong(), "jede Minute"),
+            of((1.5 * MILLISECONDS_OF_ONE_MINUTE).toLong(), "jede 1,5 Minuten"),
+            of(2 * MILLISECONDS_OF_ONE_MINUTE.toLong(), "jede 2 Minuten"),
+
+            of(MILLISECONDS_OF_ONE_SECOND.toLong(), "jede Sekunde"),
+            of(2 * MILLISECONDS_OF_ONE_SECOND.toLong(), "jede 2 Sekunden"),
+        )
+    }
+
+    private val systemLocale = Locale.getDefault()
+
+    @AfterEach
+    fun cleanUp() {
+        Locale.setDefault(systemLocale)
+    }
+
+    @MethodSource("englishData")
+    @DisplayName("EN: getFormattedInterval")
+    @ParameterizedTest(name = """{index}: durationValue = "{0}" -> "{1}"""")
+    fun getFormattedIntervalEnglish(durationValue: Long, expectedText: String) {
+        val locale = Locale("en", "US")
+        Locale.setDefault(locale)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val config = Configuration(context.resources.configuration).apply {
+            setLocale(locale)
+        }
+        val germanContext = context.createConfigurationContext(config)
+        val formatter = IntervalFormatter(ResourceResolver(germanContext))
+        val duration = Duration.ofMilliseconds(durationValue)
+        assertThat(formatter.getFormattedInterval(duration)).isEqualTo(expectedText)
+    }
+
+    @MethodSource("germanData")
+    @DisplayName("DE: getFormattedInterval")
+    @ParameterizedTest(name = """{index}: durationValue = "{0}" -> "{1}"""")
+    fun getFormattedIntervalGerman(durationValue: Long, expectedText: String) {
+        val locale = Locale("de", "DE")
+        Locale.setDefault(locale)
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val config = Configuration(context.resources.configuration).apply {
+            setLocale(locale)
+        }
+        val germanContext = context.createConfigurationContext(config)
+        val formatter = IntervalFormatter(ResourceResolver(germanContext))
+        val duration = Duration.ofMilliseconds(durationValue)
+        assertThat(formatter.getFormattedInterval(duration)).isEqualTo(expectedText)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/NextFetch.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/NextFetch.kt
@@ -1,0 +1,18 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.preferences.RealSharedPreferencesRepository
+
+data class NextFetch(
+    val nextFetchAt: Moment,
+    val interval: Duration,
+) {
+    /**
+     * Returns true if the values of [nextFetchAt] and [interval] are reasonable to be processed.
+     *
+     * See [SCHEDULE_NEXT_FETCH_AT_DEFAULT_VALUE][RealSharedPreferencesRepository.SCHEDULE_NEXT_FETCH_AT_DEFAULT_VALUE]
+     * and [SCHEDULE_NEXT_FETCH_INTERVAL_DEFAULT_VALUE][RealSharedPreferencesRepository.SCHEDULE_NEXT_FETCH_INTERVAL_DEFAULT_VALUE]
+     */
+    fun isValid() = !nextFetchAt.isEpoch() && interval.isPositive()
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
@@ -14,6 +14,10 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
         const val DISPLAY_DAY_INDEX_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.DISPLAY_DAY_INDEX"
         const val ENGELSYSTEM_SHIFTS_HASH_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.ENGELSYSTEM_SHIFTS_HASH"
         const val SCHEDULE_LAST_FETCHED_AT_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_LAST_FETCHED_AT"
+        const val SCHEDULE_NEXT_FETCH_AT_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_NEXT_FETCH_AT_KEY"
+        const val SCHEDULE_NEXT_FETCH_AT_DEFAULT_VALUE = 0L
+        const val SCHEDULE_NEXT_FETCH_INTERVAL_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SCHEDULE_NEXT_FETCH_INTERVAL_KEY"
+        const val SCHEDULE_NEXT_FETCH_INTERVAL_DEFAULT_VALUE = -1L
         const val SELECTED_SESSION_ID_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SELECTED_SESSION_ID_KEY"
         const val SEARCH_HISTORY_KEY = "nerd.tuxmobil.fahrplan.congress.Prefs.SEARCH_HISTORY_KEY"
         const val SEARCH_HISTORY_SEPARATOR = ";"
@@ -89,6 +93,26 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
     override fun setScheduleLastFetchedAt(fetchedAt: Long) = preferences.edit {
         putLong(SCHEDULE_LAST_FETCHED_AT_KEY, fetchedAt)
     }
+
+    override fun getScheduleNextFetchAt() =
+            preferences.getLong(SCHEDULE_NEXT_FETCH_AT_KEY, SCHEDULE_NEXT_FETCH_AT_DEFAULT_VALUE)
+
+    override fun setScheduleNextFetchAt(fetchAt: Long) = preferences.edit {
+        putLong(SCHEDULE_NEXT_FETCH_AT_KEY, fetchAt)
+    }
+
+    override fun resetScheduleNextFetchAt() =
+        setScheduleLastFetchedAt(SCHEDULE_NEXT_FETCH_AT_DEFAULT_VALUE)
+
+    override fun getScheduleNextFetchInterval() =
+        preferences.getLong(SCHEDULE_NEXT_FETCH_INTERVAL_KEY, SCHEDULE_NEXT_FETCH_INTERVAL_DEFAULT_VALUE)
+
+    override fun setScheduleNextFetchInterval(interval: Long) = preferences.edit {
+        putLong(SCHEDULE_NEXT_FETCH_INTERVAL_KEY, interval)
+    }
+
+    override fun resetScheduleNextFetchInterval() =
+        setScheduleNextFetchInterval(SCHEDULE_NEXT_FETCH_INTERVAL_DEFAULT_VALUE)
 
     override fun getChangesSeen() =
             preferences.getBoolean(CHANGES_SEEN_KEY, true)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -22,6 +22,14 @@ interface SharedPreferencesRepository {
     fun getScheduleLastFetchedAt(): Long
     fun setScheduleLastFetchedAt(fetchedAt: Long)
 
+    fun getScheduleNextFetchAt(): Long
+    fun setScheduleNextFetchAt(fetchAt: Long)
+    fun resetScheduleNextFetchAt()
+
+    fun getScheduleNextFetchInterval(): Long
+    fun setScheduleNextFetchInterval(interval: Long)
+    fun resetScheduleNextFetchInterval()
+
     fun getChangesSeen(): Boolean
     fun setChangesSeen(changesSeen: Boolean)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -254,7 +254,14 @@ class FahrplanFragment : Fragment(), MenuProvider, SessionViewEventsHandler {
             errorMessage.show(requireContext(), shouldShowLong = false)
         }
         viewModel.activateScheduleUpdateAlarm.observe(viewLifecycleOwner) { conferenceTimeFrame ->
-            FahrplanMisc.setUpdateAlarm(requireContext(), conferenceTimeFrame, isInitial = false, logging)
+            FahrplanMisc.setUpdateAlarm(
+                context = requireContext(),
+                conferenceTimeFrame = conferenceTimeFrame,
+                isInitial = false,
+                logging = logging,
+                onCancelScheduleNextFetch = AppRepository::deleteScheduleNextFetch,
+                onUpdateScheduleNextFetch = AppRepository::updateScheduleNextFetch ,
+            )
         }
         viewModel.shareSimple.observe(viewLifecycleOwner) { formattedSession ->
             SessionSharer.shareSimple(requireContext(), formattedSession)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/IntervalFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/IntervalFormatter.kt
@@ -1,0 +1,51 @@
+package nerd.tuxmobil.fahrplan.congress.settings
+
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Days
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Hours
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Minutes
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Seconds
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
+import kotlin.math.ceil
+
+class IntervalFormatter(private val resolving: ResourceResolving) {
+
+    fun getFormattedInterval(interval: Duration) = when (interval.unit()) {
+        Days -> {
+            val days = interval.toPartialDays()
+            val quantity = quantityOf(days)
+            val value = formattedValueOf(days)
+            resolving.getQuantityString(R.plurals.preference_summary_auto_update_interval_days, quantity, value)
+        }
+
+        Hours -> {
+            val hours = interval.toPartialHours()
+            val quantity = quantityOf(hours)
+            val value = formattedValueOf(hours)
+            resolving.getQuantityString(R.plurals.preference_summary_auto_update_interval_hours, quantity, value)
+        }
+
+        Minutes -> {
+            val minutes = interval.toPartialMinutes()
+            val quantity = quantityOf(minutes)
+            val value = formattedValueOf(minutes)
+            resolving.getQuantityString(R.plurals.preference_summary_auto_update_interval_minutes, quantity, value)
+        }
+
+        Seconds -> {
+            val seconds = interval.toPartialSeconds()
+            val quantity = quantityOf(seconds)
+            val value = formattedValueOf(seconds)
+            resolving.getQuantityString(R.plurals.preference_summary_auto_update_interval_seconds, quantity, value)
+        }
+    }
+
+    private fun quantityOf(duration: Double) = ceil(duration).toInt()
+
+    private fun formattedValueOf(duration: Double) = when (duration % 1.0 == 0.0) {
+        true -> "${duration.toInt()}"
+        false -> "%.1f".format(duration)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -18,6 +18,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -26,15 +27,20 @@ import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
+import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.extensions.toSpanned
 import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
+import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticActivity
 import nerd.tuxmobil.fahrplan.congress.utils.FahrplanMisc
 
-class SettingsFragment : PreferenceFragmentCompat() {
+class SettingsFragment(
+    val executionContext: ExecutionContext = AppExecutionContext
+) : PreferenceFragmentCompat() {
 
     private companion object {
 
@@ -44,6 +50,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private val job = Job()
     private val coroutineScope = CoroutineScope(Dispatchers.Default + job)
+    private val dateFormatter = DateFormatter.newInstance(AppRepository.readUseDeviceTimeZoneEnabled())
+    private val intervalFormatter by lazy { IntervalFormatter(ResourceResolver(requireContext())) }
     private val logging = Logging.get()
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -58,7 +66,14 @@ class SettingsFragment : PreferenceFragmentCompat() {
         requirePreference<ListPreference>(resources.getString(R.string.preference_key_schedule_refresh_interval_index)).onPreferenceChangeListener = OnPreferenceChangeListener { _, _ ->
             coroutineScope.launch {
                 delay(100) // Workaround because preference is written asynchronous.
-                FahrplanMisc.setUpdateAlarm(requireContext(), AppRepository.loadConferenceTimeFrame(), isInitial = true, logging)
+                FahrplanMisc.setUpdateAlarm(
+                    context = requireContext(),
+                    conferenceTimeFrame = AppRepository.loadConferenceTimeFrame(),
+                    isInitial = true,
+                    logging = logging,
+                    onCancelScheduleNextFetch = AppRepository::deleteScheduleNextFetch ,
+                    onUpdateScheduleNextFetch = AppRepository::updateScheduleNextFetch,
+                )
             }
             true
         }
@@ -75,11 +90,21 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         val categoryGeneral = requirePreference<PreferenceCategory>(getString(R.string.preference_key_category_general))
 
-        requirePreference<SwitchPreferenceCompat>(resources.getString(R.string.preference_key_auto_update_enabled)).onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, newValue: Any ->
+        val autoUpdatePreference = requirePreference<SwitchPreferenceCompat>(resources.getString(R.string.preference_key_auto_update_enabled))
+        autoUpdatePreference.onPreferenceChangeListener = OnPreferenceChangeListener { _: Preference?, newValue: Any ->
             val isAutoUpdateEnabled = newValue as Boolean
             if (isAutoUpdateEnabled) {
-                FahrplanMisc.setUpdateAlarm(requireContext(), AppRepository.loadConferenceTimeFrame(), isInitial = true, logging)
+                FahrplanMisc.setUpdateAlarm(
+                    context = requireContext(),
+                    conferenceTimeFrame = AppRepository.loadConferenceTimeFrame(),
+                    isInitial = true,
+                    logging = logging,
+                    onCancelScheduleNextFetch = AppRepository::deleteScheduleNextFetch,
+                    onUpdateScheduleNextFetch = AppRepository::updateScheduleNextFetch,
+                )
             } else {
+                AppRepository.deleteScheduleNextFetch()
+                autoUpdatePreference.summary = resources.getString(R.string.preference_summary_auto_update_enabled)
                 AlarmServices.newInstance(requireContext(), AppRepository).discardAutoUpdateAlarm()
             }
             true
@@ -139,6 +164,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         } else {
             screen.removePreference(engelsystemCategory)
         }
+        updateAutoUpdateSummary()
     }
 
     override fun onStop() {
@@ -178,6 +204,30 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun launchScheduleStatistic(context: Context) {
         ScheduleStatisticActivity.start(context)
+    }
+
+    private fun updateAutoUpdateSummary() {
+        val autoUpdatePreference = requirePreference<SwitchPreferenceCompat>(resources.getString(R.string.preference_key_auto_update_enabled))
+        coroutineScope.launch {
+            AppRepository.scheduleNextFetch
+                .collect { nextFetch ->
+                    val text = when (autoUpdatePreference.isChecked && nextFetch.isValid()) {
+                        true -> {
+                            val (nextFetchAt, interval) = nextFetch
+                            val nextFetchAtText = dateFormatter.getFormattedDateTimeShort(nextFetchAt.toMilliseconds(), sessionZoneOffset = null)
+                            val intervalText = intervalFormatter.getFormattedInterval(interval)
+                            resources.getString(R.string.preference_summary_auto_update_next_fetch_approximately_at, nextFetchAtText, intervalText)
+                        }
+
+                        false -> {
+                            resources.getString(R.string.preference_summary_auto_update_enabled)
+                        }
+                    }
+                    executionContext.withUiContext {
+                        autoUpdatePreference.summary = text
+                    }
+                }
+        }
     }
 
     /**

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/system/OnBootReceiver.kt
@@ -50,7 +50,14 @@ class OnBootReceiver : BroadcastReceiver() {
         if (appRepository.readAutoUpdateEnabled()) { // Check if auto update is enabled
             val lastFetchedAt = appRepository.readScheduleLastFetchedAt()
             val nowMillis = Moment.now().toMilliseconds()
-            val interval = FahrplanMisc.setUpdateAlarm(context, appRepository.loadConferenceTimeFrame(), isInitial = true, logging)
+            val interval = FahrplanMisc.setUpdateAlarm(
+                context = context,
+                conferenceTimeFrame = appRepository.loadConferenceTimeFrame(),
+                isInitial = true,
+                logging = logging,
+                onCancelScheduleNextFetch = appRepository::deleteScheduleNextFetch,
+                onUpdateScheduleNextFetch = appRepository::updateScheduleNextFetch,
+            )
 
             logging.d(LOG_TAG, "now: $nowMillis, lastFetchedAt: $lastFetchedAt")
 

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen</string>
@@ -8,6 +8,26 @@
     <!-- Automatic schedule updates -->
     <string name="preference_title_auto_update_enabled">Automatische Aktualisierung anschalten</string>
     <string name="preference_summary_auto_update_enabled">Lädt den Fahrplan regelmäßig herunter.</string>
+    <string name="preference_summary_auto_update_next_fetch_approximately_at">
+         Ungefähre nächste Aktualisierung: <xliff:g example="26.02.25 13:00" id="nextFetchAt">%1$s</xliff:g>
+        (<xliff:g example="jede 1,5 Stunden" id="interval">%2$s</xliff:g>)
+    </string>
+    <plurals name="preference_summary_auto_update_interval_days">
+        <item quantity="one">jeden Tag</item>
+        <item quantity="other">jede <xliff:g example="5" id="days">%s</xliff:g> Tage</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_hours">
+        <item quantity="one">jede Stunde</item>
+        <item quantity="other">jede <xliff:g example="5" id="hours">%s</xliff:g> Stunden</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_minutes">
+        <item quantity="one">jede Minute</item>
+        <item quantity="other">jede <xliff:g example="5" id="minutes">%s</xliff:g> Minuten</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_seconds">
+        <item quantity="one">jede Sekunde</item>
+        <item quantity="other">jede <xliff:g example="5" id="seconds">%s</xliff:g> Sekunden</item>
+    </plurals>
 
     <!-- Alarm time index -->
     <string name="preference_dialog_title_alarm_time">Wähle eine Standard-Alarmzeit</string>

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -31,9 +31,9 @@
     -->
     <string-array name="preference_entry_values_schedule_refresh_interval" translatable="false">
         <item>-1</item>
-        <item>3000</item>
-        <item>6000</item>
-        <item>12000</item>
+        <item>30000</item>
+        <item>60000</item>
+        <item>120000</item>
     </string-array>
 
     <!-- Schedule statistic -->

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
     <!-- Screen -->
     <string name="preference_key_screen" translatable="false">preferences_key_screen</string>
@@ -49,6 +49,26 @@
     <bool name="preference_default_value_auto_update_enabled">true</bool>
     <string name="preference_title_auto_update_enabled">Enable automatic updates</string>
     <string name="preference_summary_auto_update_enabled">Downloads the schedule periodically.</string>
+    <string name="preference_summary_auto_update_next_fetch_approximately_at">
+        Next update approximately at: <xliff:g example="2/26/25 13:00" id="nextFetchAt">%1$s</xliff:g>
+        (<xliff:g example="every 1.5 hours" id="interval">%2$s</xliff:g>)
+    </string>
+    <plurals name="preference_summary_auto_update_interval_days">
+        <item quantity="one">every day</item>
+        <item quantity="other">every <xliff:g example="5" id="days">%s</xliff:g> days</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_hours">
+        <item quantity="one">every hour</item>
+        <item quantity="other">every <xliff:g example="5" id="hours">%s</xliff:g> hours</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_minutes">
+        <item quantity="one">every minute</item>
+        <item quantity="other">every <xliff:g example="5" id="minutes">%s</xliff:g> minutes</item>
+    </plurals>
+    <plurals name="preference_summary_auto_update_interval_seconds">
+        <item quantity="one">every second</item>
+        <item quantity="other">every <xliff:g example="5" id="seconds">%s</xliff:g> seconds</item>
+    </plurals>
 
     <!-- Alarm time index -->
     <string name="preference_key_alarm_time_index" translatable="false">default_alarm_time</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/NextFetchTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/NextFetchTest.kt
@@ -1,0 +1,34 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import org.junit.jupiter.api.Test
+
+class NextFetchTest {
+
+    @Test
+    fun `isValid returns true`() {
+        val nextFetch = NextFetch(Moment.ofEpochMilli(1), Duration.ofMilliseconds(1))
+        assertThat(nextFetch.isValid()).isTrue()
+    }
+
+    @Test
+    fun `isValid returns false if nextFetchAt is epoch and interval is zero`() {
+        val nextFetch = NextFetch(Moment.ofEpochMilli(0), Duration.ofMilliseconds(0))
+        assertThat(nextFetch.isValid()).isFalse()
+    }
+
+    @Test
+    fun `isValid returns false if nextFetchAt is epoch`() {
+        val nextFetch = NextFetch(Moment.ofEpochMilli(0), Duration.ofMilliseconds(1))
+        assertThat(nextFetch.isValid()).isFalse()
+    }
+
+    @Test
+    fun `isValid returns false if interval is zero`() {
+        val nextFetch = NextFetch(Moment.ofEpochMilli(1), Duration.ofMilliseconds(0))
+        assertThat(nextFetch.isValid()).isFalse()
+    }
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleNextFetchTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryScheduleNextFetchTest.kt
@@ -1,0 +1,70 @@
+package nerd.tuxmobil.fahrplan.congress.repositories
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import info.metadude.android.eventfahrplan.commons.testing.MainDispatcherTestExtension
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import nerd.tuxmobil.fahrplan.congress.models.NextFetch
+import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Covers [AppRepository.scheduleNextFetch].
+ */
+@ExtendWith(MainDispatcherTestExtension::class)
+class AppRepositoryScheduleNextFetchTest {
+
+    private val sharedPreferencesRepository = mock<SharedPreferencesRepository>()
+
+    private val testableAppRepository: AppRepository
+        get() = with(AppRepository) {
+            initialize(
+                context = mock(),
+                logging = mock(),
+                executionContext = TestExecutionContext,
+                databaseScope = mock(),
+                networkScope = mock(),
+                okHttpClient = mock(),
+                alarmsDatabaseRepository = mock(),
+                sessionsDatabaseRepository = mock(),
+                scheduleNetworkRepository = mock(),
+                engelsystemNetworkRepository = mock(),
+                sharedPreferencesRepository = sharedPreferencesRepository,
+                sessionsTransformer = mock(),
+            )
+            return this
+        }
+
+    @Test
+    fun `scheduleNextFetch emits zero schedule next fetch by default`() = runTest {
+        whenever(sharedPreferencesRepository.getScheduleNextFetchAt()).thenReturn(0L)
+        testableAppRepository.scheduleNextFetch.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(NextFetch(Moment.ofEpochMilli(0), Duration.ofMilliseconds(0)))
+        }
+    }
+
+    @Test
+    fun `scheduleNextFetch emits the schedule next fetch`() = runTest {
+        val nextFetchAt = Moment.ofEpochMilli(1633046400000)
+        val interval = Duration.ofMilliseconds(3000)
+        whenever(sharedPreferencesRepository.getScheduleNextFetchAt()).thenReturn(nextFetchAt.toMilliseconds())
+        whenever(sharedPreferencesRepository.getScheduleNextFetchInterval()).thenReturn(interval.toPartialMilliseconds().toLong())
+        testableAppRepository.updateScheduleNextFetch(NextFetch(nextFetchAt, interval))
+
+        val expectedNextFetchAt = Moment.ofEpochMilli(1633046400000)
+        val expectedInterval = Duration.ofMilliseconds(3000)
+        val expected = NextFetch(expectedNextFetchAt, expectedInterval)
+        testableAppRepository.scheduleNextFetch.test {
+            val actual = awaitItem()
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+}

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Duration.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Duration.kt
@@ -1,0 +1,111 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Days
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Hours
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Minutes
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Seconds
+import org.threeten.bp.Duration as ThreeTenDuration
+
+/**
+ * Represents a duration of time.
+ */
+class Duration private constructor(private val duration: ThreeTenDuration) : Comparable<Duration> {
+
+    sealed interface Unit {
+        data object Days : Unit
+        data object Hours : Unit
+        data object Minutes : Unit
+        data object Seconds : Unit
+    }
+
+    /**
+     * Returns the [Unit] of this duration, from largest to smallest,
+     * which fully defines the duration value.
+     */
+    fun unit() = when {
+        toWholeDays() > 0 -> Days
+        toWholeHours() > 0 -> Hours
+        toWholeMinutes() > 0 -> Minutes
+        else -> Seconds
+    }
+
+    /**
+     * Returns true if this duration is greater than zero.
+     */
+    fun isPositive() = !duration.isZero && !duration.isNegative
+
+    /**
+     * Returns the absolute days of this duration.
+     */
+    fun toWholeDays() = duration.toDays()
+
+    /**
+     * Returns the absolute hours of this duration.
+     */
+    fun toWholeHours() = duration.toHours()
+
+    /**
+     * Returns the absolute minutes of this duration.
+     */
+    fun toWholeMinutes() = duration.toMinutes()
+
+    /**
+     * Returns the absolute seconds of this duration.
+     */
+    fun toWholeSeconds() = duration.seconds
+
+    /**
+     * Returns the absolute milliseconds of this duration.
+     */
+    fun toWholeMilliseconds() = duration.toMillis()
+
+    /**
+     * Returns the precise days of this duration.
+     */
+    fun toPartialDays() = duration.seconds.toDouble() / (24 * 60 * 60)
+
+    /**
+     * Returns the precise hours of this duration.
+     */
+    fun toPartialHours() = duration.seconds.toDouble() / (60 * 60)
+
+    /**
+     * Returns the precise minutes of this duration.
+     */
+    fun toPartialMinutes() = duration.seconds.toDouble() / 60
+
+    /**
+     * Returns the precise seconds of this duration.
+     */
+    fun toPartialSeconds() = duration.toMillis().toDouble() / 1000
+
+    /**
+     * Returns the precise milliseconds of this duration.
+     */
+    fun toPartialMilliseconds() = duration.toMillis().toDouble()
+
+    override fun compareTo(other: Duration): Int {
+        return duration.compareTo(other.duration) / 1_000_000
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return duration == (other as? Duration)?.duration
+    }
+
+    override fun hashCode() = duration.hashCode()
+
+    override fun toString() = duration.toString()
+
+    companion object {
+
+        /**
+         * Creates a [Duration] instance from the given [milliseconds].
+         *
+         * @param milliseconds epoch millis to create instance from
+         */
+        fun ofMilliseconds(milliseconds: Long) =
+            Duration(ThreeTenDuration.ofMillis(milliseconds))
+
+    }
+
+}

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -1,6 +1,6 @@
 package info.metadude.android.eventfahrplan.commons.temporal
 
-import org.threeten.bp.Duration
+import org.threeten.bp.Duration as ThreeTenDuration
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
@@ -120,6 +120,11 @@ class Moment private constructor(private val time: Instant) : Comparable<Moment>
     fun plusDays(days: Long): Moment = Moment(time.plus(days, ChronoUnit.DAYS))
 
     /**
+     * Returns a moment with the given [duration] added.
+     */
+    fun plusDuration(duration: Duration) = Moment(time.plusMillis(duration.toWholeMilliseconds()))
+
+    /**
      * Returns true if this moment is before the given [moment].
      */
     fun isBefore(moment: Moment): Boolean = time.toEpochMilli() < moment.toMilliseconds()
@@ -135,10 +140,15 @@ class Moment private constructor(private val time: Instant) : Comparable<Moment>
     fun isAfter(moment: Moment): Boolean = moment.isBefore(this)
 
     /**
+     * Returns true if this moment equals [Instant.EPOCH].
+     */
+    fun isEpoch(): Boolean = time == Instant.EPOCH
+
+    /**
      * Returns the duration in minutes between this and the given [moment].
      */
     fun minutesUntil(moment: Moment): Long {
-        return Duration.between(time, moment.time).toMinutes()
+        return ThreeTenDuration.between(time, moment.time).toMinutes()
     }
 
     override fun compareTo(other: Moment): Int {

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DurationTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DurationTest.kt
@@ -1,0 +1,178 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Days
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Hours
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Minutes
+import info.metadude.android.eventfahrplan.commons.temporal.Duration.Unit.Seconds
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_DAY
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_HOUR
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
+import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_SECOND
+import org.junit.jupiter.api.Test
+
+class DurationTest {
+
+    @Test
+    fun `unit returns days`() {
+        val duration = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(duration.unit()).isEqualTo(Days)
+    }
+
+    @Test
+    fun `unit returns hours`() {
+        val duration = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_HOUR)
+        assertThat(duration.unit()).isEqualTo(Hours)
+    }
+
+    @Test
+    fun `unit returns minutes`() {
+        val duration = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_MINUTE.toLong())
+        assertThat(duration.unit()).isEqualTo(Minutes)
+    }
+
+    @Test
+    fun `unit returns seconds`() {
+        val duration = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_SECOND.toLong())
+        assertThat(duration.unit()).isEqualTo(Seconds)
+    }
+
+    @Test
+    fun `isPositive returns false for negative duration`() {
+        val duration = Duration.ofMilliseconds(-1)
+        assertThat(duration.isPositive()).isFalse()
+    }
+
+    @Test
+    fun `isPositive returns false for zero duration`() {
+        val duration = Duration.ofMilliseconds(0)
+        assertThat(duration.isPositive()).isFalse()
+    }
+
+    @Test
+    fun `isPositive returns true for positive duration`() {
+        val duration = Duration.ofMilliseconds(1)
+        assertThat(duration.isPositive()).isTrue()
+    }
+
+    @Test
+    fun `toWholeDays returns days without decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_DAY * 1.3).toLong())
+        assertThat(duration.toWholeDays()).isEqualTo(1)
+    }
+
+    @Test
+    fun `toWholeHours returns hours without decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_HOUR * 2.5).toLong())
+        assertThat(duration.toWholeHours()).isEqualTo(2)
+    }
+
+    @Test
+    fun `toWholeMinutes returns minutes without decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_MINUTE * 3.8).toLong())
+        assertThat(duration.toWholeMinutes()).isEqualTo(3)
+    }
+
+    @Test
+    fun `toWholeSeconds returns seconds without decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_SECOND * 4.1).toLong())
+        assertThat(duration.toWholeSeconds()).isEqualTo(4)
+    }
+
+    @Test
+    fun `toWholeMilliseconds returns seconds without decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_SECOND * 5.639).toLong())
+        assertThat(duration.toWholeMilliseconds()).isEqualTo(5639)
+    }
+
+    @Test
+    fun `toPartialDays returns days as decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_DAY * 1.3).toLong())
+        assertThat(duration.toPartialDays()).isEqualTo(1.3)
+    }
+
+    @Test
+    fun `toPartialHours returns hours with decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_HOUR * 2.5).toLong())
+        assertThat(duration.toPartialHours()).isEqualTo(2.5)
+    }
+
+    @Test
+    fun `toPartialMinutes returns minutes with decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_MINUTE * 3.8).toLong())
+        assertThat(duration.toPartialMinutes()).isEqualTo(3.8)
+    }
+
+    @Test
+    fun `toPartialSeconds returns seconds with decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_SECOND * 4.1).toLong())
+        assertThat(duration.toPartialSeconds()).isEqualTo(4.1)
+    }
+
+    @Test
+    fun `toPartialMilliseconds returns milliseconds with decimal value`() {
+        val duration = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_SECOND * 5.741).toLong())
+        assertThat(duration.toPartialMilliseconds()).isEqualTo(5741.0)
+    }
+
+    @Test
+    fun `equals returns true for equal durations`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        val durationTwo = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(durationOne == durationTwo).isTrue()
+    }
+
+    @Test
+    fun `equals returns false for unequal durations`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        val durationTwo = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY + 1)
+        assertThat(durationOne == durationTwo).isFalse()
+    }
+
+    @Test
+    fun `equals returns false for null duration`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(durationOne.equals(null)).isFalse()
+    }
+
+    @Test
+    fun `hashCode returns same value for equal durations`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        val durationTwo = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(durationOne.hashCode()).isEqualTo(durationTwo.hashCode())
+    }
+
+    @Test
+    fun `hashCode returns different values for unequal durations`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        val durationTwo = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY + 1)
+        assertThat(durationOne.hashCode()).isNotEqualTo(durationTwo.hashCode())
+    }
+
+    @Test
+    fun `compareTo returns the correct integer value when comparing durations (days)`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        val durationTwo = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY + 1)
+        val durationThree = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(durationOne.compareTo(durationTwo)).isEqualTo(-1)
+        assertThat(durationOne.compareTo(durationThree)).isEqualTo(0)
+        assertThat(durationTwo.compareTo(durationOne)).isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo returns the correct integer value when comparing durations (seconds)`() {
+        val durationOne = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_SECOND.toLong())
+        val durationTwo = Duration.ofMilliseconds((MILLISECONDS_OF_ONE_SECOND + 1).toLong())
+        val durationThree = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_SECOND.toLong())
+        assertThat(durationOne.compareTo(durationTwo)).isEqualTo(-1)
+        assertThat(durationOne.compareTo(durationThree)).isEqualTo(0)
+        assertThat(durationTwo.compareTo(durationOne)).isEqualTo(1)
+    }
+
+    @Test
+    fun `toString returns toString representation of internal duration`() {
+        val duration = Duration.ofMilliseconds(MILLISECONDS_OF_ONE_DAY)
+        assertThat(duration.toString()).isEqualTo("PT24H")
+    }
+
+}

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -204,6 +204,12 @@ class MomentTest {
     }
 
     @Test
+    fun isEpoch() {
+        val moment = Moment.ofEpochMilli(0)
+        assertThat(moment.isEpoch()).isTrue()
+    }
+
+    @Test
     fun minutesUntil() {
         val momentOne = Moment.now()
         val momentTwo = momentOne.plusMinutes(1)
@@ -247,6 +253,12 @@ class MomentTest {
 
         val momentTwo = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_DAY).plusDays(-1)
         assertThat(momentTwo.toMilliseconds()).isEqualTo(0)
+    }
+
+    @Test
+    fun plusDuration() {
+        val momentOne = Moment.ofEpochMilli(0).plusDuration(Duration.ofMilliseconds(MILLISECONDS_OF_ONE_HOUR))
+        assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_HOUR)
     }
 
     @Test

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -46,15 +46,11 @@ dependencies {
     testImplementation project(":commons-testing")
     testImplementation Libs.junitJupiterApi
     testRuntimeOnly Libs.junitJupiterEngine
+    testImplementation Libs.junitJupiterParams
     testImplementation Libs.truth
 
     androidTestImplementation Libs.androidTestCore
     androidTestRuntimeOnly Libs.androidTestRunner
     androidTestImplementation Libs.junitJupiterApi
     androidTestImplementation Libs.truth
-
-    testImplementation Libs.junitJupiterApi
-    testRuntimeOnly Libs.junitJupiterEngine
-    testImplementation Libs.junitJupiterParams
-    testImplementation Libs.truth
 }


### PR DESCRIPTION
# Description
+ Displays the approximate next moment and the corresponding interval when the automatic update will fetch schedule data in the background.
+ The date and time are not exact because we requested an inexact schedule update alarm from the alarm manager. `AlarmManager` does not offer an API to retrieve the next alarm.
+ The summary text is updated as well when the schedule refresh interval is altered via the dedicated development setting.

## Unrelated
+ Clean up dependencies in `database` module.
+ Fix schedule refresh interval values for development.

# Screenshots
![settings1](https://github.com/user-attachments/assets/21794d0d-c35a-47cf-bd6e-55db5ee3c077) ![settings2](https://github.com/user-attachments/assets/f2529814-1f54-498f-91ab-3003e947e637) ![settings3](https://github.com/user-attachments/assets/96309777-04a2-4884-b667-90261cb08eb2)


# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)