### PR TITLE
Fix tint color not being applied to alarm icon at session card.

### DIFF
--- a/app/src/ccc38c3/res/values/colors.xml
+++ b/app/src/ccc38c3/res/values/colors.xml
@@ -15,9 +15,7 @@
     <color name="alert_dialog_button_text">#fef2ff</color>
 
     <!-- Schedule screen -->
-    <color name="schedule_time_column_background">@color/colorAccent</color>
     <color name="schedule_time_column_item_background_normal">@color/windowBackground</color>
-    <color name="schedule_time_column_item_background_emphasized">@color/colorAccent</color>
     <color name="schedule_time_column_item_text_normal">#fef2ff</color>
     <color name="schedule_time_column_item_text_emphasized">#fef2ff</color>
     <color name="schedule_horizontal_scrolling_progress_line">#fef2ff</color>

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -479,6 +479,7 @@ private fun AlarmIcon(
             .size(dimensionResource(R.dimen.session_drawable_icon_size))
             .padding(dimensionResource(R.dimen.session_drawable_icon_padding)),
         icon = R.drawable.ic_bell_on_session,
+        tint = colorResource(R.color.session_item_alarm_icon),
         contentDescription = stringResource(R.string.session_item_has_alarm_content_description),
     )
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,7 +16,7 @@
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
     <color name="text_link_pressed_background_on_light">#aafec700</color>
-    <color name="outline_variant">#88ffffff</color>
+    <color name="outline_variant">#88888888</color>
 
     <!-- Scrollbar -->
     <color name="scrollbar_background">@color/colorAccent</color>
@@ -40,9 +40,9 @@
     <color name="alert_dialog_button_text">@color/colorAccent</color>
 
     <!-- Schedule screen -->
-    <color name="schedule_time_column_background">#000000</color>
+    <color name="schedule_time_column_background">@color/colorAccent</color>
     <color name="schedule_time_column_item_background_normal">#000</color>
-    <color name="schedule_time_column_item_background_emphasized">#fff</color>
+    <color name="schedule_time_column_item_background_emphasized">@color/colorAccent</color>
     <color name="schedule_time_column_item_text_normal">#fff</color>
     <color name="schedule_time_column_item_text_emphasized">#000</color>
     <color name="schedule_horizontal_time_line">#4dffffff</color>


### PR DESCRIPTION
# Description
+ Fix tint color not being applied to alarm icon at session card.
+ Use better default colors to reduce customizing effort in product flavors.

# Successfully tested on
with `gpn2025` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)