### PR TITLE
Log when user tapped notification to provide context in crash reports.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/autoupdate/UpdateService.kt
@@ -9,6 +9,8 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.MyApp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.PendingIntentProvider
+import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.extensions.withExtras
 import nerd.tuxmobil.fahrplan.congress.net.ConnectivityObserver
 import nerd.tuxmobil.fahrplan.congress.net.FetchScheduleResult
 import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
@@ -50,7 +52,8 @@ class UpdateService : SafeJobIntentService() {
 
     private fun showScheduleUpdateNotification(version: String, changesCount: Int) {
         val notificationIntent = Intent(this, MainActivity::class.java)
-        notificationIntent.flags = FLAG_ACTIVITY_CLEAR_TOP or FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
+            .apply { flags = FLAG_ACTIVITY_CLEAR_TOP or FLAG_ACTIVITY_RESET_TASK_IF_NEEDED }
+            .withExtras(BundleKeys.SCHEDULE_UPDATE_NOTIFICATION to true)
         val contentIntent = PendingIntentProvider.getPendingIntentActivity(this, notificationIntent)
 
         val contentText = if (version.isEmpty()) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/contract/BundleKeys.kt
@@ -16,6 +16,10 @@ object BundleKeys {
     const val SESSION_ALARM_NOTIFICATION_ID =
         "nerd.tuxmobil.fahrplan.congress.SESSION_ALARM_NOTIFICATION_ID"
 
+    // Schedule update notification
+    const val SCHEDULE_UPDATE_NOTIFICATION =
+        "nerd.tuxmobil.fahrplan.congress.SCHEDULE_UPDATE_NOTIFICATION"
+
     // Side pane
     const val SIDEPANE = "nerd.tuxmobil.fahrplan.congress.SIDEPANE"
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -28,6 +28,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentManager.OnBackStackChangedListener
 import androidx.lifecycle.Lifecycle.State.RESUMED
 import info.metadude.android.eventfahrplan.commons.flow.observe
+import info.metadude.android.eventfahrplan.commons.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.about.AboutDialog
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsActivity
@@ -40,6 +41,7 @@ import nerd.tuxmobil.fahrplan.congress.changes.ChangeListFragment
 import nerd.tuxmobil.fahrplan.congress.changes.statistic.ChangeStatisticsUiState
 import nerd.tuxmobil.fahrplan.congress.changes.statistic.ChangeStatisticScreen
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
+import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys.SCHEDULE_UPDATE_NOTIFICATION
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsFragment
@@ -76,6 +78,7 @@ class MainActivity : BaseActivity(),
 
     companion object {
 
+        private const val LOG_TAG = "MainActivity"
         private const val INVALID_NOTIFICATION_ID = -1
 
         lateinit var instance: MainActivity
@@ -107,6 +110,7 @@ class MainActivity : BaseActivity(),
     private lateinit var keyguardManager: KeyguardManager
     private lateinit var errorMessageFactory: ErrorMessage.Factory
     private lateinit var progressBar: ContentLoadingProgressBar
+    private val logging = Logging.get()
     private var progressDialog: ProgressDialog? = null
     private val viewModel: MainViewModel by viewModels {
         MainViewModelFactory(AppRepository, notificationHelper, errorMessageFactory)
@@ -157,6 +161,7 @@ class MainActivity : BaseActivity(),
         initUserEngagement()
         observeViewModel()
         onSessionAlarmNotificationTapped(intent)
+        onScheduleUpdateNotificationTapped(intent)
         viewModel.checkPostNotificationsPermission()
     }
 
@@ -233,12 +238,22 @@ class MainActivity : BaseActivity(),
         super.onNewIntent(intent)
         setIntent(intent)
         onSessionAlarmNotificationTapped(intent)
+        onScheduleUpdateNotificationTapped(intent)
     }
 
     private fun onSessionAlarmNotificationTapped(intent: Intent) {
         val notificationId = intent.getIntExtra(BundleKeys.SESSION_ALARM_NOTIFICATION_ID, INVALID_NOTIFICATION_ID)
         if (notificationId != INVALID_NOTIFICATION_ID) {
+            logging.report(LOG_TAG, "Tapped session alarm notification.")
             viewModel.deleteSessionAlarmNotificationId(notificationId)
+        }
+    }
+
+    private fun onScheduleUpdateNotificationTapped(intent: Intent) {
+        val isScheduleUpdateNotification = intent.getBooleanExtra(SCHEDULE_UPDATE_NOTIFICATION, false)
+        if (isScheduleUpdateNotification) {
+            logging.report(LOG_TAG, "Tapped schedule update notification.")
+            intent.removeExtra(SCHEDULE_UPDATE_NOTIFICATION)
         }
     }
 


### PR DESCRIPTION
# Description
- Log when schedule update notification or session alarm notification are tapped so it shows up in the log output of a crash report sent by users.
- Hopefully helpful to understand https://github.com/EventFahrplan/EventFahrplan/issues/838 better.

# Successfully tested on
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)