### PR TITLE
Refactoring: Use `SettingsRepository` to retrieving settings (part 2)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServices.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.app.AlarmManagerCompat
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.PendingIntentDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.PendingIntentProvider
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toSchedulableAlarm
@@ -26,7 +25,6 @@ class AlarmServices @VisibleForTesting constructor(
         private val context: Context,
         private val repository: AppRepository,
         private val alarmManager: AlarmManager,
-        private val alarmTimeValues: List<String>,
         private val logging: Logging,
         private val pendingIntentDelegate: PendingIntentDelegate,
 ) :
@@ -44,12 +42,10 @@ class AlarmServices @VisibleForTesting constructor(
             logging: Logging = Logging.get()
         ): AlarmServices {
             val alarmManager = context.getAlarmManager()
-            val alarmTimesArray = context.resources.getStringArray(R.array.preference_entry_values_alarm_time)
             return AlarmServices(
                 context = context,
                 repository = repository,
                 alarmManager = alarmManager,
-                alarmTimesArray.toList(),
                 logging = logging,
                 pendingIntentDelegate = PendingIntentProvider,
             )
@@ -57,20 +53,13 @@ class AlarmServices @VisibleForTesting constructor(
     }
 
     /**
-     * Adds an alarm for the given [session] with the
-     * [alarm time][R.array.preference_entries_alarm_time_titles]
-     * corresponding with the given [alarmTimesIndex].
+     * Adds an alarm for the given [session] with the given alarm time offset.
      */
-    fun addSessionAlarm(session: Session, alarmTimesIndex: Int) {
-        logging.d(LOG_TAG, "Add alarm for session = ${session.sessionId}, alarmTimesIndex = $alarmTimesIndex.")
-        val alarmTimeStrings = ArrayList(alarmTimeValues)
-        val alarmTimes = ArrayList<Int>(alarmTimeStrings.size)
-        for (alarmTimeString in alarmTimeStrings) {
-            alarmTimes.add(alarmTimeString.toInt())
-        }
+    fun addSessionAlarm(session: Session, alarmTimeOffset: Int) {
+        logging.d(LOG_TAG, "Add alarm for session = ${session.sessionId}, alarmTimeOffset = $alarmTimeOffset.")
         val sessionStartTime = session.startsAt.toMilliseconds()
-        val alarmTimeOffset = alarmTimes[alarmTimesIndex] * Moment.MILLISECONDS_OF_ONE_MINUTE.toLong()
-        val alarmTime = sessionStartTime - alarmTimeOffset
+        val alarmTimeOffsetMs = alarmTimeOffset * Moment.MILLISECONDS_OF_ONE_MINUTE.toLong()
+        val alarmTime = sessionStartTime - alarmTimeOffsetMs
         val moment = Moment.ofEpochMilli(alarmTime)
         logging.d(LOG_TAG, "Add alarm: Time = ${moment.toUtcDateTime()}, in seconds = $alarmTime.")
         val sessionId = session.sessionId

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmTimePickerFragment.kt
@@ -1,30 +1,30 @@
 package nerd.tuxmobil.fahrplan.congress.alarms
 
-import nerd.tuxmobil.fahrplan.congress.R
-import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
-import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
-import nerd.tuxmobil.fahrplan.congress.BuildConfig
-import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-
-import android.os.Bundle
-import android.app.Dialog
-import android.view.View
-import android.widget.Spinner
-import android.widget.ArrayAdapter
 import android.annotation.SuppressLint
-
+import android.app.Dialog
+import android.os.Bundle
+import android.view.View
+import android.widget.ArrayAdapter
+import android.widget.Spinner
 import androidx.annotation.MainThread
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentResultListener
+import kotlinx.collections.immutable.ImmutableMap
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
+import nerd.tuxmobil.fahrplan.congress.extensions.requireViewByIdCompat
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
+import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
+import nerd.tuxmobil.fahrplan.congress.settings.getAlarmTimeEntries
 
 class AlarmTimePickerFragment : DialogFragment() {
 
     companion object {
-        const val ALARM_TIMES_INDEX_BUNDLE_KEY = "${BuildConfig.APPLICATION_ID}.ALARM_TIMES_INDEX_BUNDLE_KEY"
+        const val ALARM_TIME_BUNDLE_KEY = "${BuildConfig.APPLICATION_ID}.ALARM_TIME_BUNDLE_KEY"
         private const val FRAGMENT_TAG = "${BuildConfig.APPLICATION_ID}.ALARM_TIME_PICKER_FRAGMENT_TAG"
         private const val REQUEST_KEY_BUNDLE_KEY = "REQUEST_KEY_BUNDLE_KEY"
 
@@ -46,12 +46,13 @@ class AlarmTimePickerFragment : DialogFragment() {
     }
 
     private lateinit var spinner: Spinner
-    private var alarmTimeIndex = 0
+    private lateinit var alarmTimeEntries: ImmutableMap<Int, String>
 
     @MainThread
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val context = requireContext()
-        alarmTimeIndex = AppRepository.readAlarmTimeIndex()
+        val defaultAlarmTime = AppRepository.readAlarmTime()
+        alarmTimeEntries = getAlarmTimeEntries(context)
 
         @SuppressLint("InflateParams")
         val layout = context.getLayoutInflater().inflate(
@@ -60,34 +61,43 @@ class AlarmTimePickerFragment : DialogFragment() {
             false
         )
         // https://possiblemobile.com/2013/05/layout-inflation-as-intended/
-        initializeSpinner(layout)
+        initializeSpinner(layout, defaultAlarmTime)
         return AlertDialog.Builder(context).apply {
             setView(layout)
             setTitle(R.string.choose_alarm_time)
-            setPositiveButton(android.R.string.ok) { _, _ -> passBackAlarmTimesIndex() }
+            setPositiveButton(android.R.string.ok) { _, _ -> passBackAlarmTime() }
             setNegativeButton(android.R.string.cancel, null)
         }.create()
     }
 
-    private fun initializeSpinner(rootView: View) {
-        val arrayAdapter = ArrayAdapter.createFromResource(
+    private fun initializeSpinner(rootView: View, alarmTime: Int) {
+        val selectedItemPosition = alarmTimeEntries.keys.indexOf(alarmTime)
+            .takeIf { it != -1 } ?: error("Unsupported alarmTime: $alarmTime")
+
+        val arrayAdapter = ArrayAdapter(
             rootView.context,
-            R.array.preference_entries_alarm_time_titles,
-            android.R.layout.simple_spinner_item
+            android.R.layout.simple_spinner_item,
+            alarmTimeEntries.values.toList(),
         )
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner = rootView.requireViewByIdCompat<Spinner>(R.id.spinner).apply{
             adapter = arrayAdapter
-            setSelection(alarmTimeIndex)
+            setSelection(selectedItemPosition)
         }
     }
 
-    private fun passBackAlarmTimesIndex() {
-        val alarmTimesIndex = spinner.selectedItemPosition
+    private fun passBackAlarmTime() {
+        val selectedItemPosition = spinner.selectedItemPosition
+        val alarmTimeValues = alarmTimeEntries.keys.toList()
+        if (selectedItemPosition !in alarmTimeValues.indices) {
+            return
+        }
+
+        val alarmTime = alarmTimeValues[selectedItemPosition]
         val requestKey = requireArguments().getString(REQUEST_KEY_BUNDLE_KEY)
             ?: throw MissingRequestKeyException()
         val result = bundleOf(
-            ALARM_TIMES_INDEX_BUNDLE_KEY to alarmTimesIndex
+            ALARM_TIME_BUNDLE_KEY to alarmTime,
         )
         parentFragmentManager.setFragmentResult(requestKey, result)
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegate.kt
@@ -55,8 +55,8 @@ internal class SessionAlarmViewModelDelegate(
         }
     }
 
-    fun addAlarm(session: Session, alarmTimesIndex: Int) =
-        alarmServices.addSessionAlarm(session, alarmTimesIndex)
+    fun addAlarm(session: Session, alarmTime: Int) =
+        alarmServices.addSessionAlarm(session, alarmTime)
 
     fun deleteAlarm(session: Session) = alarmServices.deleteSessionAlarm(session)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsFragment.kt
@@ -236,10 +236,10 @@ class SessionDetailsFragment : Fragment(), MenuProvider {
     private fun showAlarmTimePicker() {
         AlarmTimePickerFragment.show(this, SESSION_DETAILS_FRAGMENT_REQUEST_KEY) { requestKey, result ->
             if (requestKey == SESSION_DETAILS_FRAGMENT_REQUEST_KEY &&
-                result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                result.containsKey(AlarmTimePickerFragment.ALARM_TIME_BUNDLE_KEY)
             ) {
-                val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
-                viewModel.addAlarm(alarmTimesIndex)
+                val alarmTime = result.getInt(AlarmTimePickerFragment.ALARM_TIME_BUNDLE_KEY)
+                viewModel.addAlarm(alarmTime)
             }
         }
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -174,9 +174,9 @@ internal class SessionDetailsViewModel(
         sessionAlarmViewModelDelegate.addAlarmWithChecks()
     }
 
-    fun addAlarm(alarmTimesIndex: Int) {
+    fun addAlarm(alarmTime: Int) {
         loadSelectedSession { session ->
-            sessionAlarmViewModelDelegate.addAlarm(session, alarmTimesIndex)
+            sessionAlarmViewModelDelegate.addAlarm(session, alarmTime)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
@@ -135,7 +135,7 @@ internal class DefaultSettingsRepository(
         return value.toInt()
     }
 
-    private fun getAlarmTime(): Int {
+    override fun getAlarmTime(): Int {
         val key = context.getString(R.string.preference_key_alarm_time_index)
         val defaultValue = context.getString(R.string.preference_default_value_alarm_time_value)
         val value = preferences.getString(key, defaultValue)!!

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
@@ -39,16 +39,6 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
         return value.toInt()
     }
 
-    override fun getAlarmTimeIndex(): Int {
-        val key = context.getString(R.string.preference_key_alarm_time_index)
-        val defaultValue = context.getString(R.string.preference_default_value_alarm_time_value)
-        val value = preferences.getString(key, defaultValue)!!
-        val entryValues = context.resources.getStringArray(R.array.preference_entry_values_alarm_time)
-        val defaultIndex = context.resources.getInteger(R.integer.preference_default_value_alarm_time_index)
-        val index = entryValues.indexOf(value)
-        return if (index == -1) defaultIndex else index
-    }
-
     override fun getDisplayDayIndex() = preferences.getInt(DISPLAY_DAY_INDEX_KEY, 1)
 
     override fun setDisplayDayIndex(displayDayIndex: Int) = preferences.edit {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
@@ -20,6 +20,7 @@ interface SettingsRepository {
     fun setAlarmTone(alarmTone: Uri?)
     fun isInsistentAlarmsEnabled(): Boolean
     fun setInsistentAlarms(enable: Boolean)
+    fun getAlarmTime(): Int
     fun setAlarmTime(alarmTime: Int)
 
     fun setScheduleRefreshInterval(interval: Int)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -5,8 +5,6 @@ interface SharedPreferencesRepository {
     fun getScheduleRefreshIntervalDefaultValue(): Int
     fun getScheduleRefreshInterval(): Int
 
-    fun getAlarmTimeIndex(): Int
-
     fun getDisplayDayIndex(): Int
     fun setDisplayDayIndex(displayDayIndex: Int)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -73,7 +73,6 @@ import nerd.tuxmobil.fahrplan.congress.net.LoadShiftsResult
 import nerd.tuxmobil.fahrplan.congress.net.ParseResult
 import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
 import nerd.tuxmobil.fahrplan.congress.net.ParseShiftsResult
-import nerd.tuxmobil.fahrplan.congress.preferences.AlarmTonePreference
 import nerd.tuxmobil.fahrplan.congress.preferences.RealSharedPreferencesRepository
 import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
@@ -89,7 +88,6 @@ import nerd.tuxmobil.fahrplan.congress.schedule.Conference
 import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanViewModel
 import nerd.tuxmobil.fahrplan.congress.search.SearchRepository
 import nerd.tuxmobil.fahrplan.congress.serialization.ScheduleChanges.Companion.computeSessionsWithChangeFlags
-import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 import nerd.tuxmobil.fahrplan.congress.validation.MetaValidation.validate
 import okhttp3.OkHttpClient
 import info.metadude.android.eventfahrplan.database.models.Meta as MetaDatabaseModel
@@ -1029,8 +1027,7 @@ object AppRepository : SearchRepository,
     fun readScheduleRefreshInterval() =
         sharedPreferencesRepository.getScheduleRefreshInterval()
 
-    fun readAlarmTimeIndex() =
-            sharedPreferencesRepository.getAlarmTimeIndex()
+    fun readAlarmTime() = settingsRepository.getAlarmTime()
 
     /**
      * Returns the alarm tone `Uri` or `null` for silent alarms to be used for notifications.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -675,20 +675,20 @@ class FahrplanFragment : Fragment(), MenuProvider {
     private fun showAlarmTimePicker() {
         AlarmTimePickerFragment.show(this, FAHRPLAN_FRAGMENT_REQUEST_KEY) { requestKey, result ->
             if (requestKey == FAHRPLAN_FRAGMENT_REQUEST_KEY &&
-                result.containsKey(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
+                result.containsKey(AlarmTimePickerFragment.ALARM_TIME_BUNDLE_KEY)
             ) {
-                val alarmTimesIndex = result.getInt(AlarmTimePickerFragment.ALARM_TIMES_INDEX_BUNDLE_KEY)
-                onAlarmTimesIndexPicked(alarmTimesIndex)
+                val alarmTime = result.getInt(AlarmTimePickerFragment.ALARM_TIME_BUNDLE_KEY)
+                onAlarmTimePicked(alarmTime)
             }
         }
     }
 
-    private fun onAlarmTimesIndexPicked(alarmTimesIndex: Int) {
+    private fun onAlarmTimePicked(alarmTime: Int) {
         if (lastSelectedSession == null) {
-            logging.e(LOG_TAG, "onAlarmTimesIndexPicked: session: null. alarmTimesIndex: $alarmTimesIndex")
-            throw MissingLastSelectedSessionException(alarmTimesIndex)
+            logging.e(LOG_TAG, "onAlarmTimePicked: session: null. alarmTime: $alarmTime")
+            throw MissingLastSelectedSessionException(alarmTime)
         } else {
-            viewModel.addAlarm(lastSelectedSession!!, alarmTimesIndex)
+            viewModel.addAlarm(lastSelectedSession!!, alarmTime)
             updateMenuItems()
         }
     }
@@ -866,6 +866,6 @@ class FahrplanFragment : Fragment(), MenuProvider {
 
 }
 
-private class MissingLastSelectedSessionException(alarmTimesIndex: Int) : NullPointerException(
-    "Last selected session is null for alarm times index = $alarmTimesIndex."
+private class MissingLastSelectedSessionException(alarmTime: Int) : NullPointerException(
+    "Last selected session is null for alarm time = $alarmTime."
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -287,9 +287,9 @@ internal class FahrplanViewModel(
         sessionAlarmViewModelDelegate.addAlarmWithChecks()
     }
 
-    fun addAlarm(session: Session, alarmTimesIndex: Int) {
+    fun addAlarm(session: Session, alarmTime: Int) {
         launch {
-            sessionAlarmViewModelDelegate.addAlarm(session, alarmTimesIndex)
+            sessionAlarmViewModelDelegate.addAlarm(session, alarmTime)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/AlarmTimeDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/AlarmTimeDialog.kt
@@ -1,8 +1,11 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
+import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
 import nerd.tuxmobil.fahrplan.congress.R
@@ -16,24 +19,26 @@ internal fun AlarmTimeDialog(
     onOptionSelected: (Int) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val entries = persistentMapOf(
-        0 to stringResource(R.string.alarm_time_title_at_start_time),
-        5 to stringResource(R.string.alarm_time_title_5_minutes_before),
-        10 to stringResource(R.string.alarm_time_title_10_minutes_before),
-        15 to stringResource(R.string.alarm_time_title_15_minutes_before),
-        20 to stringResource(R.string.alarm_time_title_20_minutes_before),
-        30 to stringResource(R.string.alarm_time_title_30_minutes_before),
-        45 to stringResource(R.string.alarm_time_title_45_minutes_before),
-        60 to stringResource(R.string.alarm_time_title_60_minutes_before),
-    ).toImmutableMap()
-
     PreferenceListDialog(
         title = stringResource(R.string.preference_dialog_title_alarm_time),
-        entries = entries,
+        entries = getAlarmTimeEntries(LocalContext.current),
         selectedOption = currentValue,
         onOptionSelected = onOptionSelected,
         onDismiss = onDismiss,
     )
+}
+
+internal fun getAlarmTimeEntries(context: Context): ImmutableMap<Int, String> {
+    return persistentMapOf(
+        0 to context.getString(R.string.alarm_time_title_at_start_time),
+        5 to context.getString(R.string.alarm_time_title_5_minutes_before),
+        10 to context.getString(R.string.alarm_time_title_10_minutes_before),
+        15 to context.getString(R.string.alarm_time_title_15_minutes_before),
+        20 to context.getString(R.string.alarm_time_title_20_minutes_before),
+        30 to context.getString(R.string.alarm_time_title_30_minutes_before),
+        45 to context.getString(R.string.alarm_time_title_45_minutes_before),
+        60 to context.getString(R.string.alarm_time_title_60_minutes_before),
+    ).toImmutableMap()
 }
 
 @Composable

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -47,44 +47,11 @@
         <item quantity="other">every <xliff:g example="5" id="seconds">%s</xliff:g> seconds</item>
     </plurals>
 
-    <!-- Alarm time index -->
+    <!-- Alarm time -->
     <string name="preference_key_alarm_time_index" translatable="false">default_alarm_time</string>
-    <!--
-    Synchronize with @strings/preference_default_value_alarm_time_value
-    -->
-    <integer name="preference_default_value_alarm_time_index">2</integer>
-    <!--
-    Synchronize with @integers/preference_default_value_alarm_time_index
-    and string-array/preference_entry_values_alarm_time
-    -->
     <string name="preference_default_value_alarm_time_value" translatable="false">10</string>
     <string name="preference_dialog_title_alarm_time">Choose a default alarm time</string>
     <string name="preference_title_alarm_time">Choose default alarm time</string>
-    <string-array name="preference_entries_alarm_time_titles" translatable="false">
-        <item>@string/alarm_time_title_at_start_time</item>
-        <item>@string/alarm_time_title_5_minutes_before</item>
-        <item>@string/alarm_time_title_10_minutes_before</item>
-        <item>@string/alarm_time_title_15_minutes_before</item>
-        <item>@string/alarm_time_title_20_minutes_before</item>
-        <item>@string/alarm_time_title_30_minutes_before</item>
-        <item>@string/alarm_time_title_45_minutes_before</item>
-        <item>@string/alarm_time_title_60_minutes_before</item>
-    </string-array>
-    <!--
-    Synchronize with @strings/preference_default_value_alarm_time_value
-    and @integers/preference_default_value_alarm_time_index
-    -->
-    <string-array name="preference_entry_values_alarm_time" translatable="false">
-        <item>0</item>
-        <item>5</item>
-        <item>10</item>
-        <item>15</item>
-        <item>20</item>
-        <item>30</item>
-        <item>45</item>
-        <item>60</item>
-    </string-array>
-
 
     <!-- Alarm tone -->
     <string name="preference_key_alarm_tone" translatable="false">reminder_tone</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmServicesTest.kt
@@ -21,7 +21,6 @@ import nerd.tuxmobil.fahrplan.congress.models.Alarm
 import nerd.tuxmobil.fahrplan.congress.models.SchedulableAlarm
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
-import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -35,7 +34,6 @@ class AlarmServicesTest {
     private var alarmManager = mock<AlarmManager>()
     private var mockContext = mock<Context>()
     private var repository = mock<AppRepository>()
-    private val alarmTimesValues = listOf("0", "10", "60")
     private val alarm = SchedulableAlarm(
         dayIndex = 3,
         sessionId = "1001",
@@ -67,7 +65,7 @@ class AlarmServicesTest {
             timeZoneOffset = ZoneOffset.of("+02:00"),
         )
 
-        alarmServices.addSessionAlarm(session, alarmTimesValues.indexOf("60"))
+        alarmServices.addSessionAlarm(session, 60)
         // AlarmServices invokes scheduleSessionAlarm() which is tested separately.
         val expectedAlarm = Alarm(
             dayIndex = 1,
@@ -76,21 +74,6 @@ class AlarmServicesTest {
             startTime = Moment.ofEpochMilli(1536328800000),
         )
         verifyInvokedOnce(repository).updateAlarm(expectedAlarm)
-    }
-
-    @Test
-    fun `addSessionAlarm throws exception if alarm time index exceeds `() {
-        val pendingIntentDelegate = mock<PendingIntentDelegate>()
-        val alarmServices = createAlarmServices(pendingIntentDelegate)
-        val session = Session(sessionId = "S2", dateUTC = 1536332400000L) // 2018-09-07T17:00:00+02:00
-
-        try {
-            alarmServices.addSessionAlarm(session, alarmTimesValues.size) // Out of bounds!
-            fail("Expect an IndexOutOfBoundsException to be thrown.")
-        } catch (e: IndexOutOfBoundsException) {
-            assertThat(e.message).isEqualTo("Index 3 out of bounds for length 3")
-        }
-        verifyNoInteractions(pendingIntentDelegate)
     }
 
     @Test
@@ -208,7 +191,6 @@ class AlarmServicesTest {
         context = mockContext,
         repository = repository,
         alarmManager = alarmManager,
-        alarmTimeValues = alarmTimesValues,
         logging = NoLogging,
         pendingIntentDelegate = pendingIntentDelegate,
     )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/SessionAlarmViewModelDelegateTest.kt
@@ -24,8 +24,8 @@ class SessionAlarmViewModelDelegateTest {
     fun `addAlarm() invokes addSessionAlarm() function`() = runTest {
         val alarmServices = mock<AlarmServices>()
         val delegate = createDelegate(alarmServices = alarmServices)
-        delegate.addAlarm(SESSION, alarmTimesIndex = 0)
-        verifyInvokedOnce(alarmServices).addSessionAlarm(SESSION, alarmTimesIndex = 0)
+        delegate.addAlarm(SESSION, alarmTime = 0)
+        verifyInvokedOnce(alarmServices).addSessionAlarm(SESSION, alarmTimeOffset = 0)
     }
 
     @Test

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -275,7 +275,7 @@ class SessionDetailsViewModelTest {
         val repository = createRepository(selectedSession = Session("S5"))
         val alarmServices = mock<AlarmServices>()
         val viewModel = createViewModel(repository, alarmServices = alarmServices)
-        viewModel.addAlarm(alarmTimesIndex = 1)
+        viewModel.addAlarm(alarmTime = 5)
         verifyInvokedOnce(repository).loadSelectedSession()
         verifyInvokedOnce(alarmServices).addSessionAlarm(any(), any())
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -481,8 +481,8 @@ class FahrplanViewModelTest {
             val alarmServices = mock<AlarmServices>()
             val viewModel = createViewModel(repository, alarmServices)
             val session = Session("session-97")
-            viewModel.addAlarm(session, alarmTimesIndex = 0)
-            verifyInvokedOnce(alarmServices).addSessionAlarm(session, alarmTimesIndex = 0)
+            viewModel.addAlarm(session, alarmTime = 0)
+            verifyInvokedOnce(alarmServices).addSessionAlarm(session, alarmTimeOffset = 0)
         }
 
         @Test


### PR DESCRIPTION
# Description

- Uses `SettingsRepository` instead of `SharedPreferencesRepository` to retrieve the "alarm time" setting
- Changes `AlarmTimePickerFragment` to use the alarm time (offset) directly, and not the index into the alarm times resource array.


# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/764