### PR TITLE
Add "recorded" property to session JSON export.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/models/SessionExport.kt
@@ -24,6 +24,7 @@ data class SessionExport(
         var links: String? = null,
         @Json(name = "starts_at")
         var startsAt: String? = null,
+        var recorded: Boolean = false,
 ) {
     constructor(session: Session) : this(
             sessionId = session.sessionId,
@@ -40,6 +41,7 @@ data class SessionExport(
             abstract = session.abstractt,
             description = session.description,
             links = session.links,
-            startsAt = Moment.ofEpochMilli(session.dateUTC).toString()
+            startsAt = Moment.ofEpochMilli(session.dateUTC).toString(),
+            recorded = !session.recordingOptOut,
     )
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/JsonSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/JsonSessionFormatTest.kt
@@ -18,7 +18,7 @@ class JsonSessionFormatTest {
         val sessions = listOf(
                 Session("session1"),
                 Session("session2"),
-                Session("session3"))
+                Session("session3", recordingOptOut = true))
         val json = JsonSessionFormat().format(sessions)
         assertThat(json).isEqualTo(EXPECTED_JSON_LIST)
     }
@@ -29,20 +29,20 @@ class JsonSessionFormatTest {
                 "\"title\":\"\",\"subtitle\":\"\",\"day\":0,\"room\":\"\",\"slug\":\"\"," +
                 "\"url\":\"\",\"speakers\":\"\",\"track\":\"\",\"type\":\"\",\"lang\":\"\"," +
                 "\"abstract\":\"\",\"description\":\"\",\"links\":\"\"," +
-                "\"starts_at\":\"1970-01-01T00:00:00Z\"}]}"
+                "\"starts_at\":\"1970-01-01T00:00:00Z\",\"recorded\":true}]}"
         const val EXPECTED_JSON_LIST = "{\"lectures\":[{\"lecture_id\":\"session1\"," +
                 "\"title\":\"\",\"subtitle\":\"\",\"day\":0,\"room\":\"\",\"slug\":\"\"" +
                 ",\"url\":\"\",\"speakers\":\"\",\"track\":\"\",\"type\":\"\",\"lang\":\"\"" +
                 ",\"abstract\":\"\",\"description\":\"\",\"links\":\"\"," +
-                "\"starts_at\":\"1970-01-01T00:00:00Z\"}," +
+                "\"starts_at\":\"1970-01-01T00:00:00Z\",\"recorded\":true}," +
                 "{\"lecture_id\":\"session2\",\"title\":\"\",\"subtitle\":\"\",\"day\":0," +
                 "\"room\":\"\",\"slug\":\"\",\"url\":\"\",\"speakers\":\"\",\"track\":\"\"," +
                 "\"type\":\"\",\"lang\":\"\",\"abstract\":\"\",\"description\":\"\"," +
-                "\"links\":\"\",\"starts_at\":\"1970-01-01T00:00:00Z\"}," +
+                "\"links\":\"\",\"starts_at\":\"1970-01-01T00:00:00Z\",\"recorded\":true}," +
                 "{\"lecture_id\":\"session3\",\"title\":\"\",\"subtitle\":\"\",\"day\":0," +
                 "\"room\":\"\",\"slug\":\"\",\"url\":\"\",\"speakers\":\"\",\"track\":\"\"," +
                 "\"type\":\"\",\"lang\":\"\",\"abstract\":\"\",\"description\":\"\",\"links\":\"\"," +
-                "\"starts_at\":\"1970-01-01T00:00:00Z\"}]}"
+                "\"starts_at\":\"1970-01-01T00:00:00Z\",\"recorded\":false}]}"
 
     }
 


### PR DESCRIPTION
# Description
- Adds the boolean `recorded` property to the JSON export of a single session and to the JSON export of the list of favorites.
- The value of the property directly depends on the value of the `optout` node in the _schedule.xml_:

``` xml
<recording>
    <license/>
    <optout>true</optout>
</recording>
```

# Before
``` json
{
    "lectures":
    [
        {
            "lecture_id": "210206",
            "title": "Build your own {event} Fahrplan app for Android",
            "subtitle": "",
            "day": 1,
            "room": "SoS Saal 6",
            "slug": "38c3-build-your-own-38c3-fahrplan-app-for-android",
            "url": "https://events.ccc.de/congress/2024/hub/de/event/build-your-own-38c3-fahrplan-app-for-android/",
            "speakers": "tbsprs",
            "track": "other",
            "type": "other",
            "lang": "en, de",
            "abstract": "",
            "description": "Lorem ipsum dolor",
            "links": "",
            "starts_at": "2024-12-27T16:00:00Z"
        }
    ]
}
```

# After
``` json
{
    "lectures":
    [
        {
            "lecture_id": "210206",
            "title": "Build your own {event} Fahrplan app for Android",
            "subtitle": "",
            "day": 1,
            "room": "SoS Saal 6",
            "slug": "38c3-build-your-own-38c3-fahrplan-app-for-android",
            "url": "https://events.ccc.de/congress/2024/hub/de/event/build-your-own-38c3-fahrplan-app-for-android/",
            "speakers": "tbsprs",
            "track": "other",
            "type": "other",
            "lang": "en, de",
            "abstract": "",
            "description": "Lorem ipsum dolor",
            "links": "",
            "starts_at": "2024-12-27T16:00:00Z",
            "recorded": true
        }
    ]
}
```

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)

---

Resolves #765