### PR TITLE
Add divider attribute to color scheme

### DIFF
--- a/app/src/ccc38c3/res/values/colors.xml
+++ b/app/src/ccc38c3/res/values/colors.xml
@@ -8,7 +8,7 @@
     <color name="windowBackground">#aa0f000a</color>
     <color name="window_background_inverted">#E7BFBDDB</color>
     <color name="multi_choice_background">#80181A</color>
-    <color name="outline_variant">#33ff5053</color>
+    <color name="divider">#33ff5053</color>
     <color name="session_alarm_item_bell_icon_text">#fef2ff</color>
 
     <!-- Alarm dialogs -->

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
@@ -47,6 +47,7 @@ data class ColorScheme(
 
     // Custom colors
     val topAppBarContainer: Color,
+    val divider: Color,
 
 )
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
@@ -17,11 +17,11 @@ internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
     onSurfaceVariant = colorResource(R.color.text_secondary), // used by SearchBarDefaults.InputField placeholder, ListItem -> overlineContent
     inverseOnSurface = colorResource(R.color.session_item_text_on_highlight_background), // used by SessionCard
     outline = colorResource(R.color.colorAccent), // used by SearchBarDefaults.InputField divider
-    outlineVariant = colorResource(R.color.outline_variant), // used by HorizontalDivider
     surfaceContainer = colorResource(R.color.colorPrimaryDark), // used by DropdownMenu
     surfaceContainerHigh = colorResource(android.R.color.transparent), // used by SearchBarDefaults.InputField container background
 ).toColorScheme(
     topAppBarContainer = colorResource(R.color.colorPrimary),
+    divider = colorResource(R.color.divider),
 )
 
 @Composable
@@ -34,11 +34,11 @@ internal fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     onSurfaceVariant = colorResource(R.color.text_secondary_inverted),
     inverseOnSurface = colorResource(R.color.session_item_text_on_highlight_background),
     outline = colorResource(R.color.colorAccent),
-    outlineVariant = colorResource(R.color.outline_variant),
     surfaceContainer = colorResource(R.color.colorPrimaryDark),
     surfaceContainerHigh = colorResource(android.R.color.transparent),
 ).toColorScheme(
     topAppBarContainer = colorResource(R.color.colorPrimary),
+    divider = colorResource(R.color.divider),
 )
 
 internal val LocalColorScheme = staticCompositionLocalOf<ColorScheme> {
@@ -47,6 +47,7 @@ internal val LocalColorScheme = staticCompositionLocalOf<ColorScheme> {
 
 private fun Material3ColorScheme.toColorScheme(
     topAppBarContainer: Color,
+    divider: Color,
 ): ColorScheme {
     return ColorScheme(
         primary = primary,
@@ -86,5 +87,6 @@ private fun Material3ColorScheme.toColorScheme(
         surfaceContainerLow = surfaceContainerLow,
         surfaceContainerLowest = surfaceContainerLowest,
         topAppBarContainer = topAppBarContainer,
+        divider = divider,
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/dividers/DividerHorizontal.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/dividers/DividerHorizontal.kt
@@ -5,13 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import androidx.compose.material3.HorizontalDivider as Material3HorizontalDivider
 
 @Composable
 fun DividerHorizontal(
     modifier: Modifier = Modifier,
     thickness: Dp = DividerDefaults.Thickness,
-    color: Color = DividerDefaults.color,
+    color: Color = EventFahrplanTheme.colorScheme.divider,
 ) {
     Material3HorizontalDivider(
         modifier = modifier,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -381,6 +381,12 @@ private fun SearchScreenPreview() {
                     speakerNames = SearchResultProperty("Hedy Llamar", ""),
                     startsAt = SearchResultProperty("December 27, 2024 10:00", ""),
                 ),
+                SearchResult(
+                    id = "2",
+                    title = SearchResultProperty("Dolor sit amet", ""),
+                    speakerNames = SearchResultProperty("Hedy Llamar", ""),
+                    startsAt = SearchResultProperty("December 27, 2024 12:00", ""),
+                ),
                 Separator(
                     DaySeparatorProperty(
                         value = "DAY 2 - 12/28/2024",

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -14,7 +14,7 @@
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
     <color name="text_link_pressed_background_on_light">#aafec700</color>
-    <color name="outline_variant">#88888888</color>
+    <color name="divider">#88888888</color>
 
     <!-- Scrollbar -->
     <color name="scrollbar_background">@color/colorAccent</color>


### PR DESCRIPTION
This avoids overwriting Material's `outlineVariant` which is used by multiple Material widgets.

This shouldn't change the appearance of the app since it currently doesn't use any Material widgets that use the `outlineVariant` theme color.

|Before|After|
|-|-|
|<img width="1060" height="2239" alt="image" src="https://github.com/user-attachments/assets/0a22e5ab-51a0-4a22-9ff3-06ae642aa1bc" />|<img width="890" height="1880" alt="image" src="https://github.com/user-attachments/assets/a020a34b-d206-4eb9-9317-40c9744966a2" />|
|<img width="1060" height="2239" alt="image" src="https://github.com/user-attachments/assets/38d1ec4c-4153-4c37-a461-eba335fe0bf2" />|<img width="1060" height="2239" alt="image" src="https://github.com/user-attachments/assets/596c2d41-0133-4f70-8fe3-ae0a39b9ac79" />|
|<img width="1052" height="108" alt="image" src="https://github.com/user-attachments/assets/bd8564fc-1c93-4b4a-90d5-5967ff370a58" />|<img width="1052" height="108" alt="image" src="https://github.com/user-attachments/assets/7c4aa8af-d96e-40af-a168-ea3944683bff" />|
|<img width="1052" height="1871" alt="image" src="https://github.com/user-attachments/assets/b924518e-4e4c-4789-b4d1-8167ff7c96ba" />|<img width="1052" height="1871" alt="image" src="https://github.com/user-attachments/assets/64253d00-aff3-4627-a832-e55c591354b5" />|
|<img width="1060" height="2239" alt="image" src="https://github.com/user-attachments/assets/0a67da2d-2043-4cdc-9f37-f4b0b20497a6" />|<img width="625" height="1319" alt="image" src="https://github.com/user-attachments/assets/1a10af49-0881-4f71-afd4-db71c958ebc0" />|
|<img width="1060" height="2239" alt="image" src="https://github.com/user-attachments/assets/a452d307-90a3-4539-997f-29a1bfe34c09" />|<img width="625" height="1319" alt="image" src="https://github.com/user-attachments/assets/1809a1e9-2a9c-4b3f-bae1-cd49f38be7ad" />|

The screenshots are from compose previews. But I also looked through the app using a Pixel 9 API 35 emulator.