### PR TITLE
Fix "Day 1" showing up for sessions of other days than day 1 in search screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensions.kt
@@ -24,11 +24,11 @@ fun List<SessionNetworkModel>.toDayIndices(): Set<Int> {
  * This field is unique for a virtual day, even for sessions after midnight.
  */
 fun List<SessionAppModel>.toVirtualDays(): List<VirtualDay> {
-    var index = 0
     return groupBy { it.dateText }
         .map { (_, sessions) ->
+            val index = sessions.first().dayIndex
             val sorted = sessions.sortedBy { it.dateUTC }
-            VirtualDay(++index, sorted)
+            VirtualDay(index, sorted)
         }
 }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeParametersFactoryTest.kt
@@ -400,8 +400,8 @@ class SessionChangeParametersFactoryTest {
             FakeFormattingDelegate(),
         )
         val sessions = listOf(
-            createUnchangedSession(dayIndex = 0),
             createUnchangedSession(dayIndex = 1),
+            createUnchangedSession(dayIndex = 2),
         )
         val actual = factory.createSessionChangeParameters(sessions, useDeviceTimeZone = true)
         assertThat(actual).hasSize(3)
@@ -416,7 +416,7 @@ class SessionChangeParametersFactoryTest {
 
 }
 
-private fun createUnchangedSession(dayIndex: Int = 0) = Session(
+private fun createUnchangedSession(dayIndex: Int = 1) = Session(
     sessionId = "2342",
     title = "Title",
     subtitle = "Subtitle",
@@ -449,6 +449,7 @@ private fun createNewSession() = Session(
     recordingOptOut = false,
     speakers = listOf("Jane Doe", "John Doe"),
     dateUTC = 1439478900000L,
+    dayIndex = 1,
     duration = Duration.ofMinutes(30),
     roomName = "Main room",
     language = "de, en",
@@ -474,6 +475,7 @@ private fun createCanceledSession() = Session(
     recordingOptOut = false,
     speakers = listOf("Jane Doe", "John Doe"),
     dateUTC = 1439478900000L,
+    dayIndex = 1,
     duration = Duration.ofMinutes(30),
     roomName = "Main room",
     language = "de, en",
@@ -499,6 +501,7 @@ private fun createChangedSession() = Session(
     recordingOptOut = false,
     speakers = listOf("Jane Doe", "John Doe"),
     dateUTC = 1439478900000L,
+    dayIndex = 1,
     duration = Duration.ofMinutes(30),
     roomName = "Main room",
     language = "de, en",
@@ -524,6 +527,7 @@ private fun createChangedEmptySession() = Session(
     recordingOptOut = true,
     speakers = emptyList(),
     dateUTC = 1439478900000L,
+    dayIndex = 1,
     duration = Duration.ofMinutes(30),
     roomName = "",
     language = "",

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -20,11 +20,11 @@ class SessionsExtensionsToVirtualDaysTest {
     @Test
     fun `toVirtualDays returns list of days with sessions broken into virtual days`() {
         val sessions = listOf(
-            createSession("2023-12-27", 1703671200000, Duration.ofMinutes(60)), // 2023-12-27T10:00:00Z
-            createSession("2023-12-27", 1703728800000, Duration.ofMinutes(45)), // 2023-12-28T02:00:00Z
-            createSession("2023-12-28", 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
-            createSession("2023-12-29", 1703844000000, Duration.ofMinutes(60)), // 2023-12-29T10:00:00Z
-            createSession("2023-12-30", 1703930400000, Duration.ofMinutes(60)), // 2023-12-30T10:00:00Z
+            createSession("2023-12-27", dayIndex = 1, 1703671200000, Duration.ofMinutes(60)), // 2023-12-27T10:00:00Z
+            createSession("2023-12-27", dayIndex = 1, 1703728800000, Duration.ofMinutes(45)), // 2023-12-28T02:00:00Z
+            createSession("2023-12-28", dayIndex = 2, 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
+            createSession("2023-12-29", dayIndex = 3, 1703844000000, Duration.ofMinutes(60)), // 2023-12-29T10:00:00Z
+            createSession("2023-12-30", dayIndex = 4, 1703930400000, Duration.ofMinutes(60)), // 2023-12-30T10:00:00Z
         )
         val virtualDays = sessions.toVirtualDays()
         val expectedVirtualDays = listOf(
@@ -40,7 +40,7 @@ class SessionsExtensionsToVirtualDaysTest {
     @Test
     fun `toVirtualDays returns list of days with correct day indices even if sessions of day 1 are missing`() {
         val sessions = listOf(
-            createSession("2023-12-28", 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
+            createSession("2023-12-28", dayIndex = 2, 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
         )
         val virtualDays = sessions.toVirtualDays()
         val expectedVirtualDays = listOf(
@@ -50,12 +50,17 @@ class SessionsExtensionsToVirtualDaysTest {
         assertThat(virtualDays).isEqualTo(expectedVirtualDays)
     }
 
-    private fun createSession(dateText: String, startsAt: Long, duration: Duration) =
-        Session(
-            sessionId = "",
-            dateText = dateText,
-            dateUTC = startsAt,
-            duration = duration,
-        )
+    private fun createSession(
+        dateText: String,
+        dayIndex: Int,
+        startsAt: Long,
+        duration: Duration,
+    ) = Session(
+        sessionId = "",
+        dateText = dateText,
+        dayIndex = dayIndex,
+        dateUTC = startsAt,
+        duration = duration,
+    )
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -28,9 +28,9 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries with today mark`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 3,
@@ -47,10 +47,10 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries although one session happens after midnight`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-18", startsAt = DAY_2_AT_230_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
-            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_2_AT_230_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 3,
@@ -67,9 +67,9 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries with today mark expecting sessions for day four`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 4,
@@ -84,9 +84,9 @@ class NavigationMenuEntriesGeneratorTest {
     }
 
     @Test
-    fun `getDayMenuEntries returns a single day entry without today mark`() {
+    fun `getDayMenuEntries returns a single day entry without today mark because the last session ended`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
         )
         val entries = getDayMenuEntries(
             numDays = 1,
@@ -95,13 +95,13 @@ class NavigationMenuEntriesGeneratorTest {
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(1)
-        assertThat(entries.first()).isEqualTo("Day 1")
+        assertThat(entries.first()).isEqualTo("Day 2")
     }
 
     @Test
     fun `getDayMenuEntries returns a single day entry with today mark matching the session end`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
         )
         val entries = getDayMenuEntries(
             numDays = 1,
@@ -110,7 +110,7 @@ class NavigationMenuEntriesGeneratorTest {
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(1)
-        assertThat(entries.first()).isEqualTo("Day 1 - Today")
+        assertThat(entries.first()).isEqualTo("Day 2 - Today")
     }
 
     @Test
@@ -138,9 +138,9 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries throws exception when numDays is less than 0`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
         )
         try {
             getDayMenuEntries(
@@ -157,8 +157,8 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries throws exception when number of days is less than date list items size`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
         )
         try {
             getDayMenuEntries(
@@ -172,9 +172,15 @@ class NavigationMenuEntriesGeneratorTest {
         }
     }
 
-    private fun createSession(dateText: String, startsAt: Long, duration: Duration) = Session(
+    private fun createSession(
+        dateText: String,
+        dayIndex: Int,
+        startsAt: Long,
+        duration: Duration,
+    ) = Session(
         sessionId = "",
         dateText = dateText,
+        dayIndex = dayIndex,
         dateUTC = startsAt,
         duration = duration,
     )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultParameterFactoryTest.kt
@@ -38,6 +38,7 @@ class SearchResultParameterFactoryTest {
                 title = "Session 123",
                 speakers = listOf("Jane Doe", "John Doe"),
                 dateText = "2015-08-13",
+                dayIndex = 1,
                 dateUTC = 1683981000000,
             ),
             Session(
@@ -45,6 +46,7 @@ class SearchResultParameterFactoryTest {
                 title = "Session 456",
                 speakers = listOf("Jane Doe", "John Doe"),
                 dateText = "2015-08-14",
+                dayIndex = 2,
                 dateUTC = 1684067400000,
             )
         )
@@ -88,6 +90,7 @@ class SearchResultParameterFactoryTest {
                 title = "",
                 speakers = emptyList(),
                 dateUTC = 1683981000000,
+                dayIndex = 1,
             )
         )
         val results = factory.createSearchResults(sessions, useDeviceTimeZone = false)


### PR DESCRIPTION
# Description
+ Searching for a session of day 2 showed up with a headline with the text "Day 1".
+ The virtual days conversion falsely assumed that sessions of all days would be passed to the conversion.
+ Add unit test to avoid regression.

# Successfully tested on
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---

Resolves #833
