### PR TITLE
Fix crash at activity destruction.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -457,10 +457,9 @@ object AppRepository : SearchRepository,
     }
 
     fun cancelLoading() {
-        parentJobs.values.forEach {
-            it.cancel()
-        }
+        val jobs = parentJobs.values.toList()
         parentJobs.clear()
+        jobs.forEach(Job::cancel)
     }
 
     /**


### PR DESCRIPTION
# Stacktrace

``` kotlin
Exception java.lang.RuntimeException: Unable to destroy activity
  {info.metadude.android.kotlinconf.schedule/nerd.tuxmobil.fahrplan.congress.schedule.MainActivity}:
  java.util.ConcurrentModificationException

  at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5454)
  at android.app.ActivityThread.handleDestroyActivity (ActivityThread.java:5487)
  at android.app.ActivityThread.handleRelaunchActivityInner (ActivityThread.java:5787)
  at android.app.ActivityThread.handleRelaunchActivity (ActivityThread.java:5703)
  at android.app.servertransaction.ActivityRelaunchItem.execute (ActivityRelaunchItem.java:71)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:135)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:95)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2253)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at androidx.test.espresso.base.Interrogator.loopAndInterrogate (Interrogator.java:10)
  at androidx.test.espresso.base.UiControllerImpl.loopUntil (UiControllerImpl.java:7)
  ...

Caused by java.util.ConcurrentModificationException:
  at java.util.LinkedHashMap$LinkedHashIterator.nextNode (LinkedHashMap.java:760)
  at java.util.LinkedHashMap$LinkedValueIterator.next (LinkedHashMap.java:788)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.cancelLoading
  at nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel.cancelLoading
  at nerd.tuxmobil.fahrplan.congress.schedule.MainActivity.onDestroy
  at android.app.Activity.performDestroy (Activity.java:8339)
  at android.app.Instrumentation.callActivityOnDestroy (Instrumentation.java:1376)
  at androidx.test.runner.MonitoringInstrumentation.callActivityOnDestroy (MonitoringInstrumentation.java:1)
  at android.app.ActivityThread.performDestroyActivity (ActivityThread.java:5441)
```

# Successfully tested on
with `gpn2025` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)