### PR TITLE
Add new settings screen (part 11)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/ScheduleRefreshIntervalDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/ScheduleRefreshIntervalDialog.kt
@@ -1,0 +1,56 @@
+package nerd.tuxmobil.fahrplan.congress.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.toImmutableMap
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+import nerd.tuxmobil.fahrplan.congress.preferences.Settings
+import nerd.tuxmobil.fahrplan.congress.settings.widgets.PreferenceListDialog
+
+@Composable
+internal fun ScheduleRefreshIntervalDialog(
+    currentValue: Int,
+    onOptionSelected: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val entries = persistentMapOf(
+        -1 to stringResource(R.string.schedule_refresh_interval_title_unmodified),
+        30_000 to stringResource(R.string.schedule_refresh_interval_title_every_30_seconds),
+        60_000 to stringResource(R.string.schedule_refresh_interval_title_every_60_seconds),
+        120_000 to stringResource(R.string.schedule_refresh_interval_title_every_120_seconds),
+    ).toImmutableMap()
+
+    PreferenceListDialog(
+        title = stringResource(R.string.preference_dialog_title_schedule_refresh_interval),
+        entries = entries,
+        selectedOption = currentValue,
+        onOptionSelected = onOptionSelected,
+        onDismiss = onDismiss,
+    )
+}
+
+@Composable
+internal fun Settings.scheduleRefreshIntervalToUiString(): String {
+    return when (scheduleRefreshInterval) {
+        -1 -> stringResource(R.string.schedule_refresh_interval_title_unmodified)
+        30_000 -> stringResource(R.string.schedule_refresh_interval_title_every_30_seconds)
+        60_000 -> stringResource(R.string.schedule_refresh_interval_title_every_60_seconds)
+        120_000 -> stringResource(R.string.schedule_refresh_interval_title_every_120_seconds)
+        else -> error("Unsupported value: $scheduleRefreshInterval")
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun ScheduleRefreshIntervalDialogPreview() {
+    EventFahrplanTheme {
+        ScheduleRefreshIntervalDialog(
+            currentValue = -1,
+            onOptionSelected = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
@@ -3,6 +3,8 @@ package nerd.tuxmobil.fahrplan.congress.settings
 import android.net.Uri
 
 internal sealed interface SettingsEvent {
+    data object ScheduleRefreshIntervalClicked : SettingsEvent
+    data class SetScheduleRefreshInterval(val refreshInterval: Int) : SettingsEvent
     data object ScheduleStatisticClicked : SettingsEvent
 
     data object AutoUpdateClicked : SettingsEvent

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -20,6 +20,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AlarmToneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificationsClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.EngelsystemUrlClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleRefreshIntervalClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.AlternativeScheduleUrlPreference
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.ClickPreference
@@ -51,7 +52,7 @@ internal fun SettingsListScreen(
                 .padding(contentPadding)
         ) {
             if (state.isDevelopmentCategoryVisible) {
-                CategoryDevelopment(onViewEvent)
+                CategoryDevelopment(state, onViewEvent)
             }
 
             CategoryGeneral(state, onViewEvent)
@@ -66,9 +67,16 @@ internal fun SettingsListScreen(
 
 @Composable
 private fun CategoryDevelopment(
+    state: SettingsUiState,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     PreferenceCategory(stringResource(R.string.development_settings)) {
+        ClickPreference(
+            title = stringResource(R.string.preference_title_schedule_refresh_interval),
+            subtitle = state.settings.scheduleRefreshIntervalToUiString(),
+            onClick = { onViewEvent(ScheduleRefreshIntervalClicked) },
+        )
+
         ClickPreference(
             title = stringResource(R.string.preference_title_schedule_statistic),
             subtitle = stringResource(R.string.preference_summary_schedule_statistic),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsNavigationDestination.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsNavigationDestination.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.settings
 
 internal sealed class SettingsNavigationDestination(val route: String) {
     data object SettingsList : SettingsNavigationDestination("settings")
+    data object ScheduleRefreshInterval : SettingsNavigationDestination("schedule_refresh_interval")
     data object ScheduleStatistic : SettingsNavigationDestination("schedule_statistic")
     data object AlternativeScheduleUrl : SettingsNavigationDestination("alternative_schedule_url")
     data object AlarmTime : SettingsNavigationDestination("alarm_time")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
@@ -25,13 +25,15 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateBack
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateTo
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.PickAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.SetActivityResult
-import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTime
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetEngelsystemShiftsUrl
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.EngelSystemUrl
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleStatistic
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.SettingsList
 
@@ -72,6 +74,13 @@ internal fun SettingsScreen(
     ) {
         composable(route = SettingsList.route) {
             SettingsListScreen(state, onViewEvent = viewModel::onViewEvent, onBack = onBack)
+        }
+        dialog(route = ScheduleRefreshInterval.route) {
+            ScheduleRefreshIntervalDialog(
+                currentValue = state.settings.scheduleRefreshInterval,
+                onOptionSelected = { viewModel.onViewEvent(SetScheduleRefreshInterval(it)) },
+                onDismiss = { navController.popBackStack() },
+            )
         }
         activity(route = ScheduleStatistic.route) {
             activityClass = ScheduleStatisticActivity::class

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
@@ -28,14 +28,17 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AutoUpdateClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificationsClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.EngelsystemUrlClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleRefreshIntervalClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetEngelsystemShiftsUrl
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.EngelSystemUrl
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleStatistic
 
 internal class SettingsViewModel(
@@ -62,6 +65,8 @@ internal class SettingsViewModel(
     private val activityResultKeys = mutableSetOf<String>()
 
     fun onViewEvent(event: SettingsEvent) = when (event) {
+        ScheduleRefreshIntervalClicked -> navigateTo(ScheduleRefreshInterval)
+        is SetScheduleRefreshInterval -> updateScheduleRefreshInterval(event.refreshInterval)
         ScheduleStatisticClicked -> navigateTo(ScheduleStatistic)
         AutoUpdateClicked -> toggleAutoUpdateEnabled()
         DeviceTimezoneClicked -> toggleUseDeviceTimeZoneEnabled()
@@ -74,6 +79,13 @@ internal class SettingsViewModel(
         is SetAlarmTime -> updateAlarmTime(event.alarmTime)
         EngelsystemUrlClicked -> navigateTo(EngelSystemUrl)
         is SetEngelsystemShiftsUrl -> updateEngelsystemShiftsUrl(event.url)
+    }
+
+    private fun updateScheduleRefreshInterval(refreshInterval: Int) {
+        settingsRepository.setScheduleRefreshInterval(refreshInterval)
+        val isAutoUpdateEnabled = uiState.value.settings.isAutoUpdateEnabled
+        scheduleNextFetchUpdater.update(isAutoUpdateEnabled)
+        navigateBack()
     }
 
     private fun toggleAutoUpdateEnabled() {


### PR DESCRIPTION
# Description

- Adds "schedule refresh interval" setting

<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/99786c8d-bcf1-48ce-ab30-a375e76382b8" />

Tested with a Pixel 9a, API 36 emulator

Implements parts of https://github.com/EventFahrplan/EventFahrplan/issues/764

# Related
- #791
- #793
- #794
- #795
- #796
- #798
- #799
- #800
- #801
- #802