### PR TITLE
Add app-specific ColorScheme class

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopAppBar.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopAppBar.kt
@@ -2,12 +2,11 @@ package nerd.tuxmobil.fahrplan.congress.designsystem.bars
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.TopAppBar as Material3TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
-import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+import androidx.compose.material3.TopAppBar as Material3TopAppBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -20,7 +19,7 @@ fun TopAppBar(
     Material3TopAppBar(
         modifier = modifier,
         colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = colorResource(R.color.colorPrimary),
+            containerColor = EventFahrplanTheme.colorScheme.topAppBarContainer,
         ),
         title = title,
         navigationIcon = navigationIcon,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
@@ -1,0 +1,92 @@
+package nerd.tuxmobil.fahrplan.congress.designsystem.colors
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.ColorScheme as Material3ColorScheme
+
+@Immutable
+data class ColorScheme(
+
+    // Material 3 colors
+    val primary: Color,
+    val onPrimary: Color,
+    val primaryContainer: Color,
+    val onPrimaryContainer: Color,
+    val inversePrimary: Color,
+    val secondary: Color,
+    val onSecondary: Color,
+    val secondaryContainer: Color,
+    val onSecondaryContainer: Color,
+    val tertiary: Color,
+    val onTertiary: Color,
+    val tertiaryContainer: Color,
+    val onTertiaryContainer: Color,
+    val background: Color,
+    val onBackground: Color,
+    val surface: Color,
+    val onSurface: Color,
+    val surfaceVariant: Color,
+    val onSurfaceVariant: Color,
+    val surfaceTint: Color,
+    val inverseSurface: Color,
+    val inverseOnSurface: Color,
+    val error: Color,
+    val onError: Color,
+    val errorContainer: Color,
+    val onErrorContainer: Color,
+    val outline: Color,
+    val outlineVariant: Color,
+    val scrim: Color,
+    val surfaceBright: Color,
+    val surfaceDim: Color,
+    val surfaceContainer: Color,
+    val surfaceContainerHigh: Color,
+    val surfaceContainerHighest: Color,
+    val surfaceContainerLow: Color,
+    val surfaceContainerLowest: Color,
+
+    // Custom colors
+    val topAppBarContainer: Color,
+
+)
+
+internal fun ColorScheme.toMaterial3ColorScheme(): Material3ColorScheme {
+    return Material3ColorScheme(
+        primary = primary,
+        onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
+        inversePrimary = inversePrimary,
+        secondary = secondary,
+        onSecondary = onSecondary,
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = onSecondaryContainer,
+        tertiary = tertiary,
+        onTertiary = onTertiary,
+        tertiaryContainer = tertiaryContainer,
+        onTertiaryContainer = onTertiaryContainer,
+        background = background,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        surfaceVariant = surfaceVariant,
+        onSurfaceVariant = onSurfaceVariant,
+        surfaceTint = surfaceTint,
+        inverseSurface = inverseSurface,
+        inverseOnSurface = inverseOnSurface,
+        error = error,
+        onError = onError,
+        errorContainer = errorContainer,
+        onErrorContainer = onErrorContainer,
+        outline = outline,
+        outlineVariant = outlineVariant,
+        scrim = scrim,
+        surfaceBright = surfaceBright,
+        surfaceDim = surfaceDim,
+        surfaceContainer = surfaceContainer,
+        surfaceContainerHigh = surfaceContainerHigh,
+        surfaceContainerHighest = surfaceContainerHighest,
+        surfaceContainerLow = surfaceContainerLow,
+        surfaceContainerLowest = surfaceContainerLowest,
+    )
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
@@ -1,10 +1,11 @@
 package nerd.tuxmobil.fahrplan.congress.designsystem.colors
 
-import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import nerd.tuxmobil.fahrplan.congress.R
+import androidx.compose.material3.ColorScheme as Material3ColorScheme
 
 @Composable
 internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
@@ -19,6 +20,8 @@ internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
     outlineVariant = colorResource(R.color.outline_variant), // used by HorizontalDivider
     surfaceContainer = colorResource(R.color.colorPrimaryDark), // used by DropdownMenu
     surfaceContainerHigh = colorResource(android.R.color.transparent), // used by SearchBarDefaults.InputField container background
+).toColorScheme(
+    topAppBarContainer = colorResource(R.color.colorPrimary),
 )
 
 @Composable
@@ -34,8 +37,54 @@ internal fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     outlineVariant = colorResource(R.color.outline_variant),
     surfaceContainer = colorResource(R.color.colorPrimaryDark),
     surfaceContainerHigh = colorResource(android.R.color.transparent),
+).toColorScheme(
+    topAppBarContainer = colorResource(R.color.colorPrimary),
 )
 
 internal val LocalColorScheme = staticCompositionLocalOf<ColorScheme> {
     error("No ColorScheme provided")
+}
+
+private fun Material3ColorScheme.toColorScheme(
+    topAppBarContainer: Color,
+): ColorScheme {
+    return ColorScheme(
+        primary = primary,
+        onPrimary = onPrimary,
+        primaryContainer = primaryContainer,
+        onPrimaryContainer = onPrimaryContainer,
+        inversePrimary = inversePrimary,
+        secondary = secondary,
+        onSecondary = onSecondary,
+        secondaryContainer = secondaryContainer,
+        onSecondaryContainer = onSecondaryContainer,
+        tertiary = tertiary,
+        onTertiary = onTertiary,
+        tertiaryContainer = tertiaryContainer,
+        onTertiaryContainer = onTertiaryContainer,
+        background = background,
+        onBackground = onBackground,
+        surface = surface,
+        onSurface = onSurface,
+        surfaceVariant = surfaceVariant,
+        onSurfaceVariant = onSurfaceVariant,
+        surfaceTint = surfaceTint,
+        inverseSurface = inverseSurface,
+        inverseOnSurface = inverseOnSurface,
+        error = error,
+        onError = onError,
+        errorContainer = errorContainer,
+        onErrorContainer = onErrorContainer,
+        outline = outline,
+        outlineVariant = outlineVariant,
+        scrim = scrim,
+        surfaceBright = surfaceBright,
+        surfaceDim = surfaceDim,
+        surfaceContainer = surfaceContainer,
+        surfaceContainerHigh = surfaceContainerHigh,
+        surfaceContainerHighest = surfaceContainerHighest,
+        surfaceContainerLow = surfaceContainerLow,
+        surfaceContainerLowest = surfaceContainerLowest,
+        topAppBarContainer = topAppBarContainer,
+    )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/themes/EventFahrplanTheme.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/themes/EventFahrplanTheme.kt
@@ -6,9 +6,11 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import nerd.tuxmobil.fahrplan.congress.designsystem.colors.ColorScheme
 import nerd.tuxmobil.fahrplan.congress.designsystem.colors.LocalColorScheme
 import nerd.tuxmobil.fahrplan.congress.designsystem.colors.darkColorScheme
 import nerd.tuxmobil.fahrplan.congress.designsystem.colors.lightColorScheme
+import nerd.tuxmobil.fahrplan.congress.designsystem.colors.toMaterial3ColorScheme
 
 @Composable
 fun EventFahrplanTheme(
@@ -21,7 +23,7 @@ fun EventFahrplanTheme(
         LocalColorScheme provides colorScheme,
     ) {
         MaterialTheme(
-            colorScheme = colorScheme,
+            colorScheme = colorScheme.toMaterial3ColorScheme(),
             typography = MaterialTheme.typography,
             content = content,
         )
@@ -30,6 +32,11 @@ fun EventFahrplanTheme(
 }
 
 object EventFahrplanTheme {
+
+    val colorScheme: ColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalColorScheme.current
 
     val typography: Typography
         @Composable


### PR DESCRIPTION
Adds a `ColorScheme` class that combines Material 3's named colors and app-specific custom colors. It's a first step towards making all app-specific colors part of `EventFahrplanTheme`.

Once this is merged, Composables that fetch fixed colors via `colorResource()` can be changed to use (custom) colors from the theme instead.

It's also a first step towards moving away from overriding named Material colors to use transparency (see e.g. [here](https://github.com/EventFahrplan/EventFahrplan/blob/504b0f37b5f247bda980fd1588c557d33b8688cc/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt#L14)). Overriding the default instead of the concrete instances that need to be changed, makes it harder to use additional Material 3 components that use the same named colors, but "break" when a transparent color is used.