### PR TITLE
Refactoring: Use `SettingsRepository` to retrieving settings (part 3)

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
@@ -128,11 +128,15 @@ internal class DefaultSettingsRepository(
         )
     }
 
-    private fun getScheduleRefreshInterval(): Int {
+    override fun getScheduleRefreshInterval(): Int {
         val key = context.getString(R.string.preference_key_schedule_refresh_interval_index)
         val defaultValue = context.getString(R.string.preference_default_value_schedule_refresh_interval_value)
         val value = preferences.getString(key, defaultValue)!!
         return value.toInt()
+    }
+
+    override fun getScheduleRefreshIntervalDefaultValue(): Int {
+        return context.getString(R.string.preference_default_value_schedule_refresh_interval_value).toInt()
     }
 
     override fun getAlarmTime(): Int {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/RealSharedPreferencesRepository.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import nerd.tuxmobil.fahrplan.congress.R
 
 class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesRepository {
 
@@ -27,17 +26,6 @@ class RealSharedPreferencesRepository(val context: Context) : SharedPreferencesR
     }
 
     private val preferences: SharedPreferences = DefaultSettingsRepository.getDefaultSharedPreferences(context.applicationContext)
-
-    override fun getScheduleRefreshIntervalDefaultValue(): Int {
-        return context.getString(R.string.preference_default_value_schedule_refresh_interval_value).toInt()
-    }
-
-    override fun getScheduleRefreshInterval(): Int {
-        val key = context.getString(R.string.preference_key_schedule_refresh_interval_index)
-        val defaultValue = context.getString(R.string.preference_default_value_schedule_refresh_interval_value)
-        val value = preferences.getString(key, defaultValue)!!
-        return value.toInt()
-    }
 
     override fun getDisplayDayIndex() = preferences.getInt(DISPLAY_DAY_INDEX_KEY, 1)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
@@ -23,6 +23,8 @@ interface SettingsRepository {
     fun getAlarmTime(): Int
     fun setAlarmTime(alarmTime: Int)
 
+    fun getScheduleRefreshInterval(): Int
+    fun getScheduleRefreshIntervalDefaultValue(): Int
     fun setScheduleRefreshInterval(interval: Int)
     fun isAutoUpdateEnabled(): Boolean
     fun setAutoUpdateEnabled(enable: Boolean)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SharedPreferencesRepository.kt
@@ -2,9 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.preferences
 
 interface SharedPreferencesRepository {
 
-    fun getScheduleRefreshIntervalDefaultValue(): Int
-    fun getScheduleRefreshInterval(): Int
-
     fun getDisplayDayIndex(): Int
     fun setDisplayDayIndex(displayDayIndex: Int)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -1022,10 +1022,9 @@ object AppRepository : SearchRepository,
     }
 
     fun readScheduleRefreshIntervalDefaultValue() =
-        sharedPreferencesRepository.getScheduleRefreshIntervalDefaultValue()
+        settingsRepository.getScheduleRefreshIntervalDefaultValue()
 
-    fun readScheduleRefreshInterval() =
-        sharedPreferencesRepository.getScheduleRefreshInterval()
+    fun readScheduleRefreshInterval() = settingsRepository.getScheduleRefreshInterval()
 
     fun readAlarmTime() = settingsRepository.getAlarmTime()
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -8,7 +8,7 @@ import nerd.tuxmobil.fahrplan.congress.NoLogging
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmUpdater.OnAlarmUpdateListener
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame
 import nerd.tuxmobil.fahrplan.congress.models.ConferenceTimeFrame.Unknown
-import nerd.tuxmobil.fahrplan.congress.preferences.SharedPreferencesRepository
+import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class AlarmUpdaterTest {
         val conferenceTimeFrame = ConferenceTimeFrame.Known(FIRST_DAY_START_TIME, LAST_DAY_END_TIME)
     }
 
-    private val sharedPreferencesRepository = mock<SharedPreferencesRepository>()
+    private val settingsRepository = mock<SettingsRepository>()
 
     private val testableAppRepository: AppRepository
         get() = with(AppRepository) {
@@ -53,8 +53,8 @@ class AlarmUpdaterTest {
                 metaDatabaseRepository = mock(),
                 scheduleNetworkRepository = mock(),
                 engelsystemRepository = mock(),
-                sharedPreferencesRepository = sharedPreferencesRepository,
-                settingsRepository = mock(),
+                sharedPreferencesRepository = mock(),
+                settingsRepository = settingsRepository,
                 sessionsTransformer = mock()
             )
             return this
@@ -72,7 +72,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval schedules alarm with development interval`() {
-        whenever(sharedPreferencesRepository.getScheduleRefreshInterval()).doReturn(THREE_SECONDS)
+        whenever(settingsRepository.getScheduleRefreshInterval()).doReturn(THREE_SECONDS)
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(THREE_SECONDS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -81,7 +81,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval schedules initial alarm with development interval`() {
-        whenever(sharedPreferencesRepository.getScheduleRefreshInterval()).doReturn(THREE_SECONDS)
+        whenever(settingsRepository.getScheduleRefreshInterval()).doReturn(THREE_SECONDS)
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, true)
         assertThat(interval).isEqualTo(THREE_SECONDS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()


### PR DESCRIPTION
# Description

Use `SettingsRepository` instead of `SharedPreferencesRepository` to retrieve the "schedule refresh interval" setting.


# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/764