### PR TITLE
Document how to customize illustrations shown at empty screens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ Please read the instructions in the [contribution guide](CONTRIBUTING.md) in ord
 
 * View program by day and rooms (side by side)
 * Custom grid layout for smartphones (**try landscape mode**) and tablets
-* Read detailed descriptions (speaker names, start time, room name, links, ...) of events
-* Search through all events
-* Add events to favorites list
+* Read detailed descriptions (speaker names, start time, room name, links, ...) of sessions
+* Search through all sessions
+* Add sessions to favorites list
 * Export favorites list
-* Setup alarms for individual events
-* Add events to your personal calendar
-* Share a link to an event with others
+* Setup alarms for individual sessions
+* Add sessions to your personal calendar
+* Share a link to a session with others
 * Keep track of program changes
 * Automatic program updates (configurable in settings)
 
 
 ### Supported languages
-*Event descriptions excluded*
+*Session descriptions excluded*
 - Danish 🇩🇰
 - Dutch 🇳🇱
 - English 🇺🇸

--- a/assets/empty-states/README.md
+++ b/assets/empty-states/README.md
@@ -2,6 +2,19 @@
 
 This directory contains illustrations which are used to represent empty states in the application.
 
+## Available illustrations
+
+Please note that not all of the illustrations are already used in the application.
+
+| Illustration                                    | Description                                  |
+|-------------------------------------------------|----------------------------------------------|
+| ![No alarm](no_alarms.svg)                      | Shown when there are no alarms set.          |
+| ![No favorites](no_favorites.svg)               | Shown when there are no favorite sessions.   |
+| ![No schedule](no_schedule.svg)                 | Shown when the schedule is empty or missing. |
+| ![No schedule changes](no_schedule_changes.svg) | Shown when there are no schedule changes.    |
+| ![No search results](no_search_results.svg)     | Shown when a search yields no results.       |
+| ![No speakers](no_speakers.svg)                 | Shown when there are no speakers listed.     |
+
 ## Design
 
 Created by [Teresa Besser](https://github.com/taseret). The original design is organized outside of this

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -55,17 +55,17 @@ In some of the steps it is the easiest to copy and adapt configuration settings,
 3. Add a new product flavor in *app/build.gradle* e.g. `awesome2021` and the corresponding folder e.g. `app/src/awesome2021`
 4. Configure all required properties in your flavor (`applicationId`, `versionName`, `buildConfigField`, `resValue`)
 5. Enable showing the app disclaimer via `SHOW_APP_DISCLAIMER` to acknowledge its origin
-6. Add a new signing config in *app/gradle.properties*
+6. Add a new signing config in `app/gradle.properties`
 7. Customize texts for the languages which you want to offer (`values/strings.xml`, `values-de/strings.xml`, ...)
-8. Add the name/s (and website/s) of the authors of the logo(s) in *copyright_logo*
-9. Add track resource names in *res/xml/track_resource_names.xml*
-10. Customize track colors in *res/values/colors_congress.xml*
-11. Customize app colors in *res/values/colors.xml*
+8. Add the name/s (and website/s) of the authors of the logo(s) in `copyright_logo`
+9. Add track resource names in `res/xml/track_resource_names.xml`
+10. Customize track colors in `res/values/colors_congress.xml`
+11. Customize app colors in `res/values/colors.xml`
 12. Verify colors both in light and dark mode (not all screens switch colors!)
-13. Add a launcher icon in different resolutions as *res/mipmap-[...]/ic_launcher.png*
-14. Add a notification icon in different resolutions as *res/drawable-[...]/ic_notification.png*
-15. Add an about dialog logo as *res/drawable/dialog_logo.xml*
-16. Customize bell and video recording icons in *res/drawable/* (optional)
+13. Add a launcher icon in different resolutions as `res/mipmap-[...]/ic_launcher.png`
+14. Add a notification icon in different resolutions as `res/drawable-[...]/ic_notification.png`
+15. Add an about dialog logo as `res/drawable/dialog_logo.xml`
+16. Customize bell and video recording icons in `res/drawable/` (optional)
 
 ## 4. Optional customization
 

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -67,6 +67,23 @@ In some of the steps it is the easiest to copy and adapt configuration settings,
 15. Add an about dialog logo as `res/drawable/dialog_logo.xml`
 16. Customize bell and video recording icons in `res/drawable/` (optional)
 
+### 3.1. Customizing illustrations shown at empty screens
+
+The app shows illustrations on empty screens. You can customize these illustrations which fit the
+look and feel of your event by importing **your own SVG files** as vector drawables to the
+`res/drawable/` folder of **your product flavor**, e.g. `app/src/awesome2021/res/drawable/`.
+If the same file names are used than your illustrations will replace the default ones in `main`.
+The following default illustrations (vector drawables) are present in the app:
+
+- No alarms: `app/src/main/res/drawable/no_alarms.xml`
+- No favorites: `app/src/main/res/drawable/no_favorites.xml`
+- No schedule: `app/src/main/res/drawable/no_schedule.xml`
+- No schedule changes: `app/src/main/res/drawable/no_schedule_changes.xml`
+- No search results: `app/src/main/res/drawable/no_search_results.xml`
+
+The original raw SVG files can be found in `assets/empty-states/`, more information is available in the
+associated [README](../assets/empty-states/README.md).
+
 ## 4. Optional customization
 
 The following options can be enabled via a `buildConfigField` and configured in *app/build.gradle* as needed.


### PR DESCRIPTION
# Description
- Document how to customize illustrations shown at empty screens.
  - Show previews of raw empty states illustrations in README.
- Improve readability of file paths.
- Clarify wording related to "sessions".

# Related
- #655
- #659