### PR TITLE
Fix session card positioning

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -34,6 +34,8 @@ import androidx.appcompat.app.ActionBar.NAVIGATION_MODE_LIST
 import androidx.appcompat.app.ActionBar.OnNavigationListener
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.view.MenuProvider
@@ -760,14 +762,15 @@ class FahrplanFragment : Fragment(), MenuProvider {
     ): RoomColumnData {
         // Prepare session data and spacings
         val sessionDataList = mutableListOf<SessionCardData>()
-        val spacings = mutableListOf<Int>()
+        val spacings = mutableListOf<Dp>()
 
         // Calculate initial spacing
         val firstSession = sessions.firstOrNull()
         if (firstSession != null) {
             val firstParams = layoutParamsBySession[firstSession.sessionId]
             val topMargin = firstParams?.topMargin ?: 0
-            spacings.add((topMargin / context.resources.displayMetrics.density).toInt())
+            val topMarginDp = (topMargin / context.resources.displayMetrics.density).dp
+            spacings.add(topMarginDp)
         }
 
         // Process each session
@@ -790,7 +793,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
             val verticalPadding = (horizontalPadding * 0.3).toInt()
 
             val heightPx = layoutParams?.height ?: calculateSessionHeight(session)
-            val heightDp = (heightPx / context.resources.displayMetrics.density).toInt()
+            val heightDp = (heightPx / context.resources.displayMetrics.density).dp
             val showBorder = session.isHighlight && isAlternativeHighlightingEnabled
             val shortSession = session.duration.toWholeMinutes() <= Duration.ofMinutes(15).toWholeMinutes()
 
@@ -853,7 +856,8 @@ class FahrplanFragment : Fragment(), MenuProvider {
             // Append spacing to the session except for the last one
             if (index < sessions.size - 1) {
                 val bottomMargin = layoutParams?.bottomMargin ?: 0
-                spacings.add((bottomMargin / context.resources.displayMetrics.density).toInt())
+                val bottomMarginDp = (bottomMargin / context.resources.displayMetrics.density).dp
+                spacings.add(bottomMarginDp)
             }
         }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/RoomColumnData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/RoomColumnData.kt
@@ -1,6 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
+import androidx.compose.ui.unit.Dp
+
 data class RoomColumnData(
     val sessionData: List<SessionCardData>,
-    val spacings: List</* sessionIndex */ Int>, // Spacings between sessions in dp
+    val spacings: List</* sessionIndex */ Dp>, // Spacings between sessions in dp
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow.Companion.Ellipsis
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
@@ -82,8 +83,8 @@ fun RoomColumn(
             // Add spacings and sessions in the right order
             columnData.sessionData.forEachIndexed { index, sessionData ->
                 // Add spacing before session if needed
-                if (index < columnData.spacings.size && columnData.spacings[index] > 0) {
-                    Spacer(Modifier.height(columnData.spacings[index].dp))
+                if (index < columnData.spacings.size && columnData.spacings[index] > 0.dp) {
+                    Spacer(Modifier.height(columnData.spacings[index]))
                 }
 
                 SessionCard(
@@ -115,7 +116,7 @@ fun SessionCard(
         Card(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(data.cardHeight.dp)
+                .height(data.cardHeight)
                 .pointerInteropFilter {
                     pressPosition = Offset(it.x, it.y)
                     false
@@ -184,7 +185,7 @@ private fun SessionCardLayout(data: SessionCardData) {
     ) {
 
         val currentDensity = LocalDensity.current
-        val cardHeightPx = (currentDensity.density * data.cardHeight).toInt()
+        val cardHeightPx = with(currentDensity) { data.cardHeight.roundToPx() }
         val innerPaddingDp = dimensionResource(R.dimen.session_drawable_inner_padding)
         val innerPaddingPx = (currentDensity.density * innerPaddingDp.value).toInt()
 
@@ -605,19 +606,19 @@ private fun RoomColumnPreview() {
 @Composable
 private fun createRoomColumnData() = RoomColumnData(
     sessionData = listOf(
-        createSessionCardData(height = 50, isFavored = false, hasAlarm = true, isRecorded = true),
-        createSessionCardData(height = 100, isFavored = true, hasAlarm = true, isRecorded = false),
-        createSessionCardData(height = 70, isFavored = false, hasAlarm = true, isRecorded = true),
-        createSessionCardData(height = 200, isFavored = true, hasAlarm = false, isRecorded = true),
-        createSessionCardData(height = 35, isFavored = false, hasAlarm = true, isRecorded = false),
+        createSessionCardData(height = 50.dp, isFavored = false, hasAlarm = true, isRecorded = true),
+        createSessionCardData(height = 100.dp, isFavored = true, hasAlarm = true, isRecorded = false),
+        createSessionCardData(height = 70.dp, isFavored = false, hasAlarm = true, isRecorded = true),
+        createSessionCardData(height = 200.dp, isFavored = true, hasAlarm = false, isRecorded = true),
+        createSessionCardData(height = 35.dp, isFavored = false, hasAlarm = true, isRecorded = false),
     ),
-    spacings = listOf(20, 80, 0, 8, 0),
+    spacings = listOf(20.dp, 80.dp, 0.dp, 8.dp, 0.dp),
 )
 
 @Preview
 @Composable
 private fun SessionCardPreview() {
-    val data = createSessionCardData(height = 200, isFavored = true, hasAlarm = true, isRecorded = false)
+    val data = createSessionCardData(height = 200.dp, isFavored = true, hasAlarm = true, isRecorded = false)
     EventFahrplanTheme {
         SessionCard(
             data = data,
@@ -631,7 +632,7 @@ private fun SessionCardPreview() {
 
 @Composable
 private fun createSessionCardData(
-    height: Int = 100,
+    height: Dp = 100.dp,
     isFavored: Boolean = false,
     hasAlarm: Boolean = false,
     isRecorded: Boolean = true,
@@ -664,7 +665,7 @@ private fun SessionCardPreview01() {
         speakerNames = stringResource(R.string.placeholder_session_speakers),
         languages = stringResource(R.string.placeholder_session_language),
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 120,
+        cardHeight = 120.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -681,7 +682,7 @@ private fun SessionCardPreview02() {
         speakerNames = stringResource(R.string.placeholder_session_speakers),
         languages = stringResource(R.string.placeholder_session_language),
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 90,
+        cardHeight = 90.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -698,7 +699,7 @@ private fun SessionCardPreview03() {
         speakerNames = "",
         languages = "",
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 90,
+        cardHeight = 90.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -715,7 +716,7 @@ private fun SessionCardPreview04() {
         speakerNames = "",
         languages = "",
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 70,
+        cardHeight = 70.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -732,7 +733,7 @@ private fun SessionCardPreview05() {
         speakerNames = "",
         languages = "",
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 55,
+        cardHeight = 55.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -749,7 +750,7 @@ private fun SessionCardPreview06() {
         speakerNames = "",
         languages = "",
         trackName = stringResource(R.string.placeholder_session_track),
-        cardHeight = 50,
+        cardHeight = 50.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -766,7 +767,7 @@ private fun SessionCardPreview07() {
         speakerNames = "",
         languages = "",
         trackName = "",
-        cardHeight = 60,
+        cardHeight = 60.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -783,7 +784,7 @@ private fun SessionCardPreview08() {
         speakerNames = "",
         languages = "",
         trackName = "",
-        cardHeight = 95,
+        cardHeight = 95.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -800,7 +801,7 @@ private fun SessionCardPreview09() {
         speakerNames = "Stephen A. Ridley, Ernest Ridley, Conan Ridley, Bridget Ridley, Frank Ridley, Barbara Ridley",
         languages = stringResource(R.string.placeholder_session_language),
         trackName = "",
-        cardHeight = 110,
+        cardHeight = 110.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -817,7 +818,7 @@ private fun SessionCardPreview10() {
         speakerNames = stringResource(R.string.placeholder_session_speakers),
         languages = stringResource(R.string.placeholder_session_language),
         trackName = "Very looooooooooooooooooooooooooooooooooooooooooooooong track name",
-        cardHeight = 160,
+        cardHeight = 160.dp,
         recordingOptOut = true,
         isFavored = true,
         hasAlarm = true,
@@ -833,7 +834,7 @@ private fun createSessionCard(
     speakerNames: String = "",
     languages: String = "",
     trackName: String = "",
-    cardHeight: Int,
+    cardHeight: Dp,
     recordingOptOut: Boolean = false,
     isFavored: Boolean = false,
     hasAlarm: Boolean = false,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionCardData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/SessionCardData.kt
@@ -1,6 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
 import androidx.annotation.ColorRes
+import androidx.compose.ui.unit.Dp
 
 data class SessionCardData(
     val sessionId: String,
@@ -13,7 +14,7 @@ data class SessionCardData(
     val stateContentDescription: String,
     val innerHorizontalPadding: Float,
     val innerVerticalPadding: Float,
-    val cardHeight: Int,
+    val cardHeight: Dp,
     val isFavored: Boolean,
     val hasAlarm: Boolean,
     val showBorder: Boolean,


### PR DESCRIPTION
# Description

Fixes session card positioning by not rounding height, top margin, and bottom margin pixel values to the nearest integer when converting to density-independent pixels.

# Before
See screenshot in #814

# After
<img width="540" height="1212" alt="image" src="https://github.com/user-attachments/assets/bce99a95-763c-4562-bae0-7dff8649be95" />

Tested with a Pixel 9a, API 36 emulator

Fixes #814
