### PR TITLE
Show number of favored sessions in favorites screen title resp. headline.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         </activity>
         <activity
             android:name="nerd.tuxmobil.fahrplan.congress.favorites.StarredListActivity"
-            android:label="@string/starred_sessions"
+            android:label="@string/favorites_screen_default_title"
             android:resizeableActivity="true"
             android:theme="@style/Theme.Congress.NoActionBar"
             tools:targetApi="24">

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -15,6 +15,7 @@ import android.widget.AbsListView
 import android.widget.AbsListView.MultiChoiceModeListener
 import android.widget.HeaderViewListAdapter
 import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
@@ -86,6 +87,8 @@ class StarredListFragment :
      */
     private lateinit var currentListView: ListView
 
+    private var headerView: TextView? = null
+
     private lateinit var loadingSpinnerView: View
 
     private val starredListAdapter: StarredListAdapter
@@ -117,10 +120,12 @@ class StarredListFragment :
             view = localInflater.inflate(R.layout.fragment_favorites_list_narrow, container, false)
             currentListView = view.requireViewByIdCompat(android.R.id.list)
             header = localInflater.inflate(R.layout.starred_header, null, false)
+            headerView = header.requireViewByIdCompat(R.id.header_view)
         } else {
             view = localInflater.inflate(R.layout.fragment_favorites_list, container, false)
             currentListView = view.requireViewByIdCompat(android.R.id.list)
             header = localInflater.inflate(R.layout.header_empty, null, false)
+            headerView = null
         }
         currentListView.addHeaderView(header, null, false)
         currentListView.setHeaderDividersEnabled(false)
@@ -155,6 +160,7 @@ class StarredListFragment :
                 contentDescriptionFormatting = ContentDescriptionFormatter(resourceResolving),
             )
             currentListView.adapter = adapter
+            updateHeaderOrTitleText(sessions.size)
             activity.invalidateOptionsMenu()
 
             loadingSpinnerView.isVisible = false
@@ -169,6 +175,15 @@ class StarredListFragment :
                 Toast.makeText(context, R.string.share_error_activity_not_found, Toast.LENGTH_SHORT).show()
             }
         }
+    }
+
+    private fun updateHeaderOrTitleText(sessionsSize: Int) {
+        val headerOrTitleText = when (sessionsSize == 0) {
+            true -> getString(R.string.favorites_screen_default_title)
+            false -> resources.getQuantityString(R.plurals.favorites_screen_title, sessionsSize, sessionsSize)
+        }
+        headerView?.text = headerOrTitleText
+        requireActivity().title = headerOrTitleText
     }
 
     @MainThread

--- a/app/src/main/res/layout/starred_header.xml
+++ b/app/src/main/res/layout/starred_header.xml
@@ -6,6 +6,7 @@
               android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/header_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="@android:style/TextAppearance.Large"
@@ -14,7 +15,7 @@
         android:paddingRight="16dp"
         android:paddingTop="32dp"
         android:fontFamily="sans-serif-light"
-        android:text="@string/starred_sessions"
+        android:text="@string/favorites_screen_default_title"
         tools:background="@android:color/holo_blue_dark"
         />
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -119,7 +119,11 @@
     <string name="schedule_changes">Fahrplanänderungen</string>
 
     <string name="general_settings">Allgemein</string>
-    <string name="starred_sessions">Favoriten</string>
+    <string name="favorites_screen_default_title">Favoriten</string>
+    <plurals name="favorites_screen_title">
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> Favorite</item>
+        <item quantity="other"><xliff:g example="3" id="count">%d</xliff:g> Favoriten</item>
+    </plurals>
     <string name="favorites_no_favorites_title">Keine favorisierten Vorträge</string>
     <string name="favorites_no_favorites_subtitle">Tippe auf den Stern in der Menüleiste, um einen Favoriten zu setzen</string>
     <string name="choose_to_delete">Wähle Vorträge</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -99,7 +99,7 @@
     <string name="schedule_changes_no_changes_title">Sin cambios en el calendario</string>
     <string name="favorites_no_favorites_title">No hay clases favoritas</string>
     <string name="schedule_changes">Cambios en el calendario</string>
-    <string name="starred_sessions">Favoritos</string>
+    <string name="favorites_screen_default_title">Favoritos</string>
     <string name="choose_to_delete">Seleccione las clases</string>
     <string name="day_separator">Día <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">¿Borrar todos los favoritos?</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -102,7 +102,7 @@
     <string name="favorites_no_favorites_title">Ei lempiluentoja</string>
     <string name="schedule_changes">Aikataulumuutokset</string>
     <string name="general_settings">Yleiset</string>
-    <string name="starred_sessions">Suosikit</string>
+    <string name="favorites_screen_default_title">Suosikit</string>
     <string name="choose_to_delete">Valitse luennot</string>
     <string name="day_separator">Päivä <xliff:g esimerkki="2" id="kongressi_päivä">%1$d</xliff:g> - <xliff:g esimerkki="29.12.2014" id="kongressipäivän_päivämäärä">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Poista kaikki suosikit?</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -98,7 +98,7 @@
     <string name="favorites_no_favorites_title">Aucune conférence dans les favoris</string>
     <string name="schedule_changes">Changements du programme</string>
     <string name="general_settings">Général</string>
-    <string name="starred_sessions">Favoris</string>
+    <string name="favorites_screen_default_title">Favoris</string>
     <string name="choose_to_delete">Sélectionnez des conférences</string>
     <string name="day_separator">Jour <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g>
     </string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -89,7 +89,7 @@
     <string name="favorites_no_favorites_title">Nessuna conferenza tra i favoriti</string>
     <string name="schedule_changes">Cambiamenti di programma</string>
     <string name="general_settings">Generale</string>
-    <string name="starred_sessions">Preferiti</string>
+    <string name="favorites_screen_default_title">Preferiti</string>
     <string name="choose_to_delete">Seleziona le conferenze</string>
     <string name="day_separator">Giorno <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Eliminare tutti i favoriti?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -95,7 +95,7 @@
     <string name="favorites_no_favorites_title">好きな講義がありません</string>
     <string name="schedule_changes">スケジュール変更</string>
     <string name="general_settings">一般</string>
-    <string name="starred_sessions">お気に入り</string>
+    <string name="favorites_screen_default_title">お気に入り</string>
     <string name="choose_to_delete">講義を選択</string>
     <string name="day_separator">日付 <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="2014.12.29" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">すべてのお気に入りを削除しますか？</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -113,7 +113,7 @@
     <string name="favorites_no_favorites_subtitle">Paspauskite ant žvaigždutės meniu juostoje, kad pažymėtumėte mėgstamas</string>
     <string name="schedule_changes">Tvarkaraščio pasikeitimai</string>
     <string name="general_settings">Bendra</string>
-    <string name="starred_sessions">Mėgstamos</string>
+    <string name="favorites_screen_default_title">Mėgstamos</string>
     <string name="choose_to_delete">Pasirinkti paskaitas</string>
     <string name="day_separator"><xliff:g example="2" id="day_of_congress">%1$d</xliff:g> diena - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Ištrinti visas mėgstamas?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -105,7 +105,7 @@
     <string name="favorites_no_favorites_subtitle">Tik op de ster in de menubalk om een favoriet in te stellen</string>
     <string name="schedule_changes">Tijdschema veranderingen</string>
     <string name="general_settings">Algemeen</string>
-    <string name="starred_sessions">Favorieten</string>
+    <string name="favorites_screen_default_title">Favorieten</string>
     <string name="choose_to_delete">Selecteer sessies</string>
     <string name="day_separator">Dag <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Alle favorieten verwijderen?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -119,7 +119,7 @@
     <string name="schedule_changes">Zmiany w agendzie</string>
     <string name="development_settings">Dla deweloperów</string>
     <string name="general_settings">Ogólne</string>
-    <string name="starred_sessions">Ulubione</string>
+    <string name="favorites_screen_default_title">Ulubione</string>
     <string name="choose_to_delete">Wybierz sesje</string>
     <string name="day_separator">Dzień <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="12/29/14" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="day_separator_content_description">Dzień <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="December 29, 2014" id="date_of_congress_day">%2$s</xliff:g></string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -108,7 +108,7 @@
     <string name="favorites_no_favorites_subtitle">Toque na estrela na barra de menu para definir um favorito</string>
     <string name="schedule_changes">Alterações no cronograma</string>
     <string name="general_settings">Geral</string>
-    <string name="starred_sessions">Favoritos</string>
+    <string name="favorites_screen_default_title">Favoritos</string>
     <string name="choose_to_delete">Selecione as sessões</string>
     <string name="day_separator">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="12/29/14" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="day_separator_content_description">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="December 29, 2014" id="date_of_congress_day">%2$s</xliff:g></string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -94,7 +94,7 @@
     <string name="favorites_no_favorites_title">Nenhuma palestra favorita</string>
     <string name="schedule_changes">Mudanças no cronograma</string>
     <string name="general_settings">Geral</string>
-    <string name="starred_sessions">Favoritos</string>
+    <string name="favorites_screen_default_title">Favoritos</string>
     <string name="choose_to_delete">Selecionar palestras</string>
     <string name="day_separator">Dia <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Excluir todos os favoritos?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -92,7 +92,7 @@
     <string name="favorites_no_favorites_title">Нет избранных лекций</string>
     <string name="schedule_changes">Изменения в расписании</string>
     <string name="general_settings">Основное</string>
-    <string name="starred_sessions">Избранное</string>
+    <string name="favorites_screen_default_title">Избранное</string>
     <string name="choose_to_delete">Выбрать лекции</string>
     <string name="day_separator">День <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Удалить всё избранное?</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -97,7 +97,7 @@
     <string name="favorites_no_favorites_title">Inga favoriserade föreläsningar</string>
     <string name="schedule_changes">Schemalägg ändringar</string>
     <string name="general_settings">Allmän</string>
-    <string name="starred_sessions">Favoriter</string>
+    <string name="favorites_screen_default_title">Favoriter</string>
     <string name="choose_to_delete">Välj föreläsningar</string>
     <string name="day_separator">Dag <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Ta bort alla favoriter?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -109,7 +109,7 @@
     <string name="favorites_no_favorites_subtitle">Favori eklemek için menü çubuğundaki yıldıza tıklayın</string>
     <string name="schedule_changes">Plan değişiklikleri</string>
     <string name="general_settings">Genel</string>
-    <string name="starred_sessions">Favoriler</string>
+    <string name="favorites_screen_default_title">Favoriler</string>
     <string name="choose_to_delete">Oturumları seç</string>
     <string name="day_separator">Gün <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="29.12.2014" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="dlg_delete_all_favorites">Tüm favorileri silmek mi istiyorsun?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,11 @@
     <string name="dash" translatable="false"><xliff:g id="dash">—</xliff:g></string>
     <string name="development_settings">Development</string>
     <string name="general_settings">General</string>
-    <string name="starred_sessions">Favorites</string>
+    <string name="favorites_screen_default_title">Favorites</string>
+    <plurals name="favorites_screen_title">
+        <item quantity="one"><xliff:g example="1" id="count">%d</xliff:g> favorite</item>
+        <item quantity="other"><xliff:g example="3" id="count">%d</xliff:g> favorites</item>
+    </plurals>
     <string name="choose_to_delete">Select sessions</string>
     <string name="day_separator">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g> - <xliff:g example="12/29/14" id="date_of_congress_day">%2$s</xliff:g></string>
     <string name="day_separator_content_description">Day <xliff:g example="2" id="day_of_congress">%1$d</xliff:g>, <xliff:g example="December 29, 2014" id="date_of_congress_day">%2$s</xliff:g></string>


### PR DESCRIPTION
# Description
+ On tablet the title is shown as a headline whereas on phones the screen title dynamically updates.

# Phone before & after
<img width="270" height="600" alt="phone-favorites-before" src="https://github.com/user-attachments/assets/ce192110-9ac2-4760-8c9d-2ddfd81d77c7" /> <img width="270" height="600" alt="phone-favorites-after" src="https://github.com/user-attachments/assets/faca92fe-a533-4fd4-b425-e6b81e15057f" />


# Tablet before & after
<img width="600" height="375" alt="tablet-favorites-before" src="https://github.com/user-attachments/assets/38669a54-d538-4c86-9507-810ee3420519" /> <img width="600" height="375" alt="tablet-favorites-after" src="https://github.com/user-attachments/assets/56221fc5-8b7d-4335-91bd-cc998759d098" />

# Successfully tested on
with `ccc38c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)