### PR TITLE
Remove unused properties from alarm models.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -8,8 +8,6 @@ import androidx.core.app.AlarmManagerCompat
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
-import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
-import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.PendingIntentDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.PendingIntentProvider
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSchedulableAlarm
@@ -31,9 +29,7 @@ class AlarmServices @VisibleForTesting constructor(
         private val alarmTimeValues: List<String>,
         private val logging: Logging,
         private val pendingIntentDelegate: PendingIntentDelegate,
-        private val formattingDelegate: FormattingDelegate,
 ) :
-    FormattingDelegate by formattingDelegate,
     PendingIntentDelegate by pendingIntentDelegate {
 
     companion object {
@@ -56,7 +52,6 @@ class AlarmServices @VisibleForTesting constructor(
                 alarmTimesArray.toList(),
                 logging = logging,
                 pendingIntentDelegate = PendingIntentProvider,
-                formattingDelegate = DateFormatterDelegate,
             )
         }
     }
@@ -80,18 +75,12 @@ class AlarmServices @VisibleForTesting constructor(
         logging.d(LOG_TAG, "Add alarm: Time = ${moment.toUtcDateTime()}, in seconds = $alarmTime.")
         val sessionId = session.sessionId
         val sessionTitle = session.title
-        val alarmTimeInMin = alarmTimes[alarmTimesIndex]
-        val useDeviceTimeZone = repository.readUseDeviceTimeZoneEnabled()
-        val timeText = formattingDelegate.getFormattedDateTimeShort(useDeviceTimeZone, moment, session.timeZoneOffset)
         val dayIndex = session.dayIndex
         val alarm = Alarm(
-            alarmTimeInMin = alarmTimeInMin,
             dayIndex = dayIndex,
-            displayTime = sessionStartTime,
             sessionId = sessionId,
             sessionTitle = sessionTitle,
             startTime = moment,
-            timeText = timeText,
         )
         val schedulableAlarm = alarm.toSchedulableAlarm()
         scheduleSessionAlarm(schedulableAlarm, true)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensions.kt
@@ -8,13 +8,10 @@ import info.metadude.android.eventfahrplan.database.models.Alarm as DatabaseAlar
 
 fun Alarm.toAlarmDatabaseModel() = DatabaseAlarm(
     id = id,
-    alarmTimeInMin = alarmTimeInMin,
     dayIndex = dayIndex,
-    displayTime = displayTime,
     sessionId = sessionId,
     title = sessionTitle,
     time = startTime,
-    timeText = timeText,
 )
 
 fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
@@ -26,11 +23,8 @@ fun Alarm.toSchedulableAlarm() = SchedulableAlarm(
 
 fun DatabaseAlarm.toAlarmAppModel() = Alarm(
     id = id,
-    alarmTimeInMin = alarmTimeInMin,
     dayIndex = dayIndex,
-    displayTime = displayTime,
     sessionId = sessionId,
     sessionTitle = title,
     startTime = time,
-    timeText = timeText,
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/Alarm.kt
@@ -5,32 +5,23 @@ import info.metadude.android.eventfahrplan.database.contract.FahrplanContract
 
 data class Alarm(
     val id: Int,
-    val alarmTimeInMin: Int,
     val dayIndex: Int,
-    val displayTime: Long,
     val sessionId: String,
     val sessionTitle: String,
     val startTime: Moment,
-    val timeText: String,
 ) {
 
     constructor(
-        alarmTimeInMin: Int,
         dayIndex: Int,
-        displayTime: Long,
         sessionId: String,
         sessionTitle: String,
         startTime: Moment,
-        timeText: String,
     ) : this(
         id = DEFAULT_VALUE_ID,
-        alarmTimeInMin = alarmTimeInMin,
         dayIndex = dayIndex,
-        displayTime = displayTime,
         sessionId = sessionId,
         sessionTitle = sessionTitle,
         startTime = startTime,
-        timeText = timeText,
     )
 
     companion object {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -71,7 +71,6 @@ class AlarmsStateFactoryTest {
             val alarms = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmTimeInMin = alarmTimeInMin,
                     alarmStartsAt = alarmStartsAt.toMilliseconds(),
                 )
             )
@@ -114,7 +113,6 @@ class AlarmsStateFactoryTest {
             val alarms = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmTimeInMin = alarmTimeInMin,
                     alarmStartsAt = alarmStartsAt.toMilliseconds(),
                 )
             )
@@ -155,16 +153,12 @@ class AlarmsStateFactoryTest {
 
     private fun createAlarm(
         sessionId: String,
-        alarmTimeInMin: Int = 10,
         alarmStartsAt: Long = 1620909000000,
     ) = Alarm(
-        alarmTimeInMin = alarmTimeInMin,
         dayIndex = 2,
-        displayTime = -1,
         sessionId = sessionId,
         sessionTitle = "Unused",
         startTime = Moment.ofEpochMilli(alarmStartsAt),
-        timeText = "Unused",
     )
 
     private fun calculateAlarmStartsAt(alarmTimeInMin: Int) =

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -53,7 +53,6 @@ class AlarmsViewModelTest {
             alarmsList = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmTimeInMin = ALARM_TIME_IN_MIN,
                     alarmStartsAt = ALARM_STARTS_AT
                 )
             ),
@@ -82,7 +81,6 @@ class AlarmsViewModelTest {
             alarmsList = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmTimeInMin = ALARM_TIME_IN_MIN,
                     alarmStartsAt = ALARM_STARTS_AT
                 )
             ),
@@ -117,7 +115,6 @@ class AlarmsViewModelTest {
                 alarmsList = listOf(
                     createAlarm(
                         sessionId = "s0",
-                        alarmTimeInMin = ALARM_TIME_IN_MIN,
                         alarmStartsAt = ALARM_STARTS_AT
                     )
                 ),
@@ -207,16 +204,12 @@ class AlarmsViewModelTest {
 
     private fun createAlarm(
         sessionId: String,
-        alarmTimeInMin: Int = 10,
         alarmStartsAt: Moment = Moment.ofEpochMilli(1620909000000)
     ) = Alarm(
-        alarmTimeInMin = alarmTimeInMin,
         dayIndex = 2,
-        displayTime = -1,
         sessionId = sessionId,
         sessionTitle = "Unused",
         startTime = alarmStartsAt,
-        timeText = "Unused"
     )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/AlarmExtensionsTest.kt
@@ -12,12 +12,9 @@ class AlarmExtensionsTest {
     @Test
     fun toAlarmAppModel_toAlarmDatabaseModel() {
         val alarm = AlarmDatabaseModel(
-            alarmTimeInMin = 20,
             dayIndex = 4,
-            displayTime = 1509617700000L,
             sessionId = "5237",
             time = Moment.ofEpochMilli(1509617700001L),
-            timeText = "02/11/2017 11:05",
             title = "My title",
         )
         assertThat(alarm.toAlarmAppModel().toAlarmDatabaseModel()).isEqualTo(alarm)
@@ -26,13 +23,10 @@ class AlarmExtensionsTest {
     @Test
     fun toSchedulableAlarm() {
         val alarm = Alarm(
-            alarmTimeInMin = 20,
             dayIndex = 4,
-            displayTime = 1509617700000L,
             sessionId = "5237",
             sessionTitle = "My title",
             startTime = Moment.ofEpochMilli(1509617700001L),
-            timeText = "02/11/2017 11:05",
         )
         val schedulableAlarm = SchedulableAlarm(
             dayIndex = 4,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryUncanceledSessionsForDayIndexTest.kt
@@ -258,13 +258,10 @@ class AppRepositoryUncanceledSessionsForDayIndexTest {
     }
 
     private fun createAlarm() = AlarmAppModel(
-        alarmTimeInMin = 0,
         dayIndex = dayIndex,
-        displayTime = 0,
         sessionId = sessionId,
         sessionTitle = "",
         startTime = Moment.ofEpochMilli(0),
-        timeText = "",
     )
 
     private fun createScheduleData(session: SessionAppModel): ScheduleData {

--- a/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
+++ b/database/src/androidTest/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensionsTest.kt
@@ -2,13 +2,10 @@ package info.metadude.android.eventfahrplan.database.extensions
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
 import info.metadude.android.eventfahrplan.database.models.Alarm
 import org.junit.jupiter.api.Test
 
@@ -17,21 +14,15 @@ class AlarmExtensionsTest {
     @Test
     fun toContentValues() {
         val alarm = Alarm(
-            alarmTimeInMin = 20,
             dayIndex = 4,
-            displayTime = 1509617700000L,
             sessionId = "5237",
             time = Moment.ofEpochMilli(1509617700001L),
-            timeText = "02/11/2017 11:05",
             title = "My title",
         )
         val values = alarm.toContentValues()
-        assertThat(values.getAsInteger(ALARM_TIME_IN_MIN)).isEqualTo(20)
         assertThat(values.getAsInteger(DAY_INDEX)).isEqualTo(4)
-        assertThat(values.getAsLong(DISPLAY_TIME)).isEqualTo(1509617700000L)
         assertThat(values.getAsString(SESSION_ID)).isEqualTo("5237")
         assertThat(values.getAsLong(TIME)).isEqualTo(1509617700001L)
-        assertThat(values.getAsString(TIME_TEXT)).isEqualTo("02/11/2017 11:05")
         assertThat(values.getAsString(SESSION_TITLE)).isEqualTo("My title")
     }
 

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/contract/FahrplanContract.java
@@ -39,18 +39,14 @@ public interface FahrplanContract {
 
             /* 00 */ String ID = "_id";
             /* 01 */ String SESSION_TITLE = "title";
-            /* 02 */ String ALARM_TIME_IN_MIN = "alarm_time_in_min";
-            /* 03 */ String TIME = "time";
-            /* 04 */ String TIME_TEXT = "timeText";
-            /* 05 */ String SESSION_ID = "eventid"; // Keep column name to avoid database migration.
-            /* 06 */ String DISPLAY_TIME = "displayTime";
-            /* 07 */ String DAY_INDEX = "day";
+            /* 02 */ String TIME = "time";
+            /* 03 */ String SESSION_ID = "eventid"; // Keep column name to avoid database migration.
+            /* 04 */ String DAY_INDEX = "day";
         }
 
         interface Defaults {
 
             int DEFAULT_VALUE_ID = 0;
-            int ALARM_TIME_IN_MIN_DEFAULT = -1;
         }
 
     }

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/AlarmExtensions.kt
@@ -1,21 +1,15 @@
 package info.metadude.android.eventfahrplan.database.extensions
 
 import androidx.core.content.contentValuesOf
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
 import info.metadude.android.eventfahrplan.database.models.Alarm
 
 fun Alarm.toContentValues() = contentValuesOf(
-        ALARM_TIME_IN_MIN to alarmTimeInMin,
         DAY_INDEX to dayIndex,
-        DISPLAY_TIME to displayTime,
         SESSION_ID to sessionId,
         SESSION_TITLE to title,
         TIME to time.toMilliseconds(),
-        TIME_TEXT to timeText
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/models/Alarm.kt
@@ -1,16 +1,12 @@
 package info.metadude.android.eventfahrplan.database.models
 
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Defaults.ALARM_TIME_IN_MIN_DEFAULT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Defaults.DEFAULT_VALUE_ID
 
 data class Alarm(
     val id: Int = DEFAULT_VALUE_ID,
-    val alarmTimeInMin: Int = ALARM_TIME_IN_MIN_DEFAULT,
     val dayIndex: Int = -1,
-    val displayTime: Long = -1, // will be stored as signed integer
     val sessionId: String = "",
     val time: Moment = Moment.ofEpochMilli(-1), // will be stored as signed integer
-    val timeText: String = "",
     val title: String = "",
 )

--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/sqliteopenhelper/AlarmsDBOpenHelper.kt
@@ -3,17 +3,12 @@ package info.metadude.android.eventfahrplan.database.sqliteopenhelper
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ALARM_TIME_IN_MIN
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DAY_INDEX
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.DISPLAY_TIME
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_ID
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.SESSION_TITLE
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Columns.TIME_TEXT
-import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.Defaults.ALARM_TIME_IN_MIN_DEFAULT
 import info.metadude.android.eventfahrplan.database.contract.FahrplanContract.AlarmsTable.NAME
-import info.metadude.android.eventfahrplan.database.extensions.addIntegerColumn
 import info.metadude.android.eventfahrplan.database.extensions.dropTableIfExist
 
 internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
@@ -31,11 +26,8 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
         const val ALARMS_TABLE_CREATE = "CREATE TABLE $NAME (" +
                 "$ID INTEGER PRIMARY KEY, " +
                 "$SESSION_TITLE TEXT, " +
-                "$ALARM_TIME_IN_MIN INTEGER DEFAULT $ALARM_TIME_IN_MIN_DEFAULT, " +
                 "$TIME INTEGER, " +
-                "$TIME_TEXT TEXT, " +
                 "$SESSION_ID INTEGER, " +
-                "$DISPLAY_TIME INTEGER, " +
                 "$DAY_INDEX INTEGER" +
                 ");"
     }
@@ -45,9 +37,6 @@ internal class AlarmsDBOpenHelper(context: Context) : SQLiteOpenHelper(
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = with(db) {
-        if (oldVersion < 2 && newVersion >= 2) {
-            addIntegerColumn(tableName = NAME, columnName = ALARM_TIME_IN_MIN, default = ALARM_TIME_IN_MIN_DEFAULT)
-        }
         if (oldVersion < 3) {
             // Clear database from 34C3.
             dropTableIfExist(NAME)


### PR DESCRIPTION
# Description
+ The three values (database columns `alarm_time_in_min`, `timeText` and `displayTime` are never read from the database. Hence, there is no reason to store them. Name-based column access is used throughout, so column index order changes do not break code.
+ The `alarm_time_in_min` and `timeText` columns are unused since: 0d3b128a665906df6d34d59b91f3ef6846e34f03.
+ The `displayTime` column (5) was stopped to be read in favor of the `time` column (3) in commit c67d67d5ff6ad05820a19e13c020bd18070bc208 after the database column indices have been shifted in commit 1ac208e51d0acb46e157b9c68d7414f330fcbd9c due to the introduction of the new `alarm_time_in_min` column.
+ The columns remain in the `alarms` database as zombies for apps which are already at database version 7. New installations will no longer create these columns.

# Successfully tested on
with `datenspuren2025` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/512
- https://github.com/EventFahrplan/EventFahrplan/pull/550