### PR TITLE
Remove actionbar theme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"
-        android:theme="@style/Theme.Congress.NoActionBar"
+        android:theme="@style/Theme.Congress"
         tools:targetApi="33">
         <activity
             android:name=".schedule.MainActivity"

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -46,7 +46,7 @@ abstract class SessionsAdapter protected constructor(
     protected val useDeviceTimeZone: Boolean
 
     init {
-        this.context = ContextThemeWrapper(context, R.style.Theme_Congress_NoActionBar)
+        this.context = ContextThemeWrapper(context, R.style.Theme_Congress)
         this.list = list
         this.numDays = numDays
         this.useDeviceTimeZone = useDeviceTimeZone

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -75,7 +75,7 @@ class ChangeListFragment : Fragment() {
         val arguments = requireArguments()
         val sidePane = arguments.getBoolean(BundleKeys.SIDEPANE)
 
-        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress_NoActionBar)
+        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress)
         val localInflater = inflater.cloneInContext(contextThemeWrapper)
         val fragmentView = localInflater.inflate(R.layout.fragment_session_list, container, false)
         fragmentView.findViewById<ComposeView>(R.id.session_changes_view).apply {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListFragment.kt
@@ -112,7 +112,7 @@ class StarredListFragment :
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress_NoActionBar)
+        val contextThemeWrapper = ContextThemeWrapper(requireContext(), R.style.Theme_Congress)
         val localInflater = inflater.cloneInContext(contextThemeWrapper)
         val view: View
         val header: View

--- a/app/src/main/res/values/styles_congress.xml
+++ b/app/src/main/res/values/styles_congress.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.Congress.NoActionBar" parent="Theme.AppCompat.NoActionBar">
+    <style name="Theme.Congress" parent="Theme.AppCompat.NoActionBar">
         <!-- Set AppCompat’s color theming attrs -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
# Description

The theme with the actionbar wasn't really used anywhere anymore. However, it still was the application theme and that's why Compose previews that showed the system UI also showed an actionbar.

This PR makes the `NoActionBar` theme the application theme and removes all overrides for the individual activities. `Theme.Congress.NoActionBar` is then renamed to `Theme.Congress` because the fact that the theme doesn't include an actionbar is a mostly irrelevant detail.