### PR TITLE
Fix preserving favorites scroll position when returning from details screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/SessionsAdapter.kt
@@ -38,12 +38,12 @@ abstract class SessionsAdapter protected constructor(
     protected var context: Context
         private set
 
-    private val list: List<Session>
-    private val numDays: Int
+    private var list: List<Session>
+    private var numDays: Int
     private lateinit var mapper: MutableList<Int>
     private lateinit var separatorStrings: MutableList<String>
     private lateinit var separatorsSet: MutableSet<Int>
-    protected val useDeviceTimeZone: Boolean
+    protected var useDeviceTimeZone: Boolean
 
     init {
         this.context = ContextThemeWrapper(context, R.style.Theme_Congress)
@@ -51,6 +51,13 @@ abstract class SessionsAdapter protected constructor(
         this.numDays = numDays
         this.useDeviceTimeZone = useDeviceTimeZone
         initMapper()
+    }
+
+    fun update(sessions: List<Session>, numDays: Int, useDeviceTimeZone: Boolean) {
+        this.list = sessions
+        this.numDays = numDays
+        this.useDeviceTimeZone = useDeviceTimeZone
+        notifyDataSetChanged()
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {


### PR DESCRIPTION
# Description
+ This solves the annoyance of **losing your reading position** after clicking into a detail view and coming back. Two changes add to the fix:
  1. Every time the fragment enters the lifecycle state "started" it observes the favored sessions. As a result a new adapter is assigned which reset the scroll position. This is now fixed by **initializing** the adapter in `onCreateView()` and then only **updating** the adapter with new data once it arrives.
  2. Further, `jumpOverPastSessions()` is now **only** executed when the user did not scroll the list before.


# Screenrecording of the fixed behavior
https://github.com/user-attachments/assets/a890d5ee-efa4-4cef-87de-860d143c3c77

# Successfully tested on
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- 23c616572852940e8e27031ea25f9fcf5ce4a3c1
- https://github.com/EventFahrplan/EventFahrplan/issues/362
- https://github.com/EventFahrplan/EventFahrplan/pull/363
- https://github.com/EventFahrplan/EventFahrplan/pull/534
- https://github.com/EventFahrplan/EventFahrplan/pull/598


---

Resolves #432