### PR TITLE
Add new settings screen (part 3)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/NewSettingsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/NewSettingsActivity.kt
@@ -1,5 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -15,8 +16,19 @@ class NewSettingsActivity : BaseActivity() {
             EventFahrplanTheme {
                 SettingsScreen(
                     onBack = { onBackPressedDispatcher.onBackPressed() },
+                    onSetActivityResult = ::setActivityResult
                 )
             }
         }
+    }
+
+    private fun setActivityResult(keys: List<String>) {
+        val resultIntent = Intent().apply {
+            for (key in keys) {
+                putExtra(key, true)
+            }
+        }
+
+        setResult(RESULT_OK, resultIntent)
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEffect.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEffect.kt
@@ -1,0 +1,7 @@
+package nerd.tuxmobil.fahrplan.congress.settings
+
+import kotlinx.collections.immutable.ImmutableList
+
+internal sealed interface SettingsEffect {
+    data class SetActivityResult(val keys: ImmutableList<String>) : SettingsEffect
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
@@ -1,10 +1,14 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import info.metadude.android.eventfahrplan.commons.flow.observe
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.SetActivityResult
 
 @Composable
 internal fun SettingsScreen(
@@ -12,8 +16,18 @@ internal fun SettingsScreen(
         factory = SettingsViewModelFactory(context = LocalContext.current),
     ),
     onBack: () -> Unit,
+    onSetActivityResult: (List<String>) -> Unit,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(lifecycleOwner) {
+        viewModel.effects.observe(lifecycleOwner) { effect ->
+            when (effect) {
+                is SetActivityResult -> onSetActivityResult(effect.keys)
+            }
+        }
+    }
 
     // TODO: Add navigation for different settings sub-screens here
     SettingsListScreen(state, onViewEvent = viewModel::onViewEvent, onBack = onBack)


### PR DESCRIPTION
# Description

- Adds support for effects to `SettingsViewModel` and `SettingsScreen`
- Replicates the activity result mechanism used by `SettingsFragment` to communicate settings changes to `MainActivity`.

Implements parts of https://github.com/EventFahrplan/EventFahrplan/issues/764

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/791
- https://github.com/EventFahrplan/EventFahrplan/pull/793