### PR TITLE
Add new settings screen (part 6)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEffect.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEffect.kt
@@ -5,5 +5,6 @@ import kotlinx.collections.immutable.ImmutableList
 internal sealed interface SettingsEffect {
     data class NavigateTo(val destination: SettingsNavigationDestination) : SettingsEffect
     data object NavigateBack : SettingsEffect
+    data object LaunchNotificationSettingsScreen : SettingsEffect
     data class SetActivityResult(val keys: ImmutableList<String>) : SettingsEffect
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
@@ -4,6 +4,7 @@ internal sealed interface SettingsEvent {
     data object ScheduleStatisticClicked : SettingsEvent
 
     data object DeviceTimezoneClicked : SettingsEvent
+    data object CustomizeNotificationsClicked : SettingsEvent
 
     data object AlarmTimeClicked : SettingsEvent
     data class SetAlarmTime(val alarmTime: Int) : SettingsEvent

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -16,9 +16,11 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.bars.TopBar
 import nerd.tuxmobil.fahrplan.congress.designsystem.templates.Scaffold
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AlarmTimeClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificationsClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.ClickPreference
+import nerd.tuxmobil.fahrplan.congress.settings.widgets.ExternalClickPreference
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.PreferenceCategory
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.SwitchPreference
 
@@ -78,6 +80,14 @@ private fun CategoryGeneral(
             checked = state.settings.isUseDeviceTimeZoneEnabled,
             onCheckedChange = { onViewEvent(DeviceTimezoneClicked) },
         )
+
+        if (state.isNotificationSettingsVisible) {
+            ExternalClickPreference(
+                title = stringResource(R.string.preference_title_app_notification_settings),
+                subtitle = stringResource(R.string.preference_summary_app_notification_settings),
+                onClick = { onViewEvent(CustomizeNotificationsClicked) },
+            )
+        }
     }
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
@@ -1,5 +1,9 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -14,6 +18,7 @@ import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import info.metadude.android.eventfahrplan.commons.flow.observe
 import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticActivity
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.LaunchNotificationSettingsScreen
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateBack
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateTo
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.SetActivityResult
@@ -34,11 +39,13 @@ internal fun SettingsScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
     LaunchedEffect(lifecycleOwner) {
         viewModel.effects.observe(lifecycleOwner) { effect ->
             when (effect) {
                 is NavigateTo -> navController.navigate(effect.destination.route)
                 NavigateBack -> navController.popBackStack()
+                LaunchNotificationSettingsScreen -> context.launchSystemNotificationScreen()
                 is SetActivityResult -> onSetActivityResult(effect.keys)
             }
         }
@@ -61,5 +68,16 @@ internal fun SettingsScreen(
                 onDismiss = { navController.popBackStack() },
             )
         }
+    }
+}
+
+private fun Context.launchSystemNotificationScreen() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsUiState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsUiState.kt
@@ -1,10 +1,12 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
+import android.os.Build
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.preferences.Settings
 
 internal data class SettingsUiState(
     val isDevelopmentCategoryVisible: Boolean = BuildConfig.DEBUG,
+    val isNotificationSettingsVisible: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O,
 
     val settings: Settings = Settings(),
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys.USE_DEVICE_TIME_ZONE_UPDATED
 import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.LaunchNotificationSettingsScreen
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateBack
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateTo
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.SetActivityResult
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AlarmTimeClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificationsClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTime
@@ -43,6 +45,7 @@ internal class SettingsViewModel(
     fun onViewEvent(event: SettingsEvent) = when (event) {
         ScheduleStatisticClicked -> navigateTo(ScheduleStatistic)
         DeviceTimezoneClicked -> toggleUseDeviceTimeZoneEnabled()
+        CustomizeNotificationsClicked -> launchNotificationSettingsScreen()
         AlarmTimeClicked -> navigateTo(AlarmTime)
         is SetAlarmTime -> updateAlarmTime(event.alarmTime)
     }
@@ -51,6 +54,10 @@ internal class SettingsViewModel(
         val enabled = uiState.value.settings.isUseDeviceTimeZoneEnabled
         settingsRepository.setUseDeviceTimeZone(!enabled)
         updateActivityResult(USE_DEVICE_TIME_ZONE_UPDATED)
+    }
+
+    private fun launchNotificationSettingsScreen() {
+        sendEffect(LaunchNotificationSettingsScreen)
     }
 
     private fun updateAlarmTime(alarmTime: Int) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ExternalClickPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ExternalClickPreference.kt
@@ -1,0 +1,49 @@
+package nerd.tuxmobil.fahrplan.congress.settings.widgets
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.designsystem.modifiers.minimumInteractiveComponentSize
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+
+@Composable
+internal fun ExternalClickPreference(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .minimumInteractiveComponentSize()
+            .clickable(onClick = onClick)
+            .padding(
+                horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
+                vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
+            ),
+    ) {
+        PreferenceText(
+            title = title,
+            subtitle = subtitle,
+            modifier = Modifier.weight(1f),
+        )
+
+        Image(
+            painter = painterResource(R.drawable.ic_open_external),
+            colorFilter = ColorFilter.tint(EventFahrplanTheme.colorScheme.onSurface),
+            contentDescription = null,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}


### PR DESCRIPTION
# Description

- Adds "customize notifications" setting that will open Android's notification settings screen for this app

<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/91042b3e-159e-4271-8ead-b9a80630ee01" />

Implements parts of https://github.com/EventFahrplan/EventFahrplan/issues/764

# Related
- #791
- #793
- #794
- #795
- #796