### PR TITLE
Fix edge-to-edge issues on schedule screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
@@ -43,6 +43,18 @@ fun View.applyHorizontalInsets(
     }
 }
 
+fun View.applyRightInsets(
+    typeMask: Int = systemBars() or displayCutout() or ime(),
+) {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { view, windowInsets ->
+        val insets = windowInsets.getInsets(typeMask)
+        view.updateLayoutParams<MarginLayoutParams> {
+            rightMargin = insets.right
+        }
+        windowInsets
+    }
+}
+
 fun View.applyBottomPadding(
     typeMask: Int = systemBars() or displayCutout() or ime(),
 ) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -62,6 +62,7 @@ import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.extensions.applyHorizontalInsets
+import nerd.tuxmobil.fahrplan.congress.extensions.applyRightInsets
 import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
 import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
@@ -362,6 +363,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
     private fun viewDay(scheduleData: ScheduleData, useDeviceTimeZone: Boolean) {
         val layoutRoot = requireView()
         val horizontalScroller = layoutRoot.requireViewByIdCompat<HorizontalSnapScrollView>(R.id.horizScroller)
+        horizontalScroller.applyRightInsets()
         horizontalScroller.scrollTo(0, 0)
         val roomCount = scheduleData.roomCount
         horizontalScroller.setRoomsCount(roomCount)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -61,6 +61,7 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmTimePickerFragment
 import nerd.tuxmobil.fahrplan.congress.calendar.CalendarSharing
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.applyHorizontalInsets
 import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
 import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
 import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
@@ -372,6 +373,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
         val roomScroller = layoutRoot.requireViewByIdCompat<HorizontalScrollView>(R.id.roomScroller)
         roomScroller.importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
         val roomTitlesRowLayout = roomScroller.getChildAt(0) as LinearLayout
+        roomTitlesRowLayout.applyHorizontalInsets()
         val columnWidth = horizontalScroller.columnWidth
         addRoomTitleViews(roomTitlesRowLayout, columnWidth, scheduleData.roomNames)
         addRoomColumns(horizontalScroller, columnWidth, scheduleData, useDeviceTimeZone)


### PR DESCRIPTION
# Description
+ Fix room titles not being centered.
  + At the same time, room titles are no longer run under 3-button navigation if enabled.
+ Fix session cards to not being covered by 3-button navigation.
  + If 3-button navigation is enabled parts of the session card text or icons can become unreadable. Hence, the right inset will be applied if the device is used in landscape orientation.

# Before and after screenshots
## 3-button navigation left, camera cutout right
<img width="600" height="270" alt="schedule-screen-cam-before" src="https://github.com/user-attachments/assets/bb8be3d1-c52b-488f-a473-6d6431875fee" /> <img width="600" height="270" alt="schedule-screen-cam-after" src="https://github.com/user-attachments/assets/8782dda8-458d-428b-b335-df8405631cb7" />
## 3-button navigation right, camera cutout left
<img width="600" height="270" alt="schedule-screen-3bn-before" src="https://github.com/user-attachments/assets/1db71753-1e58-40c5-8aea-059d0536261c" /> <img width="600" height="270" alt="schedule-screen-3bn-after" src="https://github.com/user-attachments/assets/0fdbd666-3f93-4e8f-adb5-cad99567c2e8" />

# Successfully tested on
with `ccc38c3` flavor, `debug` build, both portrait and landscape modes
- :heavy_check_mark: Google Pixel 6, Android 15 (API 35)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---

Relates #748, #785