### PR TITLE
Add new settings screen (part 12)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
@@ -17,6 +17,7 @@ internal sealed interface SettingsEvent {
 
     data object AlarmToneClicked : SettingsEvent
     data class SetAlarmTone(val alarmTone: Uri?): SettingsEvent
+    data object InsistentAlarmClicked : SettingsEvent
     data object AlarmTimeClicked : SettingsEvent
     data class SetAlarmTime(val alarmTime: Int) : SettingsEvent
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -22,6 +22,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificat
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.EngelsystemUrlClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.FastSwipingClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.InsistentAlarmClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleRefreshIntervalClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.AlternativeScheduleUrlPreference
@@ -147,6 +148,13 @@ private fun CategoryAlarms(
             title = stringResource(R.string.preference_title_alarm_tone),
             subtitle = stringResource(R.string.preference_summary_alarm_tone),
             onClick = { onViewEvent(AlarmToneClicked) },
+        )
+
+        SwitchPreference(
+            title = stringResource(R.string.preference_title_insistent_alarms_enabled),
+            subtitle = stringResource(R.string.preference_summary_insistent_alarms_enabled),
+            checked = state.settings.isInsistentAlarmsEnabled,
+            onCheckedChange = { onViewEvent(InsistentAlarmClicked) },
         )
 
         ClickPreference(

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
@@ -31,6 +31,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.CustomizeNotificat
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.EngelsystemUrlClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.FastSwipingClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.InsistentAlarmClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleRefreshIntervalClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTime
@@ -80,6 +81,7 @@ internal class SettingsViewModel(
         FastSwipingClicked -> toggleFastSwipingEnabled()
         AlarmToneClicked -> pickAlarmTone()
         is SetAlarmTone -> updateAlarmTone(event.alarmTone)
+        InsistentAlarmClicked -> toggleInsistentAlarmsEnabled()
         AlarmTimeClicked -> navigateTo(AlarmTime)
         is SetAlarmTime -> updateAlarmTime(event.alarmTime)
         EngelsystemUrlClicked -> navigateTo(EngelSystemUrl)
@@ -133,6 +135,11 @@ internal class SettingsViewModel(
 
     private fun updateAlarmTone(alarmTone: Uri?) {
         settingsRepository.setAlarmTone(alarmTone)
+    }
+
+    private fun toggleInsistentAlarmsEnabled() {
+        val enabled = uiState.value.settings.isInsistentAlarmsEnabled
+        settingsRepository.setInsistentAlarms(!enabled)
     }
 
     private fun updateAlarmTime(alarmTime: Int) {


### PR DESCRIPTION
# Description

Adds the remaining settings:
- "Enable alternative highlighting"
- "Enable fast swiping"
- "Enable insistent alarm"

<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/e72b5613-286a-4876-bf04-951df9dbcfa6" />
<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/5b32c7d1-4062-46fe-971a-c9a443510b6a" />


Tested with a Pixel 9a, API 36 emulator

Implements parts of https://github.com/EventFahrplan/EventFahrplan/issues/764

# Related
- #791
- #793
- #794
- #795
- #796
- #798
- #799
- #800
- #801
- #802
- #803