### PR TITLE
Enable predictive back.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
 
     <application
         android:name="nerd.tuxmobil.fahrplan.congress.MyApp"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
@@ -76,11 +77,12 @@
         </activity>
         <activity
             android:name="nerd.tuxmobil.fahrplan.congress.search.SearchActivity"
+            android:enableOnBackInvokedCallback="false"
             android:label="@string/search_title"
             android:parentActivityName="nerd.tuxmobil.fahrplan.congress.schedule.MainActivity"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Congress.NoActionBar"
-            tools:targetApi="24" />
+            tools:targetApi="33" />
         <activity
             android:name="nerd.tuxmobil.fahrplan.congress.settings.SettingsActivity"
             android:label="@string/settings"


### PR DESCRIPTION
# Description
+ Enable predictive back for all screens except the search screen.
+ Disable predictive back for the search screen because the Compose components currently used do not support predictive back. The back gesture does not cause the expected visual predictive back effect.
  + `androidx.compose.material3.SearchBar`
  + `androidx.compose.material3.SearchBarDefaults.InputField`

# Screenshots
<img width="270" height="600" alt="phone-schedule" src="https://github.com/user-attachments/assets/b22750a6-b2fa-4037-b580-61d91bb00cbe" /> <img width="270" height="600" alt="phone-details" src="https://github.com/user-attachments/assets/32680daf-512b-4dde-96e5-e7b111e48e06" /> <img width="270" height="600" alt="phone-favorites" src="https://github.com/user-attachments/assets/c3263f09-4f76-4360-af6c-f9141ea64b2f" /> <img width="270" height="600" alt="phone-alarms" src="https://github.com/user-attachments/assets/4c0d11f9-f327-4453-9653-c0adc2803814" /> <img width="270" height="600" alt="phone-changes" src="https://github.com/user-attachments/assets/bd1bcab3-00ba-4ddf-8603-47f10c0325be" /> <img width="270" height="600" alt="phone-settings" src="https://github.com/user-attachments/assets/4f80fce9-37b6-4b94-b41d-5f538d9aee1b" /> <img width="270" height="600" alt="phone-statistic" src="https://github.com/user-attachments/assets/c47ebea1-4c4c-406a-adf3-23d418aa422a" />

# Screenshots search screens
+ The back gesture does not cause any predictive back behavior on the search screen. Therefore, predictive back is disabled for the screen to avoid any unexpected misbehavior which might occur later.

<img width="270" height="600" alt="search-result-back" src="https://github.com/user-attachments/assets/83649e7f-6df4-41cd-a26c-b5944fdb53f9" /> <img width="270" height="600" alt="search-recent-back" src="https://github.com/user-attachments/assets/cd2be556-f3e2-455d-a963-32b5a1f7c963" />


# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

## Related
- [Android 13: Predictive back gesture](https://developer.android.com/about/versions/13/features#predictive-back-nav)
  - [Codelab: Update your app to support future predictive back gesture, 28.07.2023](https://codelabs.developers.google.com/handling-gesture-back-navigation)
- [Android 14: Add support for built-in and custom predictive back animations](https://developer.android.com/about/versions/14/features/predictive-back)
- [Android 15: Predictive back animations enabled for apps that opted in](https://developer.android.com/about/versions/15/behavior-changes-all#predictive-back) 
- [Android docs: About predictive back](https://developer.android.com/develop/ui/compose/system/predictive-back)
  - [Socialite app](https://github.com/android/socialite)
- [Android docs: Predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture)
- [Android docs:  Add support for predictive back animations](https://developer.android.com/guide/navigation/custom-back/support-animations#fragments)
- [Basics for System Back, 12.05.2022](https://www.youtube.com/watch?v=Elpqr5xpLxQ)
- [ Building for the future of Android: Migrating to Predictive Back, 10.05.2023](https://www.youtube.com/watch?v=WMMPXayjP8g&t=335s)
- [Predictive Back Samples](https://github.com/android/platform-samples/tree/main/samples/user-interface/predictiveback)
- [Compose samples](https://github.com/android/compose-samples)
  - [Now in Android App](https://github.com/android/nowinandroid)

---

Relates #748