### PR TITLE
Optimize sessions flow with boolean flags (hasAlarm, isHighlight)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/about/AboutViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.about.AboutViewEvent.OnPostalAddressClick
 import nerd.tuxmobil.fahrplan.congress.commons.ExternalNavigation
@@ -23,7 +24,7 @@ class AboutViewModel(
 
     init {
         launch {
-            repository.meta.collect { meta ->
+            repository.meta.collectLatest { meta ->
                 mutableAboutParameter.value = aboutParameterFactory.createAboutParameter(meta)
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
@@ -32,6 +32,10 @@ fun List<SessionAppModel>.toVirtualDays(): List<VirtualDay> {
         }
 }
 
+fun List<SessionAppModel>.toNumDays(): Int {
+    return map(SessionAppModel::dateText).distinct().size
+}
+
 fun List<SessionDatabaseModel>.toDateInfos() = map(SessionDatabaseModel::toDateInfo)
 
 fun List<SessionDatabaseModel>.toDayRanges(): List<DayRange> {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -56,7 +57,7 @@ class StarredListViewModel(
     fun share() {
         launch {
             val timeZoneId = repository.readMeta().timeZoneId
-            repository.starredSessions.collect { sessions ->
+            repository.starredSessions.collectLatest { sessions ->
                 simpleSessionFormat.format(sessions, timeZoneId)?.let { formattedSessions ->
                     mutableShareSimple.sendOneTimeEvent(formattedSessions)
                 }
@@ -66,7 +67,7 @@ class StarredListViewModel(
 
     fun shareToChaosflix() {
         launch {
-            repository.starredSessions.collect { sessions ->
+            repository.starredSessions.collectLatest { sessions ->
                 jsonSessionFormat.format(sessions)?.let { formattedSessions ->
                     mutableShareJson.sendOneTimeEvent(formattedSessions)
                 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Session.kt
@@ -122,6 +122,8 @@ private data class EssentialSession(
     val language: String,
     val recordingLicense: String,
     val recordingOptOut: Boolean,
+    val isHighlight: Boolean,
+    val hasAlarm: Boolean,
 ) {
     constructor(session: Session) : this(
         sessionId = session.sessionId,
@@ -142,5 +144,7 @@ private data class EssentialSession(
         language = session.language,
         recordingLicense = session.recordingLicense,
         recordingOptOut = session.recordingOptOut,
+        isHighlight = session.isHighlight,
+        hasAlarm = session.hasAlarm,
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -782,6 +782,9 @@ object AppRepository : SearchRepository,
     fun deleteAlarmForAlarmId(alarmId: Int) =
             alarmsDatabaseRepository.deleteForAlarmId(alarmId).also {
                 refreshAlarms()
+                refreshSelectedSession()
+                refreshRoomStates()
+                refreshUncanceledSessions()
             }
 
     @WorkerThread

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
@@ -266,8 +267,7 @@ object AppRepository : SearchRepository,
         refreshUncanceledSessionsSignal
             .onStart { emit(Unit) }
             .mapLatest { loadUncanceledSessionsForDayIndex() }
-            // Don't use distinctUntilChanged() here unless Session highlight and hasAlarm are
-            // part of equals and hashcode. Otherwise the schedule screen does not update.
+            .distinctUntilChanged() // If server does not respond with HTTP 304 (Not modified).
             .flowOn(executionContext.database)
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -142,7 +142,7 @@ internal class FahrplanViewModel(
 
     private fun updateSchedule() {
         launch {
-            repository.uncanceledSessionsForDayIndex.collect { scheduleData ->
+            repository.uncanceledSessionsForDayIndex.collectLatest { scheduleData ->
                 if (scheduleData.allSessions.isEmpty()) {
                     val scheduleVersion = repository.readMeta().version
                     if (scheduleVersion.isNotEmpty()) {
@@ -161,7 +161,7 @@ internal class FahrplanViewModel(
 
     private fun updateHorizontalScrollingProgressLineVisibility() {
         launch {
-            repository.loadScheduleState.collect { state ->
+            repository.loadScheduleState.collectLatest { state ->
                 val shouldShow = state.toShowHorizontalScrollingProgressLine()
                 if (shouldShow) {
                     delay(PROGRESS_BAR_HIDING_DELAY)
@@ -193,7 +193,7 @@ internal class FahrplanViewModel(
                 .map { if (it.isEmpty()) null else Conference.ofSessions(it).timeFrame }
                 .distinctUntilChanged()
                 .map { if (it == null) Unknown else Known(it.start, it.endInclusive) }
-                .collect { mutableActivateScheduleUpdateAlarm.sendOneTimeEvent(it) }
+                .collectLatest { mutableActivateScheduleUpdateAlarm.sendOneTimeEvent(it) }
         }
     }
 
@@ -251,7 +251,7 @@ internal class FahrplanViewModel(
 
     fun fillTimes(nowMoment: Moment, normalizedBoxHeight: Int) {
         launch {
-            repository.uncanceledSessionsForDayIndex.collect { scheduleData ->
+            repository.uncanceledSessionsForDayIndex.collectLatest { scheduleData ->
                 val sessions = scheduleData.allSessions
                 if (sessions.isNotEmpty()) {
                     val parameters = sessions.toTimeTextViewParameters(nowMoment, normalizedBoxHeight)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -11,7 +11,8 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -33,6 +34,7 @@ import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Fetching
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialFetching
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.InitialParsing
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.Parsing
+import nerd.tuxmobil.fahrplan.congress.schedule.observables.DayMenuParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanEmptyParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.FahrplanParameter
 import nerd.tuxmobil.fahrplan.congress.schedule.observables.ScrollToCurrentSessionParameter
@@ -72,15 +74,11 @@ internal class FahrplanViewModel(
             runsAtLeastOnAndroidTiramisu,
         )
 
-    val fahrplanParameter = combine(
-        repository.uncanceledSessionsForDayIndex.filter { it.allSessions.isNotEmpty() },
-        repository.sessionsWithoutShifts.filterNotNull(),
-    ) { scheduleDataForDayIndex, allSessionsForAllDaysWithoutShifts ->
-        createFahrplanParameter(
-            scheduleData = scheduleDataForDayIndex.customizeEngelsystemRoomName(),
-            allSessionsForAllDaysWithoutShifts = allSessionsForAllDaysWithoutShifts,
-        )
-    }
+    private val mutableDayMenuParameter = MutableStateFlow(DayMenuParameter())
+    val dayMenuParameter = mutableDayMenuParameter.asStateFlow().filter { it.isValid }
+
+    private val mutableFahrplanParameter = MutableStateFlow<FahrplanParameter?>(null)
+    val fahrplanParameter = mutableFahrplanParameter.asStateFlow().filterNotNull()
 
     private val mutableFahrplanEmptyParameter = Channel<FahrplanEmptyParameter>()
     val fahrplanEmptyParameter = mutableFahrplanEmptyParameter.receiveAsFlow()
@@ -121,20 +119,41 @@ internal class FahrplanViewModel(
     var preserveVerticalScrollPosition: Boolean = false
 
     init {
-        updateUncanceledSessions()
+        updateDayMenu()
+        updateSchedule()
         requestScheduleUpdateAlarm()
         updateHorizontalScrollingProgressLineVisibility()
     }
 
-    private fun updateUncanceledSessions() {
+    private fun updateDayMenu() {
+        launch {
+            repository.sessionsWithoutShifts.filterNotNull().collectLatest { sessions ->
+                val displayDayIndex = repository.readDisplayDayIndex()
+                val numDays = repository.readMeta().numDays
+                val dayMenuEntries = if (numDays > 1) {
+                    navigationMenuEntriesGenerator.getDayMenuEntries(numDays, sessions)
+                } else {
+                    emptyList()
+                }
+                mutableDayMenuParameter.value = DayMenuParameter(dayMenuEntries, displayDayIndex)
+            }
+        }
+    }
+
+    private fun updateSchedule() {
         launch {
             repository.uncanceledSessionsForDayIndex.collect { scheduleData ->
-                val sessions = scheduleData.allSessions
-                if (sessions.isEmpty()) {
+                if (scheduleData.allSessions.isEmpty()) {
                     val scheduleVersion = repository.readMeta().version
                     if (scheduleVersion.isNotEmpty()) {
                         mutableFahrplanEmptyParameter.sendOneTimeEvent(FahrplanEmptyParameter(scheduleVersion))
                     } // else: Nothing to do because schedule has not been loaded yet
+                } else {
+                    val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
+                    val customizedScheduleData = scheduleData.customizeEngelsystemRoomName()
+                    val parameter = FahrplanParameter(customizedScheduleData, useDeviceTimeZone)
+                    logging.d(LOG_TAG, "Loaded ${parameter.scheduleData.allSessions.size} uncanceled sessions.")
+                    mutableFahrplanParameter.value = parameter
                 }
             }
         }
@@ -200,33 +219,6 @@ internal class FahrplanViewModel(
             roomData.copy(roomName = customRoomName, sessions = customSessions)
         }
     )
-
-    private fun createFahrplanParameter(
-        scheduleData: ScheduleData,
-        allSessionsForAllDaysWithoutShifts: List<Session>,
-    ): FahrplanParameter {
-        val dayIndex = repository.readDisplayDayIndex()
-        val numDays = repository.readMeta().numDays
-        val dayMenuEntries = if (numDays > 1) {
-            navigationMenuEntriesGenerator.getDayMenuEntries(
-                numDays,
-                allSessionsForAllDaysWithoutShifts
-            )
-        } else {
-            emptyList()
-        }
-        val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
-
-        return FahrplanParameter(
-            scheduleData = scheduleData,
-            useDeviceTimeZone = useDeviceTimeZone,
-            numDays = numDays,
-            dayIndex = dayIndex,
-            dayMenuEntries = dayMenuEntries
-        ).also {
-            logging.d(LOG_TAG, "Loaded ${it.scheduleData.allSessions.size} uncanceled sessions.")
-        }
-    }
 
     /**
      * Requests loading the schedule from the [AppRepository] to update the UI. UI components must

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.alarms.SessionAlarmViewModelDelegate
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toNumDays
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame.Known
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame.Unknown
@@ -129,7 +130,7 @@ internal class FahrplanViewModel(
         launch {
             repository.sessionsWithoutShifts.filterNotNull().collectLatest { sessions ->
                 val displayDayIndex = repository.readDisplayDayIndex()
-                val numDays = repository.readMeta().numDays
+                val numDays = sessions.toNumDays()
                 val dayMenuEntries = if (numDays > 1) {
                     navigationMenuEntriesGenerator.getDayMenuEntries(numDays, sessions)
                 } else {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -6,6 +6,7 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.changes.ChangeStatistic
@@ -62,7 +63,7 @@ internal class MainViewModel(
 
     private fun observeLoadScheduleState() {
         launch {
-            repository.loadScheduleState.collect { state ->
+            repository.loadScheduleState.collectLatest { state ->
                 val uiState = state.toUiState()
                 mutableLoadScheduleUiState.sendOneTimeEvent(uiState)
                 state.handleFailureStates()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/DayMenuParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/DayMenuParameter.kt
@@ -1,0 +1,8 @@
+package nerd.tuxmobil.fahrplan.congress.schedule.observables
+
+data class DayMenuParameter(
+    val dayMenuEntries: List<String> = emptyList(),
+    val displayDayIndex: Int = 0,
+) {
+    val isValid = displayDayIndex > 0
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/observables/FahrplanParameter.kt
@@ -9,11 +9,6 @@ import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
  * in the [FahrplanViewModel] which is observed by the [FahrplanFragment].
  */
 data class FahrplanParameter(
-
     val scheduleData: ScheduleData,
     val useDeviceTimeZone: Boolean,
-    val numDays: Int,
-    val dayIndex: Int,
-    val dayMenuEntries: List<String>
-
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsFragment.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
@@ -210,7 +211,7 @@ class SettingsFragment(
         val autoUpdatePreference = requirePreference<SwitchPreferenceCompat>(resources.getString(R.string.preference_key_auto_update_enabled))
         coroutineScope.launch {
             AppRepository.scheduleNextFetch
-                .collect { nextFetch ->
+                .collectLatest { nextFetch ->
                     val text = when (autoUpdatePreference.isChecked && nextFetch.isValid()) {
                         true -> {
                             val (nextFetchAt, interval) = nextFetch

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -181,8 +181,6 @@ class AlarmsViewModelTest {
         on { sessionsWithoutShifts } doReturn emptyFlow()
         on { readAlarms(any()) } doReturn alarmsList
         on { readUseDeviceTimeZoneEnabled() } doReturn true
-        on { deleteAlarmForSessionId(any()) } doReturn 0
-        on { deleteAllAlarms() } doReturn 0
     }
 
     private fun createViewModel(

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToNumDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToNumDaysTest.kt
@@ -1,0 +1,37 @@
+package nerd.tuxmobil.fahrplan.congress.dataconverters
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [SessionsExtensions.toNumDays][toNumDays].
+ */
+class SessionsExtensionsToNumDaysTest {
+
+    @Test
+    fun `toNumDays returns zero`() {
+        val virtualDays = emptyList<Session>().toNumDays()
+        assertThat(virtualDays).isEqualTo(0)
+    }
+
+    @Test
+    fun `toNumDays returns count of virtual days`() {
+        val sessions = listOf(
+            createSession("2023-12-27"),
+            createSession("2023-12-27"),
+            createSession("2023-12-28"),
+            createSession("2023-12-29"),
+            createSession("2023-12-30"),
+        )
+        val numDays = sessions.toNumDays()
+        assertThat(numDays).isEqualTo(4)
+    }
+
+    private fun createSession(dateText: String) =
+        Session(
+            sessionId = "",
+            dateText = dateText,
+        )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -30,6 +30,8 @@ class SessionTest {
             language = "cz",
             recordingLicense = "CC-0",
             recordingOptOut = true,
+            isHighlight = true,
+            hasAlarm = true,
 
             // Not considered in equal nor hashCode.
             url = "https://example.com",
@@ -39,8 +41,6 @@ class SessionTest {
             abstractt = "Sodales ut etiam sit amet nisl purus",
             description = "Lorem ipsum dolor sit amet",
             links = "http://sample.com",
-            isHighlight = true,
-            hasAlarm = true,
 
             // Not considered in equal nor hashCode, too.
             changedTitle = true,
@@ -65,8 +65,6 @@ class SessionTest {
             abstractt = "Foo abstract",
             description = "Foo description",
             links = "https://foobar-links.org",
-            isHighlight = false,
-            hasAlarm = false,
 
             changedTitle = false,
             changedSubtitle = false,
@@ -101,6 +99,8 @@ class SessionTest {
             of("language", createSession().copy(language = "Odd language")),
             of("recordingLicense", createSession().copy(recordingLicense = "Odd recording license")),
             of("recordingOptOut", createSession().copy(recordingOptOut = false)),
+            of("isHighlight", createSession().copy(isHighlight = false)),
+            of("hasAlarm", createSession().copy(hasAlarm = false)),
         )
 
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
@@ -1,0 +1,375 @@
+package nerd.tuxmobil.fahrplan.congress.repositories
+
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.database.models.Highlight
+import info.metadude.android.eventfahrplan.database.repositories.AlarmsDatabaseRepository
+import info.metadude.android.eventfahrplan.database.repositories.HighlightsDatabaseRepository
+import info.metadude.android.eventfahrplan.database.repositories.SessionsDatabaseRepository
+import kotlinx.coroutines.test.runTest
+import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
+import nerd.tuxmobil.fahrplan.congress.exceptions.ExceptionHandling
+import nerd.tuxmobil.fahrplan.congress.models.RoomData
+import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
+import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.coroutines.CoroutineContext
+import info.metadude.android.eventfahrplan.database.models.Alarm as AlarmDatabaseModel
+import info.metadude.android.eventfahrplan.database.models.Session as SessionDatabaseModel
+import nerd.tuxmobil.fahrplan.congress.models.Alarm as AlarmAppModel
+import nerd.tuxmobil.fahrplan.congress.models.Session as SessionAppModel
+
+/**
+ * Covers [AppRepository.uncanceledSessionsForDayIndex].
+ */
+class AppRepositoryUncanceledSessionsForDayIndexTest {
+
+    private val sessionId = "123"
+    private val dayIndex = 1
+    private val roomName = "Room 1"
+    private val alarmsDatabaseRepository = InMemoryAlarmRepository()
+    private val highlightsDatabaseRepository = InMemoryHighlightsDatabaseRepository()
+    private val roomProvider = object : RoomProvider {
+        override val prioritizedRooms: List<String> = emptyList()
+        override val deprioritizedRooms: List<String> = emptyList()
+    }
+    private val sessionsTransformer = SessionsTransformer(roomProvider)
+
+    private val testableAppRepository: AppRepository
+        get() = with(AppRepository) {
+            val executionContext = TestExecutionContext
+            initialize(
+                context = mock(),
+                logging = mock(),
+                executionContext = executionContext,
+                databaseScope = DatabaseScope.of(executionContext, StandardOutputExceptionHandler),
+                networkScope = mock(),
+                okHttpClient = mock(),
+                alarmsDatabaseRepository = alarmsDatabaseRepository,
+                sessionsDatabaseRepository = createSessionsDatabaseRepository(),
+                highlightsDatabaseRepository = highlightsDatabaseRepository,
+                scheduleNetworkRepository = mock(),
+                engelsystemNetworkRepository = mock(),
+                sharedPreferencesRepository = createSharedPreferencesRepository(),
+                sessionsTransformer = sessionsTransformer,
+            )
+            return this
+        }
+
+    @Nested
+    inner class Alarm {
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session with alarm when updateAlarm is invoked`() =
+            runTest {
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = false, // initially no alarm
+                    ))
+
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate scheduling an alarm
+                    testableAppRepository.updateAlarm(createAlarm())
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = true, // alarm is now set
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session without alarm when deleteAlarmForAlarmId is invoked`() =
+            runTest {
+                testableAppRepository.updateAlarm(createAlarm())
+
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = true, // initially alarm is set
+                    ))
+
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate canceling specific alarm
+                    testableAppRepository.deleteAlarmForAlarmId(0)
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = false, // alarm is now canceled
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session without alarm when deleteAlarmForSessionId is invoked`() =
+            runTest {
+                testableAppRepository.updateAlarm(createAlarm())
+
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = true, // initially alarm is set
+                    ))
+
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate canceling specific alarm
+                    testableAppRepository.deleteAlarmForSessionId(sessionId)
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = false, // alarm is now canceled
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session without alarm when deleteAllAlarms is invoked`() =
+            runTest {
+                testableAppRepository.updateAlarm(createAlarm())
+
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = true, // initially alarm is set
+                    ))
+
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate canceling all alarms
+                    testableAppRepository.deleteAllAlarms()
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false,
+                        hasAlarm = false, // alarm is now canceled
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+    }
+
+    @Nested
+    inner class Highlight {
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session with highlight when updateHighlight is invoked`() =
+            runTest {
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = false, // initially no highlight
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate highlighting a session
+                    testableAppRepository.updateHighlight(SessionAppModel(sessionId))
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = true, // highlight is now set
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session without highlight when deleteHighlight is invoked`() =
+            runTest {
+                testableAppRepository.updateHighlight(createSession(isHighlight = true, hasAlarm = false))
+
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = true, // initially with highlight
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate removing highlight from session
+                    testableAppRepository.deleteHighlight(sessionId)
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false, // highlight is now removed
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+        @Test
+        fun `uncanceledSessionsForDayIndex emits ScheduleData containing session without highlight when deleteAllHighlights is invoked`() =
+            runTest {
+                testableAppRepository.updateHighlight(createSession(isHighlight = true, hasAlarm = false))
+
+                testableAppRepository.uncanceledSessionsForDayIndex.test {
+                    val expectedScheduleData1 = createScheduleData(createSession(
+                        isHighlight = true, // initially with highlight
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData1 = awaitItem()
+                    assertThat(actualScheduleData1).isEqualTo(expectedScheduleData1)
+
+                    // Simulate removing highlights from all sessions
+                    testableAppRepository.deleteAllHighlights()
+                    val expectedScheduleData2 = createScheduleData(createSession(
+                        isHighlight = false, // highlight is now removed
+                        hasAlarm = false,
+                    ))
+                    val actualScheduleData2 = awaitItem()
+                    assertThat(actualScheduleData2).isEqualTo(expectedScheduleData2)
+                }
+            }
+
+    }
+
+    private fun createSharedPreferencesRepository(): SharedPreferencesRepository {
+        val repository = mock<SharedPreferencesRepository>()
+        whenever(repository.getDisplayDayIndex())
+            .thenReturn(dayIndex)
+        return repository
+    }
+
+    private fun createSessionsDatabaseRepository(): SessionsDatabaseRepository {
+        val repository = mock<SessionsDatabaseRepository>()
+        val session = SessionDatabaseModel(sessionId, dayIndex = dayIndex, roomName = roomName)
+        whenever(repository.querySessionsForDayIndexOrderedByDateUtc(any()))
+            .thenReturn(listOf(session))
+        return repository
+    }
+
+    private fun createAlarm() = AlarmAppModel(
+        alarmTimeInMin = 0,
+        day = dayIndex,
+        displayTime = 0,
+        sessionId = sessionId,
+        sessionTitle = "",
+        startTime = 0,
+        timeText = "",
+    )
+
+    private fun createScheduleData(session: SessionAppModel): ScheduleData {
+        return ScheduleData(
+            dayIndex = dayIndex,
+            roomDataList = listOf(
+                RoomData(
+                    roomName = roomName,
+                    sessions = listOf(session),
+                )
+            )
+        )
+    }
+
+    private fun createSession(isHighlight: Boolean, hasAlarm: Boolean) = SessionAppModel(
+        sessionId = sessionId,
+        dayIndex = dayIndex,
+        roomName = roomName,
+        isHighlight = isHighlight,
+        hasAlarm = hasAlarm,
+    )
+
+}
+
+private class InMemoryAlarmRepository : AlarmsDatabaseRepository {
+
+    private var alarms = listOf<AlarmDatabaseModel>()
+
+    override fun update(values: ContentValues, sessionId: String): Long {
+        val alarm = AlarmDatabaseModel(sessionId = sessionId)
+        alarms = listOf(alarm)
+        return 0L
+    }
+
+    override fun query(): List<AlarmDatabaseModel> {
+        return alarms
+    }
+
+    override fun query(sessionId: String): List<AlarmDatabaseModel> {
+        throw NotImplementedError("Not needed for this test.")
+    }
+
+    override fun query(query: SQLiteDatabase.() -> Cursor): List<AlarmDatabaseModel> {
+        throw NotImplementedError("Not needed for this test.")
+    }
+
+    override fun deleteAll(): Int {
+        val affected = alarms.size
+        alarms = emptyList()
+        return affected
+    }
+
+    override fun deleteForAlarmId(alarmId: Int): Int {
+        val affected = alarms.size
+        alarms = emptyList()
+        return affected
+    }
+
+    override fun deleteForSessionId(sessionId: String): Int {
+        val affected = alarms.size
+        alarms = emptyList()
+        return affected
+    }
+
+    override fun delete(query: SQLiteDatabase.() -> Int): Int {
+        throw NotImplementedError("Not needed for this test.")
+    }
+
+}
+
+private class InMemoryHighlightsDatabaseRepository : HighlightsDatabaseRepository {
+
+    private var highlights = listOf<Highlight>()
+
+    override fun update(values: ContentValues, sessionId: String): Long {
+        val highlight = Highlight(
+            sessionId = sessionId.toInt(),
+            isHighlight = true,
+        )
+        highlights = listOf(highlight)
+        return 0L
+    }
+
+    override fun query(): List<Highlight> {
+        return highlights
+    }
+
+    override fun queryBySessionId(sessionId: Int): Highlight? {
+        return highlights.singleOrNull { it.sessionId == sessionId }
+    }
+
+    override fun delete(sessionId: String): Int {
+        val affected = highlights.size
+        highlights = emptyList()
+        return affected
+    }
+
+    override fun deleteAll(): Int {
+        val affected = highlights.size
+        highlights = emptyList()
+        return affected
+    }
+}
+
+private object StandardOutputExceptionHandler : ExceptionHandling {
+    override fun onExceptionHandling(context: CoroutineContext, throwable: Throwable) {
+        println("Exception: $throwable")
+    }
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.runTest
 import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.TestExecutionContext
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
-import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame.Known
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame.Unknown
 import nerd.tuxmobil.fahrplan.congress.models.DateInfo
@@ -255,19 +254,18 @@ class FahrplanViewModelTest {
         }
 
         @Test
-        fun `fahrplanParameter property emits FahrplanParameter containing session with alarm flag`() =
+        fun `fahrplanParameter property emits FahrplanParameter containing session with hasAlarm and isHighlight flags being set`() =
             runTest {
                 val repository = createRepository(
-                    uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData("session-01")),
+                    uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData("session-01", hasAlarm = true, isHighlight = true)),
                     sessionsWithoutShiftsFlow = flowOf(listOf(Session("not relevant"))),
                     meta = Meta(numDays = 1),
-                    alarmsFlow = flowOf(listOf(createAlarm("session-01"))),
                     displayDayIndex = 2
                 )
                 val menuEntriesGenerator = mock<NavigationMenuEntriesGenerator>()
                 val viewModel = createViewModel(repository, navigationMenuEntriesGenerator = menuEntriesGenerator)
                 val expected = FahrplanParameter(
-                    scheduleData = createScheduleData("session-01", hasAlarm = true),
+                    scheduleData = createScheduleData("session-01", hasAlarm = true, isHighlight = true),
                     useDeviceTimeZone = false,
                     numDays = 1,
                     dayIndex = 2,
@@ -677,7 +675,6 @@ class FahrplanViewModelTest {
         sessionsWithoutShiftsFlow: Flow<List<Session>> = emptyFlow(),
         loadUncanceledSessionsForDayIndex: ScheduleData = mock(),
         loadScheduleStateFlow: Flow<LoadScheduleState> = emptyFlow(),
-        alarmsFlow: Flow<List<Alarm>> = flowOf(emptyList()),
         meta: Meta = Meta(numDays = 0, version = "test-version"),
         isAutoUpdateEnabled: Boolean = true,
         displayDayIndex: Int = 0,
@@ -688,15 +685,14 @@ class FahrplanViewModelTest {
         on { sessionsWithoutShifts } doReturn sessionsWithoutShiftsFlow
         on { loadUncanceledSessionsForDayIndex() } doReturn loadUncanceledSessionsForDayIndex
         on { loadScheduleState } doReturn loadScheduleStateFlow
-        on { alarms } doReturn alarmsFlow
         on { readMeta() } doReturn meta
         on { readAutoUpdateEnabled() } doReturn isAutoUpdateEnabled
         on { readDisplayDayIndex() } doReturn displayDayIndex
         on { readDateInfos() } doReturn dateInfos
     }
 
-    private fun createScheduleData(sessionId: String? = null, hasAlarm: Boolean = false): ScheduleData {
-        val session = if (sessionId == null) null else Session(sessionId = sessionId, hasAlarm = hasAlarm)
+    private fun createScheduleData(sessionId: String? = null, hasAlarm: Boolean = false, isHighlight: Boolean = false): ScheduleData {
+        val session = if (sessionId == null) null else Session(sessionId = sessionId, hasAlarm = hasAlarm, isHighlight = isHighlight)
         return createScheduleData(session)
     }
 
@@ -727,16 +723,6 @@ class FahrplanViewModelTest {
         defaultEngelsystemRoomName = "Engelshifts",
         customEngelsystemRoomName = "Trollshifts",
         runsAtLeastOnAndroidTiramisu = runsAtLeastOnAndroidTiramisu
-    )
-
-    private fun createAlarm(@Suppress("SameParameterValue") sessionId: String) = Alarm(
-        alarmTimeInMin = 10,
-        day = 2,
-        displayTime = 0,
-        sessionId = sessionId,
-        sessionTitle = "Title",
-        startTime = 1536332400000L,
-        timeText = "Lorem ipsum"
     )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -274,8 +274,6 @@ class FahrplanViewModelTest {
                 viewModel.fahrplanParameter.test {
                     val actual = awaitItem()
                     assertThat(actual).isEqualTo(expected)
-                    // Obsolete once Session#hasAlarm is part of isEqual and hashCode
-                    assertThat(actual.scheduleData.allSessions.first().hasAlarm).isEqualTo(true)
                     awaitComplete()
                 }
                 viewModel.fahrplanEmptyParameter.test {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -251,7 +251,6 @@ class FahrplanViewModelTest {
             }
             verifyInvokedNever(menuEntriesGenerator).getDayMenuEntries(any(), anyOrNull(), any())
             verifyInvokedOnce(repository).readDisplayDayIndex()
-            verifyInvokedOnce(repository).readMeta()
         }
 
         @Test
@@ -279,7 +278,6 @@ class FahrplanViewModelTest {
                 }
                 verifyInvokedNever(menuEntriesGenerator).getDayMenuEntries(any(), anyOrNull(), any())
                 verifyInvokedOnce(repository).readDisplayDayIndex()
-                verifyInvokedOnce(repository).readMeta()
             }
 
     }
@@ -291,7 +289,10 @@ class FahrplanViewModelTest {
         fun `dayMenuEntries property emits and generates navigation menu entries`() = runTest {
             val repository = createRepository(
                 uncanceledSessionsForDayIndexFlow = flowOf(createScheduleData("session-01")),
-                sessionsWithoutShiftsFlow = flowOf(listOf(Session("session-01"))),
+                sessionsWithoutShiftsFlow = flowOf(listOf(
+                    Session("session-01", dateText = "2025-04-15"),
+                    Session("session-02", dateText = "2025-04-16")
+                )),
                 meta = Meta(numDays = 2),
                 displayDayIndex = 1,
             )
@@ -304,7 +305,6 @@ class FahrplanViewModelTest {
                 expectNoEvents()
             }
             verifyInvokedOnce(menuEntriesGenerator).getDayMenuEntries(any(), anyOrNull(), any())
-            verifyInvokedOnce(repository).readMeta()
         }
 
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/serialization/ScheduleChangesTest.kt
@@ -239,6 +239,22 @@ class ScheduleChangesTest {
                 expectedFoundNoteworthyChanges = true,
             ),
             scenario1Of(
+                scenarioDescription = "Alarm flags differ",
+                oldSessions = listOf(Session("1", hasAlarm = true)),
+                newSessions = listOf(Session("1", hasAlarm = false)),
+                expectedSessions = listOf(Session("1", hasAlarm = false)),
+                expectedOldCanceledSessions = emptyList(),
+                expectedFoundNoteworthyChanges = false,
+            ),
+            scenario1Of(
+                scenarioDescription = "Highlight flags differ",
+                oldSessions = listOf(Session("1", isHighlight = true)),
+                newSessions = listOf(Session("1", isHighlight = false)),
+                expectedSessions = listOf(Session("1", isHighlight = false)),
+                expectedOldCanceledSessions = emptyList(),
+                expectedFoundNoteworthyChanges = false,
+            ),
+            scenario1Of(
                 scenarioDescription = "Multiple properties differ",
                 oldSessions = listOf(
                     Session(


### PR DESCRIPTION
# Description
+ Unify the order of refreshable properties and related functions.
+ Unit test schedule refresh based on alarm/favorite creation resp. removal.
+ Remove redundant step to flag if session has an alarm.
+ Unit test that alarm & highlight flags are not relevant for schedule changes computation.
+ Let `Session#hasAlarm` & `isHighlight` properties be part of `equals` & `hashCode`.
+ Fix multiple room columns not rendering when device is rotated.
+ Cancel previous action block if new flow value is emitted.
+ Derive number of days from actual sessions when updating day menu.
+ Avoid updating `AppRepository` properties if no database is altered.

# Successfully tested on
with `ccc38c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
+ https://github.com/EventFahrplan/EventFahrplan/pull/734