### PR TITLE
Use proper height for `SessionCardLayout`

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -50,6 +50,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.RecyclerView.LayoutParams
 import info.metadude.android.eventfahrplan.commons.flow.observe
 import info.metadude.android.eventfahrplan.commons.logging.Logging
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.R
@@ -750,6 +751,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
             val heightPx = layoutParams?.height ?: calculateSessionHeight(session)
             val heightDp = (heightPx / context.resources.displayMetrics.density).toInt()
             val showBorder = session.isHighlight && isAlternativeHighlightingEnabled
+            val shortSession = session.duration.toWholeMinutes() <= Duration.ofMinutes(15).toWholeMinutes()
 
             val titleContentDescription = contentDescriptionFormatter
                 .getTitleContentDescription(session.title)
@@ -772,6 +774,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
                 title = SessionProperty(
                     value = session.title,
                     contentDescription = titleContentDescription,
+                    maxLines = if (shortSession) 1 else 2,
                 ),
                 subtitle = SessionProperty(
                     value = session.subtitle,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -261,22 +261,7 @@ private fun SessionCardLayout(data: SessionCardData) {
                 }
             }.firstOrNull()?.measure(constraints)
 
-            // Calculate the total height of all placeables
-            var placeablesHeight = 0
-            if (titlePlaceable != null) {
-                placeablesHeight += titlePlaceable.height
-            }
-            if (subtitlePlaceable != null) {
-                placeablesHeight += subtitlePlaceable.height
-            }
-            if (speakerNamesAndLanguagesPlaceable != null) {
-                placeablesHeight += speakerNamesAndLanguagesPlaceable.height
-            }
-            if (trackNamePlaceable != null) {
-                placeablesHeight += trackNamePlaceable.height
-            }
-
-            layout(constraints.maxWidth, placeablesHeight) {
+            layout(constraints.maxWidth, cardHeightPx) {
                 var yPosition = 0
                 yPosition += innerPaddingPx
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -327,7 +327,7 @@ private fun Title(
             fontFamily = FontFamily(Font(R.font.roboto_condensed_medium)),
             fontSize = dimensionResource(R.dimen.session_drawable_title).toTextUnit(),
             color = textColor,
-            maxLines = 2,
+            maxLines = property.maxLines,
             overflow = Ellipsis,
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionProperty.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionProperty.kt
@@ -3,4 +3,5 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 data class SessionProperty<T>(
     val value: T,
     val contentDescription: String,
+    val maxLines: Int = Int.MAX_VALUE,
 )

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Duration.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Duration.kt
@@ -99,6 +99,7 @@ class Duration private constructor(private val duration: ThreeTenDuration) : Com
     fun toPartialMilliseconds() = duration.toMillis().toDouble()
 
     override fun compareTo(other: Duration): Int {
+        // TODO: Make comparison more generic to allow directly comparing Duration instances.
         return duration.compareTo(other.duration) / 1_000_000
     }
 


### PR DESCRIPTION
# Description
+ Fix title being shifted to the top of short session cards.
  + Use proper height for SessionCardLayout.
  + The issue occurred for sessions of 15 minutes or less.
+ Improve title rendering for short sessions (15 minutes or less).
  + Limits the text lines to be shown to one line if the vertical space of a session card is limited.

# Screenshots before and after
<img width="600" height="375" alt="before" src="https://github.com/user-attachments/assets/563a35ef-59b3-4eda-8fd2-1d94187be206" /> <img width="600" height="375" alt="after" src="https://github.com/user-attachments/assets/a977cfa5-ae89-4ad3-9e99-75ee5a9b25da" />

# Successfully tested on
with `ccc38c3` flavor, `debug` build, both portrait and landscape modes
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
