### PR TITLE
Show day separators in search result list.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactory.kt
@@ -38,7 +38,7 @@ class AlarmsStateFactory(
                         alarmOffset
                     )
                 }
-                val firesAtText = formattingDelegate.getFormattedDateTimeLong(
+                val firesAtText = getFormattedDateTimeLong(
                     useDeviceTimeZone,
                     Moment.ofEpochMilli(alarm.startTime),
                     found.timeZoneOffset,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -153,7 +153,7 @@ abstract class SessionsAdapter protected constructor(
             val session = list[index]
             dayIndex = session.dayIndex
             val formattedDate = DateFormatter.newInstance(useDeviceTimeZone)
-                .getFormattedDate(session.startsAt, session.timeZoneOffset)
+                .getFormattedDateShort(session.startsAt, session.timeZoneOffset)
 
             if (dayIndex != lastDayIndex) {
                 lastDayIndex = dayIndex

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModel.kt
@@ -35,7 +35,6 @@ class ChangeListViewModel(
                 mutableSessionChangeState.value = Success(
                     sessionChangeParametersFactory.createSessionChangeParameters(
                         sessions = sessions,
-                        numDays = if (sessions.isEmpty()) 0 else repository.readMeta().numDays,
                         useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled(),
                     )
                 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -2,7 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.changes
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
-import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
+import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
@@ -25,7 +25,7 @@ class ChangeListViewModelFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatting = sessionPropertiesFormatting,
                 contentDescriptionFormatting = contentDescriptionFormatting,
-                onDateFormatter = { useDeviceTimeZone -> DateFormatter.newInstance(useDeviceTimeZone) }
+                formattingDelegate = DateFormatterDelegate,
             )
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelFactory.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.changes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
@@ -17,6 +18,7 @@ class ChangeListViewModelFactory(
 ) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        val formattingDelegate = DateFormatterDelegate
         @Suppress("UNCHECKED_CAST")
         return ChangeListViewModel(
             repository = appRepository,
@@ -25,7 +27,12 @@ class ChangeListViewModelFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatting = sessionPropertiesFormatting,
                 contentDescriptionFormatting = contentDescriptionFormatting,
-                formattingDelegate = DateFormatterDelegate,
+                daySeparatorFactory = DaySeparatorFactory(
+                    resourceResolving = resourceResolving,
+                    formattingDelegate = formattingDelegate,
+                    contentDescriptionFormatting = contentDescriptionFormatting,
+                ),
+                formattingDelegate = formattingDelegate,
             )
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
@@ -36,6 +36,7 @@ import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeState.Loading
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeState.Success
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeViewEvent.OnSessionChangeItemClick
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
@@ -105,7 +106,10 @@ private fun SessionChangesList(
         }
         itemsIndexed(parameters) { index, parameter ->
             when (parameter) {
-                is Separator -> HeaderDayDate(parameter.text)
+                is Separator -> HeaderDayDate(
+                    text = parameter.daySeparator.value,
+                    contentDescription = parameter.daySeparator.contentDescription,
+                )
                 is SessionChange -> {
                     SessionChangeItem(parameter, Modifier.clickable {
                         if (!parameter.isCanceled) {
@@ -229,7 +233,12 @@ private fun SessionChangesScreenPreview() {
     SessionChangesScreen(
         Success(
             listOf(
-                Separator("Day 1 - 31.02.2023"),
+                Separator(
+                    DaySeparatorProperty(
+                        value = "Day 1 - 31.02.2023",
+                        contentDescription = "",
+                    )
+                ),
                 SessionChange(
                     id = "changed",
                     title = SessionChangeProperty(stringResource(R.string.placeholder_session_title), "", UNCHANGED),
@@ -266,7 +275,12 @@ private fun SessionChangesScreenPreview() {
                     roomName = SessionChangeProperty(stringResource(R.string.placeholder_session_room), "", UNCHANGED),
                     languages = SessionChangeProperty(stringResource(R.string.placeholder_session_language), "", UNCHANGED),
                 ),
-                Separator("Day 2 - 01.03.2023"),
+                Separator(
+                    DaySeparatorProperty(
+                        value = "Day 2 - 01.03.2023",
+                        contentDescription = "",
+                    )
+                ),
                 SessionChange(
                     id = "new with video",
                     title = SessionChangeProperty(stringResource(R.string.placeholder_session_title), "", NEW),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParameter.kt
@@ -1,11 +1,12 @@
 package nerd.tuxmobil.fahrplan.congress.changes
 
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState
 
 sealed interface SessionChangeParameter {
 
     data class Separator(
-        val text: String,
+        val daySeparator: DaySeparatorProperty<String>,
     ) : SessionChangeParameter
 
     data class SessionChange(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.changes
 
-import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeParameter.Separator
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeParameter.SessionChange
@@ -8,6 +7,7 @@ import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.CHANGED
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.NEW
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.UNCHANGED
+import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
@@ -20,8 +20,8 @@ class SessionChangeParametersFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
-    private val onDateFormatter: (useDeviceTimeZone: Boolean) -> DateFormatter,
-) {
+    private val formattingDelegate: FormattingDelegate,
+) : FormattingDelegate by formattingDelegate {
 
     fun createSessionChangeParameters(
         sessions: List<Session>,
@@ -34,7 +34,7 @@ class SessionChangeParametersFactory(
         val parameters = mutableListOf<SessionChangeParameter>()
         sessions.forEach {
             dayIndex = it.dayIndex
-            val dayText = onDateFormatter(useDeviceTimeZone).getFormattedDateShort(it.startsAt, it.timeZoneOffset)
+            val dayText = formattingDelegate.getFormattedDateShort(useDeviceTimeZone, it.startsAt, it.timeZoneOffset)
             if (dayIndex != lastDayIndex) {
                 lastDayIndex = dayIndex
                 if (numDays > 1) {
@@ -48,7 +48,7 @@ class SessionChangeParametersFactory(
     }
 
     private fun sessionChangeOf(session: Session, dayText: String, dash: String, useDeviceTimeZone: Boolean): SessionChange {
-        val startsAt = onDateFormatter(useDeviceTimeZone).getFormattedTimeShort(session.startsAt, session.timeZoneOffset)
+        val startsAt = getFormattedTimeShort(useDeviceTimeZone, session.startsAt, session.timeZoneOffset)
         val duration = resourceResolving.getString(R.string.session_list_item_duration_text, session.duration.toWholeMinutes().toInt())
         val languages = sessionPropertiesFormatting.getLanguageText(session)
         val videoState = when {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -34,7 +34,7 @@ class SessionChangeParametersFactory(
         val parameters = mutableListOf<SessionChangeParameter>()
         sessions.forEach {
             dayIndex = it.dayIndex
-            val dayText = onDateFormatter(useDeviceTimeZone).getFormattedDate(it.startsAt, it.timeZoneOffset)
+            val dayText = onDateFormatter(useDeviceTimeZone).getFormattedDateShort(it.startsAt, it.timeZoneOffset)
             if (dayIndex != lastDayIndex) {
                 lastDayIndex = dayIndex
                 if (numDays > 1) {
@@ -48,7 +48,7 @@ class SessionChangeParametersFactory(
     }
 
     private fun sessionChangeOf(session: Session, dayText: String, dash: String, useDeviceTimeZone: Boolean): SessionChange {
-        val startsAt = onDateFormatter(useDeviceTimeZone).getFormattedTime(session.startsAt, session.timeZoneOffset)
+        val startsAt = onDateFormatter(useDeviceTimeZone).getFormattedTimeShort(session.startsAt, session.timeZoneOffset)
         val duration = resourceResolving.getString(R.string.session_list_item_duration_text, session.duration.toWholeMinutes().toInt())
         val languages = sessionPropertiesFormatting.getLanguageText(session)
         val videoState = when {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactory.kt
@@ -7,11 +7,14 @@ import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.CHANGED
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.NEW
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.UNCHANGED
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.None
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toVirtualDays
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
@@ -20,34 +23,45 @@ class SessionChangeParametersFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
+    private val daySeparatorFactory: DaySeparatorFactory,
     private val formattingDelegate: FormattingDelegate,
 ) : FormattingDelegate by formattingDelegate {
 
     fun createSessionChangeParameters(
         sessions: List<Session>,
-        numDays: Int,
         useDeviceTimeZone: Boolean,
     ): List<SessionChangeParameter> {
-        var dayIndex: Int
-        var lastDayIndex = 0
         val dash = resourceResolving.getString(R.string.dash)
         val parameters = mutableListOf<SessionChangeParameter>()
-        sessions.forEach {
-            dayIndex = it.dayIndex
-            val dayText = formattingDelegate.getFormattedDateShort(useDeviceTimeZone, it.startsAt, it.timeZoneOffset)
-            if (dayIndex != lastDayIndex) {
-                lastDayIndex = dayIndex
-                if (numDays > 1) {
-                    val dayDateSeparator = resourceResolving.getString(R.string.day_separator, dayIndex, dayText)
-                    parameters += Separator(dayDateSeparator)
+        sessions
+            .toVirtualDays()
+            .filter { it.sessions.isNotEmpty() }
+            .forEach { virtualDay ->
+                val dayIndex = virtualDay.index
+                val session = virtualDay.sessions.first()
+                parameters += Separator(
+                    DaySeparatorProperty(
+                        value = daySeparatorFactory.createDaySeparatorText(
+                            dayIndex = dayIndex,
+                            session = session,
+                            useDeviceTimeZone = useDeviceTimeZone,
+                        ),
+                        contentDescription = daySeparatorFactory.createDaySeparatorContentDescription(
+                            dayIndex = dayIndex,
+                            session = session,
+                            useDeviceTimeZone = useDeviceTimeZone,
+                        )
+                    )
+                )
+                virtualDay.sessions.forEach {
+                    parameters += sessionChangeOf(it, dash, useDeviceTimeZone)
                 }
             }
-            parameters += sessionChangeOf(it, dayText = dayText, dash = dash, useDeviceTimeZone)
-        }
         return parameters
     }
 
-    private fun sessionChangeOf(session: Session, dayText: String, dash: String, useDeviceTimeZone: Boolean): SessionChange {
+    private fun sessionChangeOf(session: Session, dash: String, useDeviceTimeZone: Boolean): SessionChange {
+        val dayText = getFormattedDateShort(useDeviceTimeZone, session.startsAt, session.timeZoneOffset)
         val startsAt = getFormattedTimeShort(useDeviceTimeZone, session.startsAt, session.timeZoneOffset)
         val duration = resourceResolving.getString(R.string.session_list_item_duration_text, session.duration.toWholeMinutes().toInt())
         val languages = sessionPropertiesFormatting.getLanguageText(session)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
@@ -11,6 +11,22 @@ import org.threeten.bp.ZoneOffset
 @Suppress("kotlin:S6516")
 object DateFormatterDelegate : FormattingDelegate {
 
+    override fun getFormattedTimeShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = DateFormatter
+        .newInstance(useDeviceTimeZone)
+        .getFormattedTimeShort(moment, timeZoneOffset)
+
+    override fun getFormattedDateShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = DateFormatter
+        .newInstance(useDeviceTimeZone)
+        .getFormattedDateShort(moment, timeZoneOffset)
+
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DateFormatterDelegate.kt
@@ -27,6 +27,14 @@ object DateFormatterDelegate : FormattingDelegate {
         .newInstance(useDeviceTimeZone)
         .getFormattedDateShort(moment, timeZoneOffset)
 
+    override fun getFormattedDateLong(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = DateFormatter
+        .newInstance(useDeviceTimeZone)
+        .getFormattedDateLong(moment, timeZoneOffset)
+
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DaySeparatorFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DaySeparatorFactory.kt
@@ -1,0 +1,31 @@
+package nerd.tuxmobil.fahrplan.congress.commons
+
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
+
+class DaySeparatorFactory(
+    private val resourceResolving: ResourceResolving,
+    private val formattingDelegate: FormattingDelegate,
+    private val contentDescriptionFormatting: ContentDescriptionFormatting,
+) {
+
+    fun createDaySeparatorText(dayIndex: Int, session: Session, useDeviceTimeZone: Boolean): String {
+        val formattedDate = formattingDelegate.getFormattedDateShort(
+            useDeviceTimeZone,
+            session.startsAt,
+            session.timeZoneOffset,
+        )
+        return resourceResolving.getString(R.string.day_separator, dayIndex, formattedDate)
+    }
+
+    fun createDaySeparatorContentDescription(dayIndex: Int, session: Session, useDeviceTimeZone: Boolean): String {
+        val formattedDate = formattingDelegate.getFormattedDateLong(
+            useDeviceTimeZone,
+            session.startsAt,
+            session.timeZoneOffset,
+        )
+        return contentDescriptionFormatting.getDaySeparatorContentDescription(dayIndex, formattedDate)
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DaySeparatorProperty.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/DaySeparatorProperty.kt
@@ -1,0 +1,6 @@
+package nerd.tuxmobil.fahrplan.congress.commons
+
+data class DaySeparatorProperty<T>(
+    val value: T,
+    val contentDescription: String,
+)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
@@ -20,6 +20,12 @@ interface FormattingDelegate {
         timeZoneOffset: ZoneOffset?,
     ): String
 
+    fun getFormattedDateLong(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ): String
+
     fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/FormattingDelegate.kt
@@ -8,6 +8,18 @@ import org.threeten.bp.ZoneOffset
  */
 interface FormattingDelegate {
 
+    fun getFormattedTimeShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ): String
+
+    fun getFormattedDateShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ): String
+
     fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -16,14 +16,14 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 @Composable
 fun HeaderDayDate(text: String) {
     Column(
-        Modifier.Companion.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
+        Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
     ) {
         val color = colorResource(R.color.text_link_on_light)
         Text(
             color = color,
             text = text.uppercase(),
             fontSize = 13.sp,
-            fontWeight = FontWeight.Companion.Bold,
+            fontWeight = Bold,
         )
         DividerHorizontal(thickness = 1.dp, color = color)
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -14,12 +16,15 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 
 @Composable
-fun HeaderDayDate(text: String) {
+fun HeaderDayDate(text: String, contentDescription: String) {
     Column(
         Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp),
     ) {
         val color = colorResource(R.color.text_link_on_light)
         Text(
+            modifier = Modifier.semantics {
+                this.contentDescription = contentDescription
+            },
             color = color,
             text = text.uppercase(),
             fontSize = 13.sp,
@@ -32,5 +37,5 @@ fun HeaderDayDate(text: String) {
 @Preview
 @Composable
 private fun HeaderDayDatePreview() {
-    HeaderDayDate("Day 1 - 31.02.2023")
+    HeaderDayDate("Day 1 - 31.02.2023", "")
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListAdapter.kt
@@ -68,7 +68,7 @@ class StarredListAdapter internal constructor(
                 .getLanguageContentDescription(languageText)
 
             day.isVisible = false
-            val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime(session.startsAt, session.timeZoneOffset)
+            val timeText = DateFormatter.newInstance(useDeviceTimeZone).getFormattedTimeShort(session.startsAt, session.timeZoneOffset)
             time.textOrHide = timeText
             time.contentDescription = contentDescriptionFormatting
                 .getStartTimeContentDescription(timeText)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonOutlined
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
+import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderDayDate
 import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDecorative
 import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDecorativeVector
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.Loading
@@ -48,6 +50,7 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextOverline
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextSupportingContent
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.SearchResult
+import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.Separator
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.Loading
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.Success
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnBackIconClick
@@ -224,12 +227,16 @@ private fun SearchResultList(
     LazyColumn(state = rememberLazyListState()) {
         itemsIndexed(parameters) { index, parameter ->
             when (parameter) {
+                is Separator -> HeaderDayDate(
+                    text = parameter.daySeparator.value,
+                    contentDescription = parameter.daySeparator.contentDescription,
+                )
                 is SearchResult -> {
                     SearchResultItem(parameter, Modifier.clickable {
                         onViewEvent(OnSearchResultItemClick(parameter.id))
                     })
                     val next = parameters.getOrNull(index + 1)
-                    if (index < parameters.size - 1 && (next != null)) {
+                    if (index < parameters.size - 1 && next is SearchResult) {
                         DividerHorizontal(Modifier.padding(horizontal = 12.dp))
                     }
                 }
@@ -343,17 +350,29 @@ private fun SearchScreenPreview() {
         searchHistory = emptyList(),
         state = Success(
             listOf(
+                Separator(
+                    DaySeparatorProperty(
+                        value = "DAY 1 - 12/27/2024",
+                        contentDescription = "Day 1 - December 27, 2024",
+                    )
+                ),
                 SearchResult(
                     id = "1",
                     title = SearchResultProperty("Lorem ipsum dolor sit amet", ""),
                     speakerNames = SearchResultProperty("Hedy Llamar", ""),
                     startsAt = SearchResultProperty("December 27, 2024 10:00", ""),
                 ),
+                Separator(
+                    DaySeparatorProperty(
+                        value = "DAY 2 - 12/28/2024",
+                        contentDescription = "Day 2 - December 28, 2024",
+                    )
+                ),
                 SearchResult(
                     id = "3",
                     title = SearchResultProperty("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", ""),
                     speakerNames = SearchResultProperty("Jane Doe", ""),
-                    startsAt = SearchResultProperty("December 27, 2024 18:30", "")
+                    startsAt = SearchResultProperty("December 28, 2024 18:30", "")
                 ),
             )
         ),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameter.kt
@@ -1,6 +1,12 @@
 package nerd.tuxmobil.fahrplan.congress.search
 
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
+
 sealed interface SearchResultParameter {
+
+    data class Separator(
+        val daySeparator: DaySeparatorProperty<String>,
+    ) : SearchResultParameter
 
     data class SearchResult(
         val id: String,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
@@ -1,10 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress.search
 
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
+import nerd.tuxmobil.fahrplan.congress.dataconverters.toVirtualDays
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.SearchResult
+import nerd.tuxmobil.fahrplan.congress.search.SearchResultParameter.Separator
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 
@@ -12,11 +16,37 @@ class SearchResultParameterFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
+    private val daySeparatorFactory: DaySeparatorFactory,
     private val formattingDelegate: FormattingDelegate,
 ) : FormattingDelegate by formattingDelegate {
 
-    fun createSearchResults(sessions: List<Session>, useDeviceTimeZone: Boolean): List<SearchResult> {
-        return sessions.map { createSearchResult(it, useDeviceTimeZone) }
+    fun createSearchResults(sessions: List<Session>, useDeviceTimeZone: Boolean): List<SearchResultParameter> {
+        val list = mutableListOf<SearchResultParameter>()
+        sessions
+            .toVirtualDays()
+            .filter { it.sessions.isNotEmpty() }
+            .forEach { virtualDay ->
+                val dayIndex = virtualDay.index
+                val session = virtualDay.sessions.first()
+                list += Separator(
+                    DaySeparatorProperty(
+                        value = daySeparatorFactory.createDaySeparatorText(
+                            dayIndex = dayIndex,
+                            session = session,
+                            useDeviceTimeZone = useDeviceTimeZone,
+                        ),
+                        contentDescription = daySeparatorFactory.createDaySeparatorContentDescription(
+                            dayIndex = dayIndex,
+                            session = session,
+                            useDeviceTimeZone = useDeviceTimeZone,
+                        )
+                    )
+                )
+                virtualDay.sessions.forEach {
+                    list += createSearchResult(it, useDeviceTimeZone)
+                }
+            }
+        return list
     }
 
     private fun createSearchResult(session: Session, useDeviceTimeZone: Boolean): SearchResult {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactory.kt
@@ -12,7 +12,7 @@ class SearchResultParameterFactory(
     private val resourceResolving: ResourceResolving,
     private val sessionPropertiesFormatting: SessionPropertiesFormatting,
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
-    private val formattingDelegate: FormattingDelegate
+    private val formattingDelegate: FormattingDelegate,
 ) : FormattingDelegate by formattingDelegate {
 
     fun createSearchResults(sessions: List<Session>, useDeviceTimeZone: Boolean): List<SearchResult> {
@@ -24,7 +24,7 @@ class SearchResultParameterFactory(
         val title = session.title.ifEmpty { dash }
         val formattedSpeakerNames = sessionPropertiesFormatting.getFormattedSpeakers(session)
         val speakers = if (session.speakers.isEmpty()) dash else formattedSpeakerNames
-        val startsAtText = formattingDelegate.getFormattedDateTimeLong(
+        val startsAtText = getFormattedDateTimeLong(
             useDeviceTimeZone,
             session.startsAt,
             session.timeZoneOffset,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.search
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
 import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatting
@@ -16,6 +17,7 @@ class SearchViewModelFactory(
 ) : Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        val formattingDelegate = DateFormatterDelegate
         @Suppress("UNCHECKED_CAST")
         return SearchViewModel(
             repository = appRepository,
@@ -25,7 +27,12 @@ class SearchViewModelFactory(
                 resourceResolving = resourceResolving,
                 sessionPropertiesFormatting = sessionPropertiesFormatting,
                 contentDescriptionFormatting = contentDescriptionFormatting,
-                formattingDelegate = DateFormatterDelegate,
+                daySeparatorFactory = DaySeparatorFactory(
+                    resourceResolving = resourceResolving,
+                    formattingDelegate = formattingDelegate,
+                    contentDescriptionFormatting = contentDescriptionFormatting,
+                ),
+                formattingDelegate = formattingDelegate,
             ),
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -85,4 +85,8 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) : Co
         return "$isHighlightContentDescription, $startsAtContentDescription, $roomNameContentDescription"
     }
 
+    override fun getDaySeparatorContentDescription(dayIndex: Int, formattedDate: String): String {
+        return resourceResolving.getString(R.string.day_separator_content_description, dayIndex, formattedDate)
+    }
+
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatter.kt
@@ -79,7 +79,7 @@ class ContentDescriptionFormatter(val resourceResolving: ResourceResolving) : Co
         val roomNameContentDescription: String = getRoomNameContentDescription(session.roomName)
         val startsAtText = DateFormatter
             .newInstance(useDeviceTimeZone)
-            .getFormattedTime(session.startsAt, session.timeZoneOffset)
+            .getFormattedTimeShort(session.startsAt, session.timeZoneOffset)
         val startsAtContentDescription = getStartTimeContentDescription(startsAtText)
         val isHighlightContentDescription = getHighlightContentDescription(session.isHighlight)
         return "$isHighlightContentDescription, $startsAtContentDescription, $roomNameContentDescription"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatting.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ContentDescriptionFormatting.kt
@@ -25,4 +25,6 @@ interface ContentDescriptionFormatting {
 
     fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean): String
 
+    fun getDaySeparatorContentDescription(dayIndex: Int, formattedDate: String): String
+
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -123,6 +123,7 @@
     <string name="favorites_no_favorites_subtitle">Tippe auf den Stern in der Menüleiste, um einen Favoriten zu setzen</string>
     <string name="choose_to_delete">Wähle Vorträge</string>
     <string name="day_separator">Tag <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
+    <string name="day_separator_content_description">Tag <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="29. December 2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Alle Favoriten löschen?</string>
     <string name="dlg_delete_all_favorites_delete_all">Alle löschen</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,7 +142,8 @@
     <string name="general_settings">General</string>
     <string name="starred_sessions">Favorites</string>
     <string name="choose_to_delete">Select sessions</string>
-    <string name="day_separator">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
+    <string name="day_separator">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="12/29/14" id="date_of_congress_day">%2$s</xliff:g></string>
+    <string name="day_separator_content_description">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="December 29, 2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Delete all favorites?</string>
     <string name="dlg_delete_all_favorites_delete_all">Delete all</string>
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -186,6 +186,12 @@ private class FakeFormattingDelegate : FormattingDelegate {
         timeZoneOffset: ZoneOffset?,
     ) = throw NotImplementedError("Not needed for this test.")
 
+    override fun getFormattedDateLong(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
+
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -173,6 +173,19 @@ class AlarmsStateFactoryTest {
 }
 
 private class FakeFormattingDelegate : FormattingDelegate {
+
+    override fun getFormattedTimeShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
+
+    override fun getFormattedDateShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
+
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,
         moment: Moment,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListViewModelTest.kt
@@ -128,7 +128,6 @@ class ChangeListViewModelTest {
             assertThat(awaitItem()).isEqualTo(expectedState)
             expectNoEvents()
         }
-        verifyInvokedOnce(repository).readMeta()
         verifyInvokedOnce(repository).readUseDeviceTimeZoneEnabled()
     }
 
@@ -205,7 +204,7 @@ class ChangeListViewModelTest {
             )
         }
         return mock<SessionChangeParametersFactory> {
-            on { createSessionChangeParameters(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn parameters
+            on { createSessionChangeParameters(anyOrNull(), anyOrNull()) } doReturn parameters
         }
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -1,13 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress.changes
 
 import com.google.common.truth.Truth.assertThat
-import info.metadude.android.eventfahrplan.commons.temporal.DateFormatter
 import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.CANCELED
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.CHANGED
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.NEW
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.UNCHANGED
+import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.fail
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.threeten.bp.ZoneOffset
 
 private const val SOME_DATE = "8/13/15"
 private const val SOME_TIME = "5:15 PM"
@@ -33,7 +35,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             ContentDescriptionFormatter(mock()),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val actual = factory.createSessionChangeParameters(emptyList(), numDays = 0, useDeviceTimeZone = true)
         assertThat(actual).isEmpty()
@@ -45,7 +47,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(createUnchangedSession())
         val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
@@ -107,7 +109,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(createNewSession())
         val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
@@ -169,7 +171,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(createCanceledSession())
         val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
@@ -231,7 +233,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(createChangedSession())
         val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
@@ -293,7 +295,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(createChangedEmptySession())
         val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
@@ -355,7 +357,7 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
-            DateFormatterCallback,
+            FakeFormattingDelegate(),
         )
         val sessions = listOf(
             createUnchangedSession(dayIndex = 0),
@@ -509,11 +511,32 @@ private fun createContentDescriptionFormatter() = mock<ContentDescriptionFormatt
     on { getStateContentDescription(anyOrNull(), anyOrNull()) } doReturn ""
 }
 
-private object DateFormatterCallback : (Boolean) -> DateFormatter {
-    override fun invoke(useDeviceTimeZone: Boolean) = mock<DateFormatter> {
-        on { getFormattedDateShort(anyOrNull(), anyOrNull()) } doReturn SOME_DATE
-        on { getFormattedTimeShort(anyOrNull(), anyOrNull()) } doReturn SOME_TIME
-    }
+private class FakeFormattingDelegate : FormattingDelegate {
+
+    override fun getFormattedTimeShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = SOME_TIME
+
+    override fun getFormattedDateShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = SOME_DATE
+
+    override fun getFormattedDateTimeShort(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
+
+    override fun getFormattedDateTimeLong(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
+
 }
 
 private object CompleteResourceResolver : ResourceResolving {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -511,8 +511,8 @@ private fun createContentDescriptionFormatter() = mock<ContentDescriptionFormatt
 
 private object DateFormatterCallback : (Boolean) -> DateFormatter {
     override fun invoke(useDeviceTimeZone: Boolean) = mock<DateFormatter> {
-        on { getFormattedDate(anyOrNull(), anyOrNull()) } doReturn SOME_DATE
-        on { getFormattedTime(anyOrNull(), anyOrNull()) } doReturn SOME_TIME
+        on { getFormattedDateShort(anyOrNull(), anyOrNull()) } doReturn SOME_DATE
+        on { getFormattedTimeShort(anyOrNull(), anyOrNull()) } doReturn SOME_TIME
     }
 }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -8,6 +8,8 @@ import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.CHANGED
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.NEW
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeProperty.ChangeState.UNCHANGED
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
@@ -26,6 +28,7 @@ import org.threeten.bp.ZoneOffset
 
 private const val SOME_DATE = "8/13/15"
 private const val SOME_TIME = "5:15 PM"
+private const val SOME_DAY_SEPARATOR_TEXT = "Day 1 - 8/13/2015"
 
 class SessionChangeParametersFactoryTest {
 
@@ -35,9 +38,10 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             ContentDescriptionFormatter(mock()),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
-        val actual = factory.createSessionChangeParameters(emptyList(), numDays = 0, useDeviceTimeZone = true)
+        val actual = factory.createSessionChangeParameters(emptyList(), useDeviceTimeZone = true)
         assertThat(actual).isEmpty()
     }
 
@@ -47,11 +51,18 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(createUnchangedSession())
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
-        val expected = SessionChangeParameter.SessionChange(
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        val expectedSessionChange = SessionChangeParameter.SessionChange(
             id = "2342",
             title = SessionChangeProperty(
                 value = "Title",
@@ -100,7 +111,7 @@ class SessionChangeParametersFactoryTest {
             ),
             isCanceled = false,
         )
-        assertThat(actual).containsExactly(expected)
+        assertThat(actual).containsExactly(expectedSeparator, expectedSessionChange)
     }
 
     @Test
@@ -109,11 +120,18 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(createNewSession())
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
-        val expected = SessionChangeParameter.SessionChange(
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        val expectedSessionChange = SessionChangeParameter.SessionChange(
             id = "2342",
             title = SessionChangeProperty(
                 value = "Title",
@@ -162,7 +180,7 @@ class SessionChangeParametersFactoryTest {
             ),
             isCanceled = false,
         )
-        assertThat(actual).containsExactly(expected)
+        assertThat(actual).containsExactly(expectedSeparator, expectedSessionChange)
     }
 
     @Test
@@ -171,11 +189,18 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(createCanceledSession())
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
-        val expected = SessionChangeParameter.SessionChange(
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        val expectedSessionChange = SessionChangeParameter.SessionChange(
             id = "2342",
             title = SessionChangeProperty(
                 value = "Title",
@@ -224,7 +249,7 @@ class SessionChangeParametersFactoryTest {
             ),
             isCanceled = true,
         )
-        assertThat(actual).containsExactly(expected)
+        assertThat(actual).containsExactly(expectedSeparator, expectedSessionChange)
     }
 
     @Test
@@ -233,11 +258,18 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(createChangedSession())
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
-        val expected = SessionChangeParameter.SessionChange(
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        val expectedSessionChange = SessionChangeParameter.SessionChange(
             id = "2342",
             title = SessionChangeProperty(
                 value = "Title",
@@ -286,7 +318,7 @@ class SessionChangeParametersFactoryTest {
             ),
             isCanceled = false,
         )
-        assertThat(actual).containsExactly(expected)
+        assertThat(actual).containsExactly(expectedSeparator, expectedSessionChange)
     }
 
     @Test
@@ -295,11 +327,18 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(createChangedEmptySession())
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 1, useDeviceTimeZone = true)
-        val expected = SessionChangeParameter.SessionChange(
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        val expectedSessionChange = SessionChangeParameter.SessionChange(
             id = "2342",
             title = SessionChangeProperty(
                 value = "-",
@@ -348,7 +387,7 @@ class SessionChangeParametersFactoryTest {
             ),
             isCanceled = false,
         )
-        assertThat(actual).containsExactly(expected)
+        assertThat(actual).containsExactly(expectedSeparator, expectedSessionChange)
     }
 
     @Test
@@ -357,15 +396,22 @@ class SessionChangeParametersFactoryTest {
             CompleteResourceResolver,
             createSessionPropertiesFormatter(),
             createContentDescriptionFormatter(),
+            createDaySeparatorFactory(),
             FakeFormattingDelegate(),
         )
         val sessions = listOf(
             createUnchangedSession(dayIndex = 0),
             createUnchangedSession(dayIndex = 1),
         )
-        val actual = factory.createSessionChangeParameters(sessions, numDays = 2, useDeviceTimeZone = true)
+        val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
         assertThat(actual).hasSize(3)
-        assertThat(actual).contains(SessionChangeParameter.Separator("Day 1 ..."))
+        val expectedSeparator = SessionChangeParameter.Separator(
+            daySeparator = DaySeparatorProperty(
+                value = SOME_DAY_SEPARATOR_TEXT,
+                contentDescription = "",
+            )
+        )
+        assertThat(actual).contains(expectedSeparator)
     }
 
 }
@@ -511,6 +557,11 @@ private fun createContentDescriptionFormatter() = mock<ContentDescriptionFormatt
     on { getStateContentDescription(anyOrNull(), anyOrNull()) } doReturn ""
 }
 
+private fun createDaySeparatorFactory() = mock<DaySeparatorFactory> {
+    on { createDaySeparatorText(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn SOME_DAY_SEPARATOR_TEXT
+    on { createDaySeparatorContentDescription(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn ""
+}
+
 private class FakeFormattingDelegate : FormattingDelegate {
 
     override fun getFormattedTimeShort(
@@ -524,6 +575,12 @@ private class FakeFormattingDelegate : FormattingDelegate {
         moment: Moment,
         timeZoneOffset: ZoneOffset?,
     ) = SOME_DATE
+
+    override fun getFormattedDateLong(
+        useDeviceTimeZone: Boolean,
+        moment: Moment,
+        timeZoneOffset: ZoneOffset?,
+    ) = throw NotImplementedError("Not needed for this test.")
 
     override fun getFormattedDateTimeShort(
         useDeviceTimeZone: Boolean,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsParameterFactoryTest.kt
@@ -81,6 +81,12 @@ class SessionDetailsParameterFactoryTest {
             timeZoneOffset: ZoneOffset?,
         ) = throw NotImplementedError("Not needed for this test.")
 
+        override fun getFormattedDateLong(
+            useDeviceTimeZone: Boolean,
+            moment: Moment,
+            timeZoneOffset: ZoneOffset?,
+        ) = throw NotImplementedError("Not needed for this test.")
+
         override fun getFormattedDateTimeShort(
             useDeviceTimeZone: Boolean,
             moment: Moment,
@@ -133,6 +139,7 @@ class SessionDetailsParameterFactoryTest {
         override fun getLanguageContentDescription(languageCode: String) = ""
         override fun getStartTimeContentDescription(startTimeText: String) = ""
         override fun getStateContentDescription(session: Session, useDeviceTimeZone: Boolean) = ""
+        override fun getDaySeparatorContentDescription(dayIndex: Int, formattedDate: String) = ""
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsParameterFactoryTest.kt
@@ -68,6 +68,19 @@ class SessionDetailsParameterFactoryTest {
     }
 
     private class FakeFormattingDelegate : FormattingDelegate {
+
+        override fun getFormattedTimeShort(
+            useDeviceTimeZone: Boolean,
+            moment: Moment,
+            timeZoneOffset: ZoneOffset?,
+        ) = throw NotImplementedError("Not needed for this test.")
+
+        override fun getFormattedDateShort(
+            useDeviceTimeZone: Boolean,
+            moment: Moment,
+            timeZoneOffset: ZoneOffset?,
+        ) = throw NotImplementedError("Not needed for this test.")
+
         override fun getFormattedDateTimeShort(
             useDeviceTimeZone: Boolean,
             moment: Moment,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -2,6 +2,8 @@ package nerd.tuxmobil.fahrplan.congress.search
 
 import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
+import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
@@ -15,6 +17,7 @@ import org.mockito.kotlin.mock
 
 private const val SOME_DATE = "8/13/15"
 private const val SOME_TIME = "5:15 PM"
+private const val SOME_DAY_SEPARATOR_TEXT = "Day 1 - 8/13/2015"
 
 class SearchResultParameterFactoryTest {
 
@@ -27,31 +30,57 @@ class SearchResultParameterFactoryTest {
     }
 
     @Test
-    fun `createSearchResults returns sessions when sessions is not empty`() {
+    fun `createSearchResults returns separators and sessions when sessions is not empty`() {
         val factory = createFactory()
         val sessions = listOf(
             Session(
                 sessionId = "123",
                 title = "Session 123",
                 speakers = listOf("Jane Doe", "John Doe"),
+                dateText = "2015-08-13",
                 dateUTC = 1683981000000,
+            ),
+            Session(
+                sessionId = "456",
+                title = "Session 456",
+                speakers = listOf("Jane Doe", "John Doe"),
+                dateText = "2015-08-14",
+                dateUTC = 1684067400000,
             )
         )
         val results = factory.createSearchResults(sessions, useDeviceTimeZone = false)
         assertThat(results).isEqualTo(
             listOf(
+                SearchResultParameter.Separator(
+                    DaySeparatorProperty(
+                        value = SOME_DAY_SEPARATOR_TEXT,
+                        contentDescription = "",
+                    )
+                ),
                 SearchResultParameter.SearchResult(
                     id = "123",
                     title = SearchResultProperty(value = "Session 123", contentDescription = "Title: Session 123"),
                     speakerNames = SearchResultProperty(value = "Jane Doe; John Doe", contentDescription = "Speakers: Jane Doe; John Doe"),
                     startsAt = SearchResultProperty(value = "$SOME_DATE, $SOME_TIME", contentDescription = "Start time: $SOME_DATE, $SOME_TIME"),
-                )
+                ),
+                SearchResultParameter.Separator(
+                    DaySeparatorProperty(
+                        value = SOME_DAY_SEPARATOR_TEXT,
+                        contentDescription = "",
+                    )
+                ),
+                SearchResultParameter.SearchResult(
+                    id = "456",
+                    title = SearchResultProperty(value = "Session 456", contentDescription = "Title: Session 456"),
+                    speakerNames = SearchResultProperty(value = "Jane Doe; John Doe", contentDescription = "Speakers: Jane Doe; John Doe"),
+                    startsAt = SearchResultProperty(value = "$SOME_DATE, $SOME_TIME", contentDescription = "Start time: $SOME_DATE, $SOME_TIME"),
+                ),
             )
         )
     }
 
     @Test
-    fun `createSearchResults returns sessions with dashes when sessions is not empty and contains empty properties`() {
+    fun `createSearchResults returns separators and sessions with dashes when sessions is not empty and contains empty properties`() {
         val factory = createFactory()
         val sessions = listOf(
             Session(
@@ -64,6 +93,12 @@ class SearchResultParameterFactoryTest {
         val results = factory.createSearchResults(sessions, useDeviceTimeZone = false)
         assertThat(results).isEqualTo(
             listOf(
+                SearchResultParameter.Separator(
+                    DaySeparatorProperty(
+                        value = SOME_DAY_SEPARATOR_TEXT,
+                        contentDescription = "",
+                    )
+                ),
                 SearchResultParameter.SearchResult(
                     id = "123",
                     title = SearchResultProperty(value = "-", contentDescription = ""),
@@ -79,6 +114,7 @@ class SearchResultParameterFactoryTest {
             resourceResolving = CompleteResourceResolver,
             sessionPropertiesFormatting = sessionPropertiesFormatting,
             contentDescriptionFormatting = ContentDescriptionFormatter(CompleteResourceResolver),
+            daySeparatorFactory = daySeparatorFactory,
             formattingDelegate = formattingDelegate,
         )
     }
@@ -87,7 +123,13 @@ class SearchResultParameterFactoryTest {
         on { getFormattedSpeakers(anyOrNull()) } doReturn "Jane Doe; John Doe"
     }
 
+    private val daySeparatorFactory = mock<DaySeparatorFactory> {
+        on { createDaySeparatorText(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn SOME_DAY_SEPARATOR_TEXT
+        on { createDaySeparatorContentDescription(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn ""
+    }
+
     private val formattingDelegate = mock<FormattingDelegate> {
+        on { getFormattedDateShort(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn SOME_DATE
         on { getFormattedDateTimeLong(anyOrNull(), anyOrNull(), anyOrNull()) } doReturn "$SOME_DATE, $SOME_TIME"
     }
 }
@@ -95,10 +137,11 @@ class SearchResultParameterFactoryTest {
 private object CompleteResourceResolver : ResourceResolving {
     override fun getString(id: Int, vararg formatArgs: Any) = when (id) {
         R.string.dash -> "-"
-        R.string.session_list_item_title_content_description -> "Title: Session 123"
+        R.string.session_list_item_title_content_description -> "Title: ${formatArgs.first()}"
         R.string.session_list_item_start_time_content_description -> "Start time: $SOME_DATE, $SOME_TIME"
         R.string.session_list_item_zero_speakers_content_description -> "No speakers"
         R.plurals.session_list_item_speakers_content_description -> "Speakers: Jane Doe; John Doe"
+        R.string.day_separator -> "Day ${formatArgs.first()} - ${formatArgs.last()}"
         else -> fail("Unknown string id : $id")
     }
 

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -18,6 +18,7 @@ class DateFormatter private constructor(
     private val timeShortNumberOnlyFormatter = DateTimeFormatter.ofPattern("HH:mm")
     private val timeShortFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val dateShortFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+    private val dateLongFormatter = DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG)
     private val dateShortTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT, FormatStyle.SHORT)
     private val dateLongTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.SHORT)
     private val dateFullTimeShortFormatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.FULL, FormatStyle.SHORT)
@@ -60,6 +61,19 @@ class DateFormatter private constructor(
     fun getFormattedDateShort(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
         val zoneOffset = zoneOffsetProvider.getAvailableZoneOffset(sessionZoneOffset)
         return dateShortFormatter.format(moment.toZonedDateTime(zoneOffset))
+    }
+
+    /**
+     * Returns day, month and year in current system locale in long format.
+     * E.g. January 22, 2019 or 22. Januar 2019
+     *
+     * Formatting happens by taking the [original time zone of the associated session][sessionZoneOffset]
+     * into account. If [sessionZoneOffset] is missing then formatting falls back to using the
+     * current time zone offset of the device.
+     */
+    fun getFormattedDateLong(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
+        val zoneOffset = zoneOffsetProvider.getAvailableZoneOffset(sessionZoneOffset)
+        return dateLongFormatter.format(moment.toZonedDateTime(zoneOffset))
     }
 
     /**

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatter.kt
@@ -38,26 +38,26 @@ class DateFormatter private constructor(
 
     /**
      * Returns 01:00 AM, 02:00 PM, 14:00 etc, depending on current system locale either
-     * in 24 or 12 hour format. The latter featuring AM or PM postfixes.
+     * in 24 or 12 hour short format. The latter featuring AM or PM postfixes.
      *
      * Formatting happens by taking the [original time zone of the associated session][sessionZoneOffset]
      * into account. If [sessionZoneOffset] is missing then formatting falls back to using the
      * current time zone offset of the device.
      */
-    fun getFormattedTime(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
+    fun getFormattedTimeShort(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
         val zoneOffset = zoneOffsetProvider.getAvailableZoneOffset(sessionZoneOffset)
         return timeShortFormatter.format(moment.toZonedDateTime(zoneOffset))
     }
 
     /**
-     * Returns day, month and year in current system locale.
+     * Returns day, month and year in current system locale in short format.
      * E.g. 1/22/19 or 22.01.19
      *
      * Formatting happens by taking the [original time zone of the associated session][sessionZoneOffset]
      * into account. If [sessionZoneOffset] is missing then formatting falls back to using the
      * current time zone offset of the device.
      */
-    fun getFormattedDate(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
+    fun getFormattedDateShort(moment: Moment, sessionZoneOffset: ZoneOffset?): String {
         val zoneOffset = zoneOffsetProvider.getAvailableZoneOffset(sessionZoneOffset)
         return dateShortFormatter.format(moment.toZonedDateTime(zoneOffset))
     }

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -33,19 +33,19 @@ class DateFormatterTest {
     }
 
     @Test
-    fun getFormattedTime() {
+    fun getFormattedTimeShort() {
         Locale.setDefault(Locale("en", "US"))
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+1"))
-        assertThat(createDateFormatter().getFormattedTime(moment, getTimeZoneOffsetNow())).isEqualTo("1:00 AM")
+        assertThat(createDateFormatter().getFormattedTimeShort(moment, getTimeZoneOffsetNow())).isEqualTo("1:00 AM")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+14"))
-        assertThat(createDateFormatter().getFormattedTime(moment, getTimeZoneOffsetNow())).isEqualTo("2:00 PM")
+        assertThat(createDateFormatter().getFormattedTimeShort(moment, getTimeZoneOffsetNow())).isEqualTo("2:00 PM")
 
         Locale.setDefault(Locale("de", "DE"))
-        assertThat(createDateFormatter().getFormattedTime(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
+        assertThat(createDateFormatter().getFormattedTimeShort(moment, getTimeZoneOffsetNow())).isEqualTo("14:00")
 
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+6"))
-        assertThat(createDateFormatter().getFormattedTime(moment, getTimeZoneOffsetNow())).isEqualTo("06:00")
+        assertThat(createDateFormatter().getFormattedTimeShort(moment, getTimeZoneOffsetNow())).isEqualTo("06:00")
     }
 
     @Test
@@ -66,12 +66,12 @@ class DateFormatterTest {
     }
 
     @Test
-    fun getFormattedDate() {
+    fun getFormattedDateShort() {
         Locale.setDefault(Locale.US)
-        assertThat(createDateFormatter().getFormattedDate(moment, getTimeZoneOffsetNow())).isEqualTo("1/22/19")
+        assertThat(createDateFormatter().getFormattedDateShort(moment, getTimeZoneOffsetNow())).isEqualTo("1/22/19")
 
         Locale.setDefault(Locale.GERMANY)
-        assertThat(createDateFormatter().getFormattedDate(moment, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
+        assertThat(createDateFormatter().getFormattedDateShort(moment, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
     }
 
     // This test only passes when being executed in a JDK 9+ environment.

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/DateFormatterTest.kt
@@ -74,6 +74,15 @@ class DateFormatterTest {
         assertThat(createDateFormatter().getFormattedDateShort(moment, getTimeZoneOffsetNow())).isEqualTo("22.01.19")
     }
 
+    @Test
+    fun getFormattedDateLong() {
+        Locale.setDefault(Locale.US)
+        assertThat(createDateFormatter().getFormattedDateLong(moment, getTimeZoneOffsetNow())).isEqualTo("January 22, 2019")
+
+        Locale.setDefault(Locale.GERMANY)
+        assertThat(createDateFormatter().getFormattedDateLong(moment, getTimeZoneOffsetNow())).isEqualTo("22. Januar 2019")
+    }
+
     // This test only passes when being executed in a JDK 9+ environment.
     // See https://stackoverflow.com/questions/65732319/how-to-stabilize-flaky-datetimeformatteroflocalizeddatetime-test
     @Test


### PR DESCRIPTION
# Description
+ This visual grouping makes it easier to understand when sessions of the search result list take place without reading the detail information of each item.
+ The implementation matches the one of the schedule changes screen.
+ Revise `SessionChangeParametersFactory`.
  + Extract `DaySeparatorFactory` to be reusable.
  + Improve accessibility by adding content description to day separator.
  + Use `List<Session>#toVirtualDays()` to get rid of deprecated `Session#dayIndex` within `SessionChangeParametersFactory`.
+ Use `FormattingDelegate` in `SessionChangeParametersFactory`.
+ Let `DateFormatter` function names be more descriptive.

# Before & after
<img width="270" height="600" alt="search-before" src="https://github.com/user-attachments/assets/a1bed3b2-da8f-4197-83a9-0a612425dc94" /> <img width="270" height="600" alt="search-after" src="https://github.com/user-attachments/assets/60d0aa2b-cef1-40e4-9c02-4fadc2aed82a" />

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)