### PR TITLE
Update Portuguese (Brazil) translation.

### DIFF
--- a/app/src/main/res/values-pt-rBR/preferences.xml
+++ b/app/src/main/res/values-pt-rBR/preferences.xml
@@ -6,9 +6,14 @@
     <!--
     Synchronize with string-array/preference_entry_values_schedule_refresh
     -->
+    <string name="preference_dialog_title_schedule_refresh_interval">Escolher um intervalo de atualização do cronograma</string>
     <!--
     Synchronize with @strings/preference_default_value_schedule_refresh_interval_value
     -->
+    <string name="schedule_refresh_interval_title_unmodified">deixar sem modificação</string>
+    <string name="schedule_refresh_interval_title_every_30_seconds">a cada 30 segundos</string>
+    <string name="schedule_refresh_interval_title_every_60_seconds">a cada minuto</string>
+    <string name="schedule_refresh_interval_title_every_120_seconds">a cada 2 minutos</string>
     <!-- Schedule statistic -->
     <string name="preference_title_schedule_statistic">Estatísticas do Cronograma</string>
     <string name="preference_summary_schedule_statistic">Inspecionar valores da coluna do cronograma</string>
@@ -58,6 +63,9 @@
     <!-- Alternative highlighting -->
     <string name="preference_title_alternative_highlighting_enabled">Ativar o realce alternativo</string>
     <string name="preference_summary_alternative_highlighting_enabled">Adiciona uma borda ao redor das sessões favoritas.</string>
+    <!-- Fast swiping -->
+    <string name="preference_title_fast_swiping_enabled">Habilitar deslizar rápido</string>
+    <string name="preference_summary_fast_swiping_enabled">Permite deslizar por várias salas.</string>
     <!-- Alternative schedule URL -->
     <string name="preference_title_alternative_schedule_url">Configurar URL alternativa para o cronograma</string>
     <string name="preference_summary_alternative_schedule_url">Insira URL secundária caso o servidor pré-configurado não puder ser alcançado.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -73,6 +73,7 @@
     <string name="progress_processing_data">Processando o cronograma &#8230;</string>
     <string name="day">Dia</string>
     <string name="fahrplan">Cronograma</string>
+    <string name="schedule_generated_by">Cronograma gerado por: <xliff:g example="pretalx" id="name">%s</xliff:g>, <xliff:g example="2024.1.0" id="version">%s</xliff:g></string>
     <string name="schedule_no_schedule_data_title">Não há programação para exibir</string>
     <string name="schedule_no_schedule_data_subtitle">Por favor, volte mais tarde</string>
     <string name="appVersion">Versão do Aplicativo <xliff:g example="1.40.2" id="appVersion">%s</xliff:g></string>
@@ -109,12 +110,15 @@
     <string name="general_settings">Geral</string>
     <string name="starred_sessions">Favoritos</string>
     <string name="choose_to_delete">Selecione as sessões</string>
-    <string name="day_separator">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
+    <string name="day_separator">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="12/29/14" id="date_of_congress_day">%2$s</xliff:g></string>
+    <string name="day_separator_content_description">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="December 29, 2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Apagar todos os favoritos?</string>
     <string name="dlg_delete_all_favorites_delete_all">Apagar tudo</string>
     <string name="share_error_activity_not_found">Nenhum aplicativo adequado instalado.</string>
     <!-- Build information -->
     <string name="build_info_time">Tempo de build: <xliff:g example="2015-12-27T13:42Z" id="build_time">%s</xliff:g>
+    </string>
+    <string name="modified_at">        Hora da modificação: <xliff:g example="2015-12-26T23:24Z" id="modification_time">%s</xliff:g>
     </string>
     <string name="build_info_version_code">Versão do código: <xliff:g example="42" id="version_code">%s</xliff:g>
     </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@
     <string name="schedule_changes">Schedule changes</string>
 
     <string name="dash" translatable="false"><xliff:g id="dash">—</xliff:g></string>
-    <string name="development_settings" translatable="false">Development</string>
+    <string name="development_settings">Development</string>
     <string name="general_settings">General</string>
     <string name="starred_sessions">Favorites</string>
     <string name="choose_to_delete">Select sessions</string>


### PR DESCRIPTION
# Description
+ This translates the remaining strings to Portuguese (Brazil) :heart_eyes_cat: 
+ Thanks a lot @Smarzaro.
+ Two more strings are enabled for translation now.

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)