### PR TITLE
Unit test ZoneOffsetProvider#getAvailableZoneOffset.

### DIFF
--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/ZoneOffsetProvider.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/ZoneOffsetProvider.kt
@@ -1,0 +1,22 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import org.threeten.bp.Clock
+import org.threeten.bp.OffsetDateTime
+import org.threeten.bp.ZoneOffset
+
+internal class ZoneOffsetProvider(
+    val clock: Clock,
+    val useDeviceTimeZone: Boolean,
+) {
+
+    /**
+     * Returns the available zone offset - either the given [sessionZoneOffset] or the zone offset
+     * of the device. The user can overrule the logic by setting [useDeviceTimeZone].
+     */
+    fun getAvailableZoneOffset(sessionZoneOffset: ZoneOffset?): ZoneOffset {
+        val deviceZoneOffset = OffsetDateTime.now(clock).offset
+        val useDeviceZoneOffset = sessionZoneOffset == null || sessionZoneOffset == deviceZoneOffset
+        return if (useDeviceTimeZone || useDeviceZoneOffset) deviceZoneOffset else sessionZoneOffset
+    }
+
+}

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/ZoneOffsetProviderTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/ZoneOffsetProviderTest.kt
@@ -1,0 +1,83 @@
+package info.metadude.android.eventfahrplan.commons.temporal
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.threeten.bp.Clock
+import org.threeten.bp.Instant
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZoneOffset.UTC
+
+class ZoneOffsetProviderTest {
+
+    @Nested
+    inner class DeviceZoneOffset {
+
+        @Test
+        fun `getAvailableZoneOffset returns the device zone offset when useDeviceTimeZone = true regardless if sessionZoneOffset = null`() {
+            val zoneOffset = getAvailableZoneOffset(
+                deviceZoneOffset = UTC,
+                sessionZoneOffset = null,
+                useDeviceTimeZone = true,
+            )
+            assertThat(zoneOffset).isEqualTo(UTC)
+        }
+
+        @Test
+        fun `getAvailableZoneOffset returns the device zone offset when useDeviceTimeZone = true regardless if sessionZoneOffset is set`() {
+            val zoneOffset = getAvailableZoneOffset(
+                deviceZoneOffset = UTC,
+                sessionZoneOffset = ZoneOffset.ofHours(2),
+                useDeviceTimeZone = true,
+            )
+            assertThat(zoneOffset).isEqualTo(UTC)
+        }
+
+        @Test
+        fun `getAvailableZoneOffset returns the device zone offset as a fallback when sessionZoneOffset = null, although useDeviceTimeZone = false`() {
+            val zoneOffset = getAvailableZoneOffset(
+                deviceZoneOffset = UTC,
+                sessionZoneOffset = null,
+                useDeviceTimeZone = false,
+            )
+            assertThat(zoneOffset).isEqualTo(UTC)
+        }
+
+        @Test
+        fun `getAvailableZoneOffset returns the device zone offset when useDeviceTimeZone = false and deviceZoneOffset == sessionZoneOffset`() {
+            val zoneOffset = getAvailableZoneOffset(
+                deviceZoneOffset = ZoneOffset.ofHours(-7),
+                sessionZoneOffset = ZoneOffset.ofHours(-7),
+                useDeviceTimeZone = false,
+            )
+            assertThat(zoneOffset).isEqualTo(ZoneOffset.ofHours(-7))
+        }
+
+    }
+
+    @Nested
+    inner class SessionZoneOffset {
+
+        @Test
+        fun `getAvailableZoneOffset returns the session zone offset when useDeviceTimeZone = false and sessionZoneOffset is set`() {
+            val zoneOffset = getAvailableZoneOffset(
+                deviceZoneOffset = UTC,
+                sessionZoneOffset = ZoneOffset.ofHours(2),
+                useDeviceTimeZone = false,
+            )
+            assertThat(zoneOffset).isEqualTo(ZoneOffset.ofHours(2))
+        }
+
+    }
+
+}
+
+private fun getAvailableZoneOffset(
+    deviceZoneOffset: ZoneOffset,
+    sessionZoneOffset: ZoneOffset?,
+    useDeviceTimeZone: Boolean,
+): ZoneOffset {
+    // The instant is not relevant for these tests, we care about the zone offset.
+    val clock = Clock.fixed(Instant.EPOCH, deviceZoneOffset)
+    return ZoneOffsetProvider(clock, useDeviceTimeZone).getAvailableZoneOffset(sessionZoneOffset)
+}


### PR DESCRIPTION
# Description
+ Remove unnecessary non-null assertion (!!) on a non-null `sessionZoneOffset`.
+ Add `clock` parameter to make zone offset calculation testable.

# Successfully tested on
with `hope2024` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---

Relates #630