### PR TITLE
Random housekeeping (dayIndex, sessionId, parseFahrplan, dateText).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
@@ -59,7 +59,7 @@ class AlarmReceiver : BroadcastReceiver() {
                 //Toast.makeText(context, "Alarm worked.", Toast.LENGTH_LONG).show();
 
                 val uniqueNotificationId = AppRepository.createSessionAlarmNotificationId(sessionId)
-                val launchIntent = createLaunchIntent(context, sessionId, day, uniqueNotificationId)
+                val launchIntent = createLaunchIntent(context, sessionId, dayIndex = day, notificationId = uniqueNotificationId)
                 val contentIntent = PendingIntentProvider.getPendingIntentActivity(context, launchIntent)
 
                 val notificationHelper = NotificationHelper(context)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmReceiver.kt
@@ -52,14 +52,14 @@ class AlarmReceiver : BroadcastReceiver() {
             }
             ALARM_SESSION -> {
                 val sessionId = intent.getStringExtra(BundleKeys.ALARM_SESSION_ID)!!
-                val day = intent.getIntExtra(BundleKeys.ALARM_DAY, 1)
+                val dayIndex = intent.getIntExtra(BundleKeys.ALARM_DAY_INDEX, 1)
                 val start = intent.getLongExtra(BundleKeys.ALARM_START_TIME, System.currentTimeMillis())
                 val title = intent.getStringExtra(BundleKeys.ALARM_TITLE)!!
                 logging.report(LOG_TAG, "sessionId = $sessionId, intent = $intent")
                 //Toast.makeText(context, "Alarm worked.", Toast.LENGTH_LONG).show();
 
                 val uniqueNotificationId = AppRepository.createSessionAlarmNotificationId(sessionId)
-                val launchIntent = createLaunchIntent(context, sessionId, dayIndex = day, notificationId = uniqueNotificationId)
+                val launchIntent = createLaunchIntent(context, sessionId, dayIndex = dayIndex, notificationId = uniqueNotificationId)
                 val contentIntent = PendingIntentProvider.getPendingIntentActivity(context, launchIntent)
 
                 val notificationHelper = NotificationHelper(context)
@@ -102,14 +102,14 @@ class AlarmReceiver : BroadcastReceiver() {
         val context: Context,
         val sessionId: String,
         val title: String,
-        val day: Int,
+        val dayIndex: Int,
         val startTime: Long,
     ) {
 
         fun getIntent(isAddAlarmIntent: Boolean) = Intent(context, AlarmReceiver::class.java)
             .withExtras(
                 BundleKeys.ALARM_SESSION_ID to sessionId,
-                BundleKeys.ALARM_DAY to day,
+                BundleKeys.ALARM_DAY_INDEX to dayIndex,
                 BundleKeys.ALARM_TITLE to title,
                 BundleKeys.ALARM_START_TIME to startTime
             ).apply {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -83,10 +83,10 @@ class AlarmServices @VisibleForTesting constructor(
         val alarmTimeInMin = alarmTimes[alarmTimesIndex]
         val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
         val timeText = formattingDelegate.getFormattedDateTimeShort(useDeviceTimeZone, alarmTime, session.timeZoneOffset)
-        val day = session.dayIndex
+        val dayIndex = session.dayIndex
         val alarm = Alarm(
             alarmTimeInMin = alarmTimeInMin,
-            day = day,
+            dayIndex = dayIndex,
             displayTime = sessionStartTime,
             sessionId = sessionId,
             sessionTitle = sessionTitle,
@@ -132,7 +132,7 @@ class AlarmServices @VisibleForTesting constructor(
             context = context,
             sessionId = alarm.sessionId,
             title = alarm.sessionTitle,
-            day = alarm.day,
+            dayIndex = alarm.dayIndex,
             startTime = alarm.startTime
         ).getIntent(isAddAlarmIntent = true)
 
@@ -156,7 +156,7 @@ class AlarmServices @VisibleForTesting constructor(
             context = context,
             sessionId = alarm.sessionId,
             title = alarm.sessionTitle,
-            day = alarm.day,
+            dayIndex = alarm.dayIndex,
             startTime = alarm.startTime
         ).getIntent(isAddAlarmIntent = false)
         discardAlarm(context, intent)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -84,7 +84,15 @@ class AlarmServices @VisibleForTesting constructor(
         val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
         val timeText = formattingDelegate.getFormattedDateTimeShort(useDeviceTimeZone, alarmTime, session.timeZoneOffset)
         val day = session.dayIndex
-        val alarm = Alarm(alarmTimeInMin, day, sessionStartTime, sessionId, sessionTitle, alarmTime, timeText)
+        val alarm = Alarm(
+            alarmTimeInMin = alarmTimeInMin,
+            day = day,
+            displayTime = sessionStartTime,
+            sessionId = sessionId,
+            sessionTitle = sessionTitle,
+            startTime = alarmTime,
+            timeText = timeText,
+        )
         val schedulableAlarm = alarm.toSchedulableAlarm()
         scheduleSessionAlarm(schedulableAlarm, true)
         repository.updateAlarm(alarm)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -52,7 +52,7 @@ internal class AlarmsViewModel(
         launch {
             repository.deleteAlarmForSessionId(value.sessionId)
             val alarm = SchedulableAlarm(
-                day = value.dayIndex,
+                dayIndex = value.dayIndex,
                 sessionId = value.sessionId,
                 sessionTitle = value.title,
                 startTime = value.firesAt,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -55,7 +55,7 @@ internal class AlarmsViewModel(
                 day = value.dayIndex,
                 sessionId = value.sessionId,
                 sessionTitle = value.title,
-                startTime = value.firesAt
+                startTime = value.firesAt,
             )
             alarmServices.discardSessionAlarm(alarm)
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -144,21 +144,21 @@ abstract class SessionsAdapter protected constructor(
         separatorStrings = mutableListOf()
         mapper = mutableListOf()
 
-        var day: Int
-        var lastDay = 0
+        var dayIndex: Int
+        var lastDayIndex = 0
         var sepCount = 0
 
         val daySeparator = context.getString(R.string.day_separator)
         for (index in list.indices) {
             val session = list[index]
-            day = session.dayIndex
+            dayIndex = session.dayIndex
             val formattedDate = DateFormatter.newInstance(useDeviceTimeZone)
                 .getFormattedDate(session.dateUTC, session.timeZoneOffset)
 
-            if (day != lastDay) {
-                lastDay = day
+            if (dayIndex != lastDayIndex) {
+                lastDayIndex = dayIndex
                 if (numDays > 1) {
-                    val dayDateSeparator = String.format(daySeparator, day, formattedDate)
+                    val dayDateSeparator = String.format(daySeparator, dayIndex, formattedDate)
                     separatorStrings.add(dayDateSeparator)
                     separatorsSet.add(index + sepCount)
                     mapper.add(sepCount)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
@@ -4,7 +4,7 @@ object BundleKeys {
 
     // Add + delete alarm
     const val ALARM_SESSION_ID = "nerd.tuxmobil.fahrplan.congress.ALARM_SESSION_ID"
-    const val ALARM_DAY = "nerd.tuxmobil.fahrplan.congress.ALARM_DAY"
+    const val ALARM_DAY_INDEX = "nerd.tuxmobil.fahrplan.congress.ALARM_DAY"
     const val ALARM_TITLE = "nerd.tuxmobil.fahrplan.congress.ALARM_TITLE"
     const val ALARM_START_TIME = "nerd.tuxmobil.fahrplan.congress.ALARM_START_TIME"
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
@@ -9,7 +9,7 @@ import info.metadude.android.eventfahrplan.database.models.Alarm as DatabaseAlar
 fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
     id = id,
     alarmTimeInMin = alarmTimeInMin,
-    day = day,
+    dayIndex = dayIndex,
     displayTime = displayTime,
     sessionId = sessionId,
     title = sessionTitle,
@@ -18,7 +18,7 @@ fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
 )
 
 fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
-    day = day,
+    dayIndex = dayIndex,
     sessionId = sessionId,
     sessionTitle = sessionTitle,
     startTime = startTime,
@@ -27,7 +27,7 @@ fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
 fun DatabaseAlarm.toAlarmAppModel() = Alarm(
     id = id,
     alarmTimeInMin = alarmTimeInMin,
-    day = day,
+    dayIndex = dayIndex,
     displayTime = displayTime,
     sessionId = sessionId,
     sessionTitle = title,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
@@ -7,30 +7,30 @@ import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import info.metadude.android.eventfahrplan.database.models.Alarm as DatabaseAlarm
 
 fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
-        id = id,
-        alarmTimeInMin = alarmTimeInMin,
-        day = day,
-        displayTime = displayTime,
-        sessionId = sessionId,
-        title = sessionTitle,
-        time = startTime,
-        timeText = timeText
+    id = id,
+    alarmTimeInMin = alarmTimeInMin,
+    day = day,
+    displayTime = displayTime,
+    sessionId = sessionId,
+    title = sessionTitle,
+    time = startTime,
+    timeText = timeText,
 )
 
 fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
-        day = day,
-        sessionId = sessionId,
-        sessionTitle = sessionTitle,
-        startTime = startTime
+    day = day,
+    sessionId = sessionId,
+    sessionTitle = sessionTitle,
+    startTime = startTime,
 )
 
 fun DatabaseAlarm.toAlarmAppModel() = Alarm(
-        id = id,
-        alarmTimeInMin = alarmTimeInMin,
-        day = day,
-        displayTime = displayTime,
-        sessionId = sessionId,
-        sessionTitle = title,
-        startTime = time,
-        timeText = timeText
+    id = id,
+    alarmTimeInMin = alarmTimeInMin,
+    day = day,
+    displayTime = displayTime,
+    sessionId = sessionId,
+    sessionTitle = title,
+    startTime = time,
+    timeText = timeText,
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensions.kt
@@ -25,7 +25,7 @@ fun SessionAppModel.toRoom() = Room(identifier = roomIdentifier, name = roomName
 fun SessionDatabaseModel.toDateInfo(): DateInfo = DateInfo(dayIndex, Moment.parseDate(dateText))
 
 fun SessionAppModel.toHighlightDatabaseModel() = HighlightDatabaseModel(
-        sessionId = Integer.parseInt(sessionId),
+        sessionId = sessionId,
         isHighlight = isHighlight
 )
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
@@ -3,35 +3,33 @@ package nerd.tuxmobil.fahrplan.congress.models
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract
 
 data class Alarm(
-
-        val id: Int,
-        val alarmTimeInMin: Int,
-        val day: Int,
-        val displayTime: Long,
-        val sessionId: String,
-        val sessionTitle: String,
-        val startTime: Long,
-        val timeText: String
-
+    val id: Int,
+    val alarmTimeInMin: Int,
+    val day: Int,
+    val displayTime: Long,
+    val sessionId: String,
+    val sessionTitle: String,
+    val startTime: Long,
+    val timeText: String,
 ) {
 
     constructor(
-            alarmTimeInMin: Int,
-            day: Int,
-            displayTime: Long,
-            sessionId: String,
-            sessionTitle: String,
-            startTime: Long,
-            timeText: String
+        alarmTimeInMin: Int,
+        day: Int,
+        displayTime: Long,
+        sessionId: String,
+        sessionTitle: String,
+        startTime: Long,
+        timeText: String,
     ) : this(
-            DEFAULT_VALUE_ID,
-            alarmTimeInMin,
-            day,
-            displayTime,
-            sessionId,
-            sessionTitle,
-            startTime,
-            timeText
+        id = DEFAULT_VALUE_ID,
+        alarmTimeInMin = alarmTimeInMin,
+        day = day,
+        displayTime = displayTime,
+        sessionId = sessionId,
+        sessionTitle = sessionTitle,
+        startTime = startTime,
+        timeText = timeText,
     )
 
     companion object {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
@@ -5,7 +5,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract
 data class Alarm(
     val id: Int,
     val alarmTimeInMin: Int,
-    val day: Int,
+    val dayIndex: Int,
     val displayTime: Long,
     val sessionId: String,
     val sessionTitle: String,
@@ -15,7 +15,7 @@ data class Alarm(
 
     constructor(
         alarmTimeInMin: Int,
-        day: Int,
+        dayIndex: Int,
         displayTime: Long,
         sessionId: String,
         sessionTitle: String,
@@ -24,7 +24,7 @@ data class Alarm(
     ) : this(
         id = DEFAULT_VALUE_ID,
         alarmTimeInMin = alarmTimeInMin,
-        day = day,
+        dayIndex = dayIndex,
         displayTime = displayTime,
         sessionId = sessionId,
         sessionTitle = sessionTitle,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
@@ -1,10 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.models
 
 data class SchedulableAlarm(
-
-        val day: Int,
-        val sessionId: String,
-        val sessionTitle: String,
-        val startTime: Long
-
+    val day: Int,
+    val sessionId: String,
+    val sessionTitle: String,
+    val startTime: Long,
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/SchedulableAlarm.kt
@@ -1,7 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.models
 
 data class SchedulableAlarm(
-    val day: Int,
+    val dayIndex: Int,
     val sessionId: String,
     val sessionTitle: String,
     val startTime: Long,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -753,7 +753,7 @@ object AppRepository : SearchRepository,
         val highlightedSessionIds = readHighlights()
             .asSequence()
             .filter { it.isHighlight }
-            .map { it.sessionId.toString() }
+            .map { it.sessionId }
             .toSet()
 
         val highlightedSessions = sessions.map { session ->
@@ -866,7 +866,7 @@ object AppRepository : SearchRepository,
             .querySessionBySessionId(sessionId)
 
         val isHighlighted = highlightsDatabaseRepository
-            .queryBySessionId(sessionId.toInt())
+            .queryBySessionId(sessionId)
             ?.isHighlight ?: false
 
         val hasAlarm = alarmsDatabaseRepository

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -35,7 +35,12 @@ class AlarmServicesTest {
     private var mockContext = mock<Context>()
     private var repository = mock<AppRepository>()
     private val alarmTimesValues = listOf("0", "10", "60")
-    private val alarm = SchedulableAlarm(3, "1001", "Welcome", 700)
+    private val alarm = SchedulableAlarm(
+        day = 3,
+        sessionId = "1001",
+        sessionTitle = "Welcome",
+        startTime = 700,
+    )
 
     @Test
     fun `newInstance returns a new preconfigured instance of the AlarmServices class`() {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -36,7 +36,7 @@ class AlarmServicesTest {
     private var repository = mock<AppRepository>()
     private val alarmTimesValues = listOf("0", "10", "60")
     private val alarm = SchedulableAlarm(
-        day = 3,
+        dayIndex = 3,
         sessionId = "1001",
         sessionTitle = "Welcome",
         startTime = 700,
@@ -72,7 +72,7 @@ class AlarmServicesTest {
         // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
         val expectedAlarm = Alarm(
             alarmTimeInMin = 60,
-            day = 1,
+            dayIndex = 1,
             displayTime = 1536332400000,
             sessionId = "S1",
             sessionTitle = "Title",
@@ -197,7 +197,7 @@ class AlarmServicesTest {
 
     // TODO Move into a unit test for AlarmReceiver once it is written.
     private fun assertIntentExtras(intent: Intent, action: String) {
-        assertThat(intent.getIntExtra(BundleKeys.ALARM_DAY, 9)).isEqualTo(alarm.day)
+        assertThat(intent.getIntExtra(BundleKeys.ALARM_DAY_INDEX, 9)).isEqualTo(alarm.dayIndex)
         assertThat(intent.getStringExtra(BundleKeys.ALARM_SESSION_ID)).isEqualTo(alarm.sessionId)
         assertThat(intent.getLongExtra(BundleKeys.ALARM_START_TIME, 0)).isEqualTo(alarm.startTime)
         assertThat(intent.getStringExtra(BundleKeys.ALARM_TITLE)).isEqualTo(alarm.sessionTitle)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -159,7 +159,7 @@ class AlarmsStateFactoryTest {
         alarmStartsAt: Long = 1620909000000,
     ) = Alarm(
         alarmTimeInMin = alarmTimeInMin,
-        day = 2,
+        dayIndex = 2,
         displayTime = -1,
         sessionId = sessionId,
         sessionTitle = "Unused",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -210,7 +210,7 @@ class AlarmsViewModelTest {
         alarmStartsAt: Long = 1620909000000
     ) = Alarm(
         alarmTimeInMin = alarmTimeInMin,
-        day = 2,
+        dayIndex = 2,
         displayTime = -1,
         sessionId = sessionId,
         sessionTitle = "Unused",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
@@ -11,13 +11,13 @@ class AlarmExtensionsTest {
     @Test
     fun toAlarmAppModel_toAlarmDatabaseModel() {
         val alarm = AlarmDatabaseModel(
-                alarmTimeInMin = 20,
-                day = 4,
-                displayTime = 1509617700000L,
-                sessionId = "5237",
-                time = 1509617700001L,
-                timeText = "02/11/2017 11:05",
-                title = "My title"
+            alarmTimeInMin = 20,
+            day = 4,
+            displayTime = 1509617700000L,
+            sessionId = "5237",
+            time = 1509617700001L,
+            timeText = "02/11/2017 11:05",
+            title = "My title",
         )
         assertThat(alarm.toAlarmAppModel().toAlarmDatabaseModel()).isEqualTo(alarm)
     }
@@ -25,19 +25,19 @@ class AlarmExtensionsTest {
     @Test
     fun toSchedulableAlarm() {
         val alarm = Alarm(
-                alarmTimeInMin = 20,
-                day = 4,
-                displayTime = 1509617700000L,
-                sessionId = "5237",
-                sessionTitle = "My title",
-                startTime = 1509617700001L,
-                timeText = "02/11/2017 11:05"
+            alarmTimeInMin = 20,
+            day = 4,
+            displayTime = 1509617700000L,
+            sessionId = "5237",
+            sessionTitle = "My title",
+            startTime = 1509617700001L,
+            timeText = "02/11/2017 11:05",
         )
         val schedulableAlarm = SchedulableAlarm(
-                day = 4,
-                sessionId = "5237",
-                sessionTitle = "My title",
-                startTime = 1509617700001L
+            day = 4,
+            sessionId = "5237",
+            sessionTitle = "My title",
+            startTime = 1509617700001L,
         )
         assertThat(alarm.toSchedulableAlarm()).isEqualTo(schedulableAlarm)
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
@@ -12,7 +12,7 @@ class AlarmExtensionsTest {
     fun toAlarmAppModel_toAlarmDatabaseModel() {
         val alarm = AlarmDatabaseModel(
             alarmTimeInMin = 20,
-            day = 4,
+            dayIndex = 4,
             displayTime = 1509617700000L,
             sessionId = "5237",
             time = 1509617700001L,
@@ -26,7 +26,7 @@ class AlarmExtensionsTest {
     fun toSchedulableAlarm() {
         val alarm = Alarm(
             alarmTimeInMin = 20,
-            day = 4,
+            dayIndex = 4,
             displayTime = 1509617700000L,
             sessionId = "5237",
             sessionTitle = "My title",
@@ -34,7 +34,7 @@ class AlarmExtensionsTest {
             timeText = "02/11/2017 11:05",
         )
         val schedulableAlarm = SchedulableAlarm(
-            day = 4,
+            dayIndex = 4,
             sessionId = "5237",
             sessionTitle = "My title",
             startTime = 1509617700001L,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionExtensionsTest.kt
@@ -251,7 +251,7 @@ class SessionExtensionsTest {
             sessionId = "4723",
             isHighlight = true,
         )
-        val highlight = Highlight(sessionId = 4723, isHighlight = true)
+        val highlight = Highlight(sessionId = "4723", isHighlight = true)
         assertThat(session.toHighlightDatabaseModel()).isEqualTo(highlight)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -257,7 +257,7 @@ class AppRepositoryLoadAndParseScheduleTest {
             "23"
         )
         whenever(highlightsDatabaseRepository.queryBySessionId(any())) doReturn DatabaseHighlight(
-            sessionId = 23,
+            sessionId = "23",
             isHighlight = false
         )
         whenever(alarmsDatabaseRepository.query(anyString())) doReturn emptyList()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
@@ -340,7 +340,7 @@ private class InMemoryHighlightsDatabaseRepository : HighlightsDatabaseRepositor
 
     override fun update(values: ContentValues, sessionId: String): Long {
         val highlight = Highlight(
-            sessionId = sessionId.toInt(),
+            sessionId = sessionId,
             isHighlight = true,
         )
         highlights = listOf(highlight)
@@ -351,7 +351,7 @@ private class InMemoryHighlightsDatabaseRepository : HighlightsDatabaseRepositor
         return highlights
     }
 
-    override fun queryBySessionId(sessionId: Int): Highlight? {
+    override fun queryBySessionId(sessionId: String): Highlight? {
         return highlights.singleOrNull { it.sessionId == sessionId }
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
@@ -258,7 +258,7 @@ class AppRepositoryUncanceledSessionsForDayIndexTest {
 
     private fun createAlarm() = AlarmAppModel(
         alarmTimeInMin = 0,
-        day = dayIndex,
+        dayIndex = dayIndex,
         displayTime = 0,
         sessionId = sessionId,
         sessionTitle = "",

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
@@ -2,7 +2,7 @@ package info.metadude.android.eventfahrplan.database.extensions
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
@@ -17,7 +17,7 @@ class AlarmExtensionsTest {
     fun toContentValues() {
         val alarm = Alarm(
             alarmTimeInMin = 20,
-            day = 4,
+            dayIndex = 4,
             displayTime = 1509617700000L,
             sessionId = "5237",
             time = 1509617700001L,
@@ -26,7 +26,7 @@ class AlarmExtensionsTest {
         )
         val values = alarm.toContentValues()
         assertThat(values.getAsInteger(ALARM_TIME_IN_MIN)).isEqualTo(20)
-        assertThat(values.getAsInteger(DAY)).isEqualTo(4)
+        assertThat(values.getAsInteger(DAY_INDEX)).isEqualTo(4)
         assertThat(values.getAsLong(DISPLAY_TIME)).isEqualTo(1509617700000L)
         assertThat(values.getAsString(SESSION_ID)).isEqualTo("5237")
         assertThat(values.getAsLong(TIME)).isEqualTo(1509617700001L)

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
@@ -16,13 +16,13 @@ class AlarmExtensionsTest {
     @Test
     fun toContentValues() {
         val alarm = Alarm(
-                alarmTimeInMin = 20,
-                day = 4,
-                displayTime = 1509617700000L,
-                sessionId = "5237",
-                time = 1509617700001L,
-                timeText = "02/11/2017 11:05",
-                title = "My title"
+            alarmTimeInMin = 20,
+            day = 4,
+            displayTime = 1509617700000L,
+            sessionId = "5237",
+            time = 1509617700001L,
+            timeText = "02/11/2017 11:05",
+            title = "My title",
         )
         val values = alarm.toContentValues()
         assertThat(values.getAsInteger(ALARM_TIME_IN_MIN)).isEqualTo(20)

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
@@ -11,8 +11,8 @@ class HighlightExtensionsTest {
     @Test
     fun toContentValues() {
         val highlight = Highlight(
-                sessionId = 2342,
-                isHighlight = true
+            sessionId = 2342,
+            isHighlight = true
         )
         val values = highlight.toContentValues()
         assertThat(values.getAsInteger(SESSION_ID)).isEqualTo(2342)

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/HighlightExtensionsTest.kt
@@ -11,7 +11,7 @@ class HighlightExtensionsTest {
     @Test
     fun toContentValues() {
         val highlight = Highlight(
-            sessionId = 2342,
+            sessionId = "2342",
             isHighlight = true
         )
         val values = highlight.toContentValues()

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensionsTest.kt
@@ -16,7 +16,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_TEXT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_UTC
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
@@ -88,7 +88,7 @@ class SessionExtensionsTest {
         val values = session.toContentValues()
         assertThat(values.getAsInteger(SESSION_ID)).isEqualTo(7331)
         assertThat(values.getAsString(ABSTRACT)).isEqualTo("Lorem ipsum")
-        assertThat(values.getAsInteger(DAY)).isEqualTo(3)
+        assertThat(values.getAsInteger(DAY_INDEX)).isEqualTo(3)
         assertThat(values.getAsString(DATE_TEXT)).isEqualTo("2015-08-13")
         assertThat(values.getAsLong(DATE_UTC)).isEqualTo(1439478900000L)
         assertThat(values.getAsString(DESCR)).isEqualTo("Lorem ipsum dolor sit amet")

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -42,7 +42,7 @@ public interface FahrplanContract {
             /* 4 */ String TIME_TEXT = "timeText";
             /* 5 */ String SESSION_ID = "eventid"; // Keep column name to avoid database migration.
             /* 6 */ String DISPLAY_TIME = "displayTime";
-            /* 7 */ String DAY = "day";
+            /* 7 */ String DAY_INDEX = "day";
         }
 
         interface Defaults {
@@ -93,7 +93,7 @@ public interface FahrplanContract {
             /* 00 */ String SESSION_ID = "event_id"; // Keep column name to avoid database migration.
             /* 01 */ String TITLE = "title";
             /* 02 */ String SUBTITLE = "subtitle";
-            /* 03 */ String DAY = "day";
+            /* 03 */ String DAY_INDEX = "day";
             /* 04 */ String ROOM_NAME = "room";
             /* 05 */ String START = "start";
             /* 06 */ String DURATION = "duration";

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
@@ -2,7 +2,7 @@ package info.metadude.android.eventfahrplan.database.extensions
 
 import androidx.core.content.contentValuesOf
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
@@ -12,7 +12,7 @@ import info.metadude.android.eventfahrplan.database.models.Alarm
 
 fun Alarm.toContentValues() = contentValuesOf(
         ALARM_TIME_IN_MIN to alarmTimeInMin,
-        DAY to day,
+        DAY_INDEX to dayIndex,
         DISPLAY_TIME to displayTime,
         SESSION_ID to sessionId,
         SESSION_TITLE to title,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/SessionExtensions.kt
@@ -18,7 +18,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_TEXT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_UTC
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
@@ -47,7 +47,7 @@ import info.metadude.android.eventfahrplan.database.models.Session
 fun Session.toContentValues() = contentValuesOf(
         SESSION_ID to sessionId,
         ABSTRACT to abstractt,
-        DAY to dayIndex,
+        DAY_INDEX to dayIndex,
         DATE_TEXT to dateText,
         DATE_UTC to dateUTC,
         DESCR to description,

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
@@ -6,7 +6,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Al
 data class Alarm(
     val id: Int = DEFAULT_VALUE_ID,
     val alarmTimeInMin: Int = ALARM_TIME_IN_MIN_DEFAULT,
-    val day: Int = -1,
+    val dayIndex: Int = -1,
     val displayTime: Long = -1, // will be stored as signed integer
     val sessionId: String = "",
     val time: Long = -1, // will be stored as signed integer

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
@@ -4,14 +4,12 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Al
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Defaults.DEFAULT_VALUE_ID
 
 data class Alarm(
-
-        val id: Int = DEFAULT_VALUE_ID,
-        val alarmTimeInMin: Int = ALARM_TIME_IN_MIN_DEFAULT,
-        val day: Int = -1,
-        val displayTime: Long = -1, // will be stored as signed integer
-        val sessionId: String = "",
-        val time: Long = -1, // will be stored as signed integer
-        val timeText: String = "",
-        val title: String = ""
-
+    val id: Int = DEFAULT_VALUE_ID,
+    val alarmTimeInMin: Int = ALARM_TIME_IN_MIN_DEFAULT,
+    val day: Int = -1,
+    val displayTime: Long = -1, // will be stored as signed integer
+    val sessionId: String = "",
+    val time: Long = -1, // will be stored as signed integer
+    val timeText: String = "",
+    val title: String = "",
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
@@ -1,6 +1,6 @@
 package info.metadude.android.eventfahrplan.database.models
 
 data class Highlight(
-    val sessionId: Int,
+    val sessionId: String,
     val isHighlight: Boolean,
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Highlight.kt
@@ -1,8 +1,6 @@
 package info.metadude.android.eventfahrplan.database.models
 
 data class Highlight(
-
-        val sessionId: Int,
-        val isHighlight: Boolean
-
+    val sessionId: Int,
+    val isHighlight: Boolean,
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/HighlightsDatabaseRepository.kt
@@ -14,7 +14,7 @@ interface HighlightsDatabaseRepository {
 
     fun update(values: ContentValues, sessionId: String): Long
     fun query(): List<Highlight>
-    fun queryBySessionId(sessionId: Int): Highlight?
+    fun queryBySessionId(sessionId: String): Highlight?
     fun delete(sessionId: String): Int
     fun deleteAll(): Int
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
@@ -6,7 +6,7 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
@@ -63,7 +63,7 @@ internal class RealAlarmsDatabaseRepository(
         val alarms = cursor.map {
             Alarm(
                 id = cursor.getInt(ID),
-                day = cursor.getInt(DAY),
+                dayIndex = cursor.getInt(DAY_INDEX),
                 sessionId = cursor.getString(SESSION_ID),
                 time = cursor.getLong(TIME),
                 title = cursor.getString(SESSION_TITLE),

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealAlarmsDatabaseRepository.kt
@@ -62,11 +62,11 @@ internal class RealAlarmsDatabaseRepository(
 
         val alarms = cursor.map {
             Alarm(
-                    id = cursor.getInt(ID),
-                    day = cursor.getInt(DAY),
-                    sessionId = cursor.getString(SESSION_ID),
-                    time = cursor.getLong(TIME),
-                    title = cursor.getString(SESSION_TITLE)
+                id = cursor.getInt(ID),
+                day = cursor.getInt(DAY),
+                sessionId = cursor.getString(SESSION_ID),
+                time = cursor.getLong(TIME),
+                title = cursor.getString(SESSION_TITLE),
             )
         }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealHighlightsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealHighlightsDatabaseRepository.kt
@@ -46,8 +46,7 @@ internal class RealHighlightsDatabaseRepository(
         }
 
         return cursor.map {
-            val sessionIdString = cursor.getString(SESSION_ID)
-            val sessionId = Integer.parseInt(sessionIdString)
+            val sessionId = cursor.getString(SESSION_ID)
             val highlightState = cursor.getInt(HIGHLIGHT)
             val isHighlighted = highlightState == HIGHLIGHT_STATE_ON
 
@@ -55,13 +54,13 @@ internal class RealHighlightsDatabaseRepository(
         }
     }
 
-    override fun queryBySessionId(sessionId: Int): Highlight? {
+    override fun queryBySessionId(sessionId: String): Highlight? {
         val database = sqLiteOpenHelper.readableDatabase
         val cursor = try {
             database.read(
                 tableName = HighlightsTable.NAME,
                 selection = "$SESSION_ID=?",
-                selectionArgs = arrayOf(sessionId.toString())
+                selectionArgs = arrayOf(sessionId)
             )
         } catch (e: SQLiteException) {
             return null

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/repositories/RealSessionsDatabaseRepository.kt
@@ -23,7 +23,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_TEXT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_UTC
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
@@ -208,7 +208,7 @@ internal class RealSessionsDatabaseRepository(
 
     override fun querySessionsForDayIndexOrderedByDateUtc(dayIndex: Int) = query {
         read(SessionsTable.NAME,
-                selection = "$DAY=?",
+                selection = "$DAY_INDEX=?",
                 selectionArgs = arrayOf(String.format("%d", dayIndex)),
                 orderBy = DATE_UTC)
     }
@@ -253,7 +253,7 @@ internal class RealSessionsDatabaseRepository(
                     abstractt = cursor.getString(ABSTRACT),
                     dateText = cursor.getString(DATE_TEXT),
                     dateUTC = cursor.getLong(DATE_UTC),
-                    dayIndex = cursor.getInt(DAY),
+                    dayIndex = cursor.getInt(DAY_INDEX),
                     description = cursor.getString(DESCR),
                     duration = cursor.getInt(DURATION),
                     feedbackUrl = cursor.getStringOrNull(FEEDBACK_URL),
@@ -313,7 +313,7 @@ internal class RealSessionsDatabaseRepository(
                             columnNamePresent = SUBTITLE_PRESENT,
                         ),
                         cursor.toColumnStatistic(
-                            name = DAY,
+                            name = DAY_INDEX,
                             columnNameNone = DAY_INDEX_NONE,
                             columnNamePresent = DAY_INDEX_PRESENT,
                         ),

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
@@ -36,7 +36,7 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
                 "$TIME_TEXT TEXT, " +
                 "$SESSION_ID INTEGER, " +
                 "$DISPLAY_TIME INTEGER, " +
-                "$DAY INTEGER" +
+                "$DAY_INDEX INTEGER" +
                 ");"
     }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/SessionsDBOpenHelper.kt
@@ -22,7 +22,7 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.Se
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.CHANGED_TRACK
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_TEXT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DATE_UTC
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY
+import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DAY_INDEX
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DESCR
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.DURATION
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.SessionsTable.Columns.FEEDBACK_URL
@@ -117,7 +117,7 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
                 "$SESSION_ID TEXT, " +
                 "$TITLE TEXT, " +
                 "$SUBTITLE TEXT, " +
-                "$DAY INTEGER, " +
+                "$DAY_INDEX INTEGER, " +
                 "$ROOM_NAME TEXT, " +
                 "$ROOM_IDENTIFIER TEXT DEFAULT '', " +
                 "$SLUG TEXT, " +
@@ -169,8 +169,8 @@ internal class SessionsDBOpenHelper(context: Context) : SQLiteOpenHelper(
                     "COUNT(CASE WHEN $TITLE IS NOT NULL AND $TITLE != '' THEN 1 END) AS $TITLE_PRESENT, " +
                     "COUNT(CASE WHEN $SUBTITLE IS NULL OR $SUBTITLE = '' THEN 1 END) AS $SUBTITLE_NONE, " +
                     "COUNT(CASE WHEN $SUBTITLE IS NOT NULL AND $SUBTITLE != '' THEN 1 END) AS $SUBTITLE_PRESENT, " +
-                    "COUNT(CASE WHEN $DAY IS NULL OR $DAY = '' THEN 1 END) AS $DAY_INDEX_NONE, " +
-                    "COUNT(CASE WHEN $DAY IS NOT NULL AND $DAY != '' THEN 1 END) AS $DAY_INDEX_PRESENT, " +
+                    "COUNT(CASE WHEN $DAY_INDEX IS NULL OR $DAY_INDEX = '' THEN 1 END) AS $DAY_INDEX_NONE, " +
+                    "COUNT(CASE WHEN $DAY_INDEX IS NOT NULL AND $DAY_INDEX != '' THEN 1 END) AS $DAY_INDEX_PRESENT, " +
                     "COUNT(CASE WHEN $ROOM_NAME IS NULL OR $ROOM_NAME = '' THEN 1 END) AS $ROOM_NAME_NONE, " +
                     "COUNT(CASE WHEN $ROOM_NAME IS NOT NULL AND $ROOM_NAME != '' THEN 1 END) AS $ROOM_NAME_PRESENT, " +
                     "COUNT(CASE WHEN $START IS NULL OR $START = '' THEN 1 END) AS $START_TIME_NONE, " +

--- a/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/utils/UriParser.kt
+++ b/engelsystem/src/main/java/info/metadude/android/eventfahrplan/engelsystem/utils/UriParser.kt
@@ -43,7 +43,7 @@ class UriParser {
             else path.trimStart('/')
 
     /**
-     * The API key provides as a query parameter value, as in: ?key=a1b2c3
+     * The API key provided as a query parameter value, as in: ?key=a1b2c3
      */
     private fun parseApiKey(query: String?) = try {
         val queryPart = query ?: throw ParsingException("Query is missing")

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -15,9 +15,11 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import info.metadude.android.eventfahrplan.commons.logging.Logging;
 import info.metadude.android.eventfahrplan.network.models.HttpHeader;
@@ -73,6 +75,8 @@ public class FahrplanParser {
 }
 
 class ParserTask extends AsyncTask<String, Void, Boolean> {
+
+    private static final String LOG_TAG = "ParserTask";
 
     @NonNull
     private final Logging logging;
@@ -143,6 +147,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
             int day = 0;
             int dayChangeTime = 600; // Only provided by Pentabarf; corresponds to 10:00 am.
             String dateText = "";
+            Set<String> uniqueDateTexts = new HashSet<>();
             int roomIndex = 0;
             int roomMapIndex = 0;
             boolean scheduleComplete = false;
@@ -171,6 +176,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                             String index = parser.getAttributeValue(null, "index");
                             day = Integer.parseInt(index);
                             dateText = parser.getAttributeValue(null, "date");
+                            uniqueDateTexts.add(dateText);
                             String end = parser.getAttributeValue(null, "end");
                             if (end == null) {
                                 throw new MissingXmlAttributeException("day", "end");
@@ -205,6 +211,9 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
             }
             if (isCancelled()) {
                 return false;
+            }
+            if (uniqueDateTexts.size() != numdays) {
+                logging.e(LOG_TAG, "Count of dateTexts " + uniqueDateTexts + " and numdays " + numdays + " mismatch.");
             }
             meta.setNumDays(numdays);
             return true;

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -9,7 +9,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
 
+import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -190,174 +192,9 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                             roomGuid = parser.getAttributeValue(null, "guid");
                         }
                         if (name.equalsIgnoreCase("event")) {
-                            String id = parser.getAttributeValue(null, "id");
-                            Session session = new Session();
-                            session.setSessionId(id);
-                            session.setDayIndex(day);
-                            session.setRoomName(Objects.requireNonNullElse(roomName, ""));
-                            session.setRoomGuid(Objects.requireNonNullElse(roomGuid, ""));
-                            session.setDateText(dateText);
-                            session.setRoomIndex(roomMapIndex);
-                            eventType = parser.next();
-                            boolean isSessionDone = false;
-                            while (eventType != XmlPullParser.END_DOCUMENT
-                                    && !isSessionDone && !isCancelled()) {
-                                switch (eventType) {
-                                    case XmlPullParser.END_TAG:
-                                        name = parser.getName();
-                                        if (name.equals("event")) {
-                                            sessions.add(session);
-                                            isSessionDone = true;
-                                        }
-                                        break;
-                                    case XmlPullParser.START_TAG:
-                                        name = parser.getName();
-                                        //noinspection IfCanBeSwitch
-                                        if (name.equals("title")) {
-                                            parser.next();
-                                            session.setTitle(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("subtitle")) {
-                                            parser.next();
-                                            session.setSubtitle(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("slug")) {
-                                            parser.next();
-                                            session.setSlug(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("feedback_url")) {
-                                            parser.next();
-                                            session.setFeedbackUrl(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("url")) {
-                                            parser.next();
-                                            session.setUrl(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("track")) {
-                                            parser.next();
-                                            session.setTrack(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("type")) {
-                                            parser.next();
-                                            session.setType(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("language")) {
-                                            parser.next();
-                                            session.setLanguage(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("abstract")) {
-                                            parser.next();
-                                            session.setAbstractt(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("description")) {
-                                            parser.next();
-                                            session.setDescription(XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("person")) {
-                                            parser.next();
-                                            String separator = !session.getSpeakers().isEmpty() ? ";" : "";
-                                            session.setSpeakers(session.getSpeakers() + separator + XmlPullParsers.getSanitizedText(parser));
-                                        } else if (name.equals("link")) {
-                                            String url = parser.getAttributeValue(null, "href");
-                                            parser.next();
-                                            String urlName = XmlPullParsers.getSanitizedText(parser);
-                                            if (url == null) {
-                                                url = urlName;
-                                            }
-                                            if (!url.contains("://")) {
-                                                url = "http://" + url;
-                                            }
-                                            StringBuilder sb = new StringBuilder();
-                                            if (!session.getLinks().isEmpty()) {
-                                                sb.append(session.getLinks());
-                                                sb.append(",");
-                                            }
-                                            sb.append("[").append(urlName).append("]").append("(")
-                                                    .append(url).append(")");
-                                            session.setLinks(sb.toString());
-                                        } else if (name.equals("start")) {
-                                            parser.next();
-                                            session.setStartTime(DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser)));
-                                            session.setRelativeStartTime(session.getStartTime());
-                                            if (session.getRelativeStartTime() < dayChangeTime) {
-                                                session.setRelativeStartTime(session.getRelativeStartTime() + MINUTES_OF_ONE_DAY);
-                                            }
-                                        } else if (name.equals("duration")) {
-                                            parser.next();
-                                            int minutes = DurationParser.getMinutes(XmlPullParsers.getSanitizedText(parser));
-                                            session.setDuration(minutes);
-                                        } else if (name.equals("date")) {
-                                            parser.next();
-                                            String sanitizedText = XmlPullParsers.getSanitizedText(parser);
-                                            session.setDateUTC(DateParser.getDateTime(sanitizedText));
-                                            session.setTimeZoneOffset(info.metadude.android.eventfahrplan.commons.temporal.DateParser.parseTimeZoneOffset(sanitizedText));
-                                        } else if (name.equals("recording")) {
-                                            eventType = parser.next();
-                                            boolean recordingDone = false;
-                                            while (eventType != XmlPullParser.END_DOCUMENT
-                                                    && !recordingDone && !isCancelled()) {
-                                                switch (eventType) {
-                                                    case XmlPullParser.END_TAG:
-                                                        name = parser.getName();
-                                                        if (name.equals("recording")) {
-                                                            recordingDone = true;
-                                                        }
-                                                        break;
-                                                    case XmlPullParser.START_TAG:
-                                                        name = parser.getName();
-                                                        if (name.equals("license")) {
-                                                            parser.next();
-                                                            session.setRecordingLicense(XmlPullParsers.getSanitizedText(parser));
-                                                        } else if (name.equals("optout")) {
-                                                            parser.next();
-                                                            session.setRecordingOptOut(Boolean.parseBoolean(XmlPullParsers.getSanitizedText(parser)));
-                                                        }
-                                                        break;
-                                                }
-                                                if (recordingDone) {
-                                                    break;
-                                                }
-                                                eventType = parser.next();
-                                            }
-                                        }
-                                        break;
-                                }
-                                if (isSessionDone) {
-                                    break;
-                                }
-                                eventType = parser.next();
-                            }
+                            parseEvent(parser, day, dayChangeTime, roomMapIndex, roomName, roomGuid, dateText);
                         } else if (name.equalsIgnoreCase("conference")) {
-                            boolean confDone = false;
-                            eventType = parser.next();
-                            while (eventType != XmlPullParser.END_DOCUMENT
-                                    && !confDone) {
-                                switch (eventType) {
-                                    case XmlPullParser.END_TAG:
-                                        name = parser.getName();
-                                        if (name.equals("conference")) {
-                                            confDone = true;
-                                        }
-                                        break;
-                                    case XmlPullParser.START_TAG:
-                                        name = parser.getName();
-                                        if (name.equals("subtitle")) {
-                                            parser.next();
-                                            meta.setSubtitle(XmlPullParsers.getSanitizedText(parser));
-                                        }
-                                        if (name.equals("title")) {
-                                            parser.next();
-                                            meta.setTitle(XmlPullParsers.getSanitizedText(parser));
-                                        }
-                                        if (name.equals("release")) {
-                                            parser.next();
-                                            meta.setVersion(XmlPullParsers.getSanitizedText(parser));
-                                        }
-                                        if (name.equals("day_change")) {
-                                            parser.next();
-                                            dayChangeTime = DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser));
-                                        }
-                                        if (name.equals("time_zone_name")) {
-                                            parser.next();
-                                            meta.setTimeZoneName(XmlPullParsers.getSanitizedText(parser));
-                                        }
-                                        break;
-                                }
-                                if (confDone) {
-                                    break;
-                                }
-                                eventType = parser.next();
-                            }
+                            dayChangeTime = parseConference(parser, dayChangeTime);
                         }
                         break;
                 }
@@ -374,6 +211,191 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
         } catch (Exception e) {
             e.printStackTrace();
             return false;
+        }
+    }
+
+    private int parseConference(
+            XmlPullParser parser,
+            int dayChangeTime
+    ) throws IOException, XmlPullParserException {
+        String name;
+        int eventType;
+        boolean confDone = false;
+        eventType = parser.next();
+        while (eventType != XmlPullParser.END_DOCUMENT && !confDone) {
+            switch (eventType) {
+                case XmlPullParser.END_TAG:
+                    name = parser.getName();
+                    if (name.equals("conference")) {
+                        confDone = true;
+                    }
+                    break;
+                case XmlPullParser.START_TAG:
+                    name = parser.getName();
+                    if (name.equals("subtitle")) {
+                        parser.next();
+                        meta.setSubtitle(XmlPullParsers.getSanitizedText(parser));
+                    }
+                    if (name.equals("title")) {
+                        parser.next();
+                        meta.setTitle(XmlPullParsers.getSanitizedText(parser));
+                    }
+                    if (name.equals("release")) {
+                        parser.next();
+                        meta.setVersion(XmlPullParsers.getSanitizedText(parser));
+                    }
+                    if (name.equals("day_change")) {
+                        parser.next();
+                        dayChangeTime = DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser));
+                    }
+                    if (name.equals("time_zone_name")) {
+                        parser.next();
+                        meta.setTimeZoneName(XmlPullParsers.getSanitizedText(parser));
+                    }
+                    break;
+            }
+            if (confDone) {
+                break;
+            }
+            eventType = parser.next();
+        }
+        return dayChangeTime;
+    }
+
+    private void parseEvent(
+            XmlPullParser parser,
+            int day,
+            int dayChangeTime,
+            int roomMapIndex,
+            String roomName,
+            String roomGuid,
+            String dateText
+    ) throws IOException, XmlPullParserException {
+        String name;
+        int eventType;
+        String id = parser.getAttributeValue(null, "id");
+        Session session = new Session();
+        session.setSessionId(id);
+        session.setDayIndex(day);
+        session.setRoomName(Objects.requireNonNullElse(roomName, ""));
+        session.setRoomGuid(Objects.requireNonNullElse(roomGuid, ""));
+        session.setDateText(dateText);
+        session.setRoomIndex(roomMapIndex);
+        eventType = parser.next();
+        boolean isSessionDone = false;
+        while (eventType != XmlPullParser.END_DOCUMENT && !isSessionDone && !isCancelled()) {
+            switch (eventType) {
+                case XmlPullParser.END_TAG:
+                    name = parser.getName();
+                    if (name.equals("event")) {
+                        sessions.add(session);
+                        isSessionDone = true;
+                    }
+                    break;
+                case XmlPullParser.START_TAG:
+                    name = parser.getName();
+                    //noinspection IfCanBeSwitch
+                    if (name.equals("title")) {
+                        parser.next();
+                        session.setTitle(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("subtitle")) {
+                        parser.next();
+                        session.setSubtitle(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("slug")) {
+                        parser.next();
+                        session.setSlug(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("feedback_url")) {
+                        parser.next();
+                        session.setFeedbackUrl(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("url")) {
+                        parser.next();
+                        session.setUrl(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("track")) {
+                        parser.next();
+                        session.setTrack(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("type")) {
+                        parser.next();
+                        session.setType(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("language")) {
+                        parser.next();
+                        session.setLanguage(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("abstract")) {
+                        parser.next();
+                        session.setAbstractt(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("description")) {
+                        parser.next();
+                        session.setDescription(XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("person")) {
+                        parser.next();
+                        String separator = !session.getSpeakers().isEmpty() ? ";" : "";
+                        session.setSpeakers(session.getSpeakers() + separator + XmlPullParsers.getSanitizedText(parser));
+                    } else if (name.equals("link")) {
+                        String url = parser.getAttributeValue(null, "href");
+                        parser.next();
+                        String urlName = XmlPullParsers.getSanitizedText(parser);
+                        if (url == null) {
+                            url = urlName;
+                        }
+                        if (!url.contains("://")) {
+                            url = "http://" + url;
+                        }
+                        StringBuilder sb = new StringBuilder();
+                        if (!session.getLinks().isEmpty()) {
+                            sb.append(session.getLinks());
+                            sb.append(",");
+                        }
+                        sb.append("[").append(urlName).append("]").append("(").append(url).append(")");
+                        session.setLinks(sb.toString());
+                    } else if (name.equals("start")) {
+                        parser.next();
+                        session.setStartTime(DateParser.getMinutes(XmlPullParsers.getSanitizedText(parser)));
+                        session.setRelativeStartTime(session.getStartTime());
+                        if (session.getRelativeStartTime() < dayChangeTime) {
+                            session.setRelativeStartTime(session.getRelativeStartTime() + MINUTES_OF_ONE_DAY);
+                        }
+                    } else if (name.equals("duration")) {
+                        parser.next();
+                        int minutes = DurationParser.getMinutes(XmlPullParsers.getSanitizedText(parser));
+                        session.setDuration(minutes);
+                    } else if (name.equals("date")) {
+                        parser.next();
+                        String sanitizedText = XmlPullParsers.getSanitizedText(parser);
+                        session.setDateUTC(DateParser.getDateTime(sanitizedText));
+                        session.setTimeZoneOffset(info.metadude.android.eventfahrplan.commons.temporal.DateParser.parseTimeZoneOffset(sanitizedText));
+                    } else if (name.equals("recording")) {
+                        eventType = parser.next();
+                        boolean recordingDone = false;
+                        while (eventType != XmlPullParser.END_DOCUMENT && !recordingDone && !isCancelled()) {
+                            switch (eventType) {
+                                case XmlPullParser.END_TAG:
+                                    name = parser.getName();
+                                    if (name.equals("recording")) {
+                                        recordingDone = true;
+                                    }
+                                    break;
+                                case XmlPullParser.START_TAG:
+                                    name = parser.getName();
+                                    if (name.equals("license")) {
+                                        parser.next();
+                                        session.setRecordingLicense(XmlPullParsers.getSanitizedText(parser));
+                                    } else if (name.equals("optout")) {
+                                        parser.next();
+                                        session.setRecordingOptOut(Boolean.parseBoolean(XmlPullParsers.getSanitizedText(parser)));
+                                    }
+                                    break;
+                            }
+                            if (recordingDone) {
+                                break;
+                            }
+                            eventType = parser.next();
+                        }
+                    }
+                    break;
+            }
+            if (isSessionDone) {
+                break;
+            }
+            eventType = parser.next();
         }
     }
 

--- a/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
+++ b/network/src/main/java/info/metadude/android/eventfahrplan/network/serialization/FahrplanParser.java
@@ -144,7 +144,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
             int numdays = 0;
             String roomName = null;
             String roomGuid = "";
-            int day = 0;
+            int dayIndex = 0;
             int dayChangeTime = 600; // Only provided by Pentabarf; corresponds to 10:00 am.
             String dateText = "";
             Set<String> uniqueDateTexts = new HashSet<>();
@@ -174,7 +174,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                         }
                         if (name.equals("day")) {
                             String index = parser.getAttributeValue(null, "index");
-                            day = Integer.parseInt(index);
+                            dayIndex = Integer.parseInt(index);
                             dateText = parser.getAttributeValue(null, "date");
                             uniqueDateTexts.add(dateText);
                             String end = parser.getAttributeValue(null, "end");
@@ -182,8 +182,8 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                                 throw new MissingXmlAttributeException("day", "end");
                             }
                             dayChangeTime = DateParser.getDayChange(end);
-                            if (day > numdays) {
-                                numdays = day;
+                            if (dayIndex > numdays) {
+                                numdays = dayIndex;
                             }
                         }
                         if (name.equals("room")) {
@@ -198,7 +198,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
                             roomGuid = parser.getAttributeValue(null, "guid");
                         }
                         if (name.equalsIgnoreCase("event")) {
-                            parseEvent(parser, day, dayChangeTime, roomMapIndex, roomName, roomGuid, dateText);
+                            parseEvent(parser, dayIndex, dayChangeTime, roomMapIndex, roomName, roomGuid, dateText);
                         } else if (name.equalsIgnoreCase("conference")) {
                             dayChangeTime = parseConference(parser, dayChangeTime);
                         }
@@ -273,7 +273,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
 
     private void parseEvent(
             XmlPullParser parser,
-            int day,
+            int dayIndex,
             int dayChangeTime,
             int roomMapIndex,
             String roomName,
@@ -285,7 +285,7 @@ class ParserTask extends AsyncTask<String, Void, Boolean> {
         String id = parser.getAttributeValue(null, "id");
         Session session = new Session();
         session.setSessionId(id);
-        session.setDayIndex(day);
+        session.setDayIndex(dayIndex);
         session.setRoomName(Objects.requireNonNullElse(roomName, ""));
         session.setRoomGuid(Objects.requireNonNullElse(roomGuid, ""));
         session.setDateText(dateText);


### PR DESCRIPTION
# Description
+ Correctly pass `Highlight#sessionId` around as String.
+ Clarify meaning of `dayIndex` properties and `DAY_INDEX` constants.
+ Clean up code.
+ Log error if count of unique `dateText` attributes and number of days mismatch.
+ Reduce complexity of `ParserTask#parseFahrplan` by extracting functions.
+ Fix minor typo.

# Successfully tested on
with `ccc38c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)