### PR TITLE
Fix the loss of Engelsystem shifts when schedule is reloaded and contains changes.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepository.kt
@@ -518,7 +518,7 @@ object AppRepository : SearchRepository,
                               onLoadingShiftsDone: (loadShiftsResult: LoadShiftsResult) -> Unit) {
         scheduleNetworkRepository.parseSchedule(scheduleXml, httpHeader,
                 onUpdateSessions = { sessions ->
-                    val oldSessions = loadSessionsForAllDays(true).toSessionsNetworkModel()
+                    val oldSessions = loadSessionsForAllDays(includeEngelsystemShifts = false).toSessionsNetworkModel()
                     val newSessions = sessions.sanitize()
                     val scheduleChanges = computeSessionsWithChangeFlags(newSessions, oldSessions)
                     if (scheduleChanges.foundNoteworthyChanges) {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/AppRepositoryLoadAndParseScheduleTest.kt
@@ -209,9 +209,9 @@ class AppRepositoryLoadAndParseScheduleTest {
             scheduleNetworkRepository.onFetchScheduleFinished(success)
 
             // onUpdateSessions
-            whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn listOf(
-                DatabaseSession(sessionId = "55", isHighlight = true, changedLanguage = true)
-            )
+            val storedSessions = listOf(DatabaseSession(sessionId = "55", isHighlight = true, changedLanguage = true))
+            whenever(sessionsDatabaseRepository.querySessionsOrderedByDateUtc()) doReturn storedSessions
+            whenever(sessionsDatabaseRepository.querySessionsWithoutRoom(any())) doReturn storedSessions
             whenever(highlightsDatabaseRepository.query()) doReturn emptyList()
             whenever(alarmsDatabaseRepository.query()) doReturn emptyList()
 


### PR DESCRIPTION
# Description
+ Precondition to reproduce the bug:
  1. The server must respond with a schedule change
  2. The server must respond with the correct HTTP status codes:
     - `HTTP 200 OK` if any session changed
     - `HTTP 304 Not Modified` if no session changed
+ If the server always responds with `HTTP 200 OK`, then the bug is immediately visible (as in the reported MRMCD scenario, see https://github.com/EventFahrplan/EventFahrplan/issues/784).
+ The fix scopes the comparison of old and new sessions in `computeSessionsWithChangeFlags()` to the actual schedule data, excluding shifts. Shifts are not part of the loaded schedule data and would therefore be deleted via `updateSessions()` every time new schedule data is parsed.
+ Broken since: 2657183d3da71906ce483e98839062b395cebc44 Before, the `engelsystem-repository` library did not support caching headers for requests and responses. Consequently, Engelsystem shifts have been freshly loaded and parsed with every request, regardless of whether formerly stored shifts were deleted during a schedule update. Therefore, the bug was present for longer, but not so visible.

# Before
- Engelsystem shifts disappear when schedule update arrives

  https://github.com/user-attachments/assets/84a3318a-ba9c-4a11-82a6-d5d3987f1d5d


# After
- Engelsystem shifts stay when schedule update arrives

  https://github.com/user-attachments/assets/d836d2d7-bf2f-4588-815c-70078ddb0b56



# Successfully tested on
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

---
Resolves #784