### PR TITLE
Fix crash at app start on devices running Android before Pie 9 (API 28).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/base/BaseActivity.kt
@@ -70,7 +70,7 @@ abstract class BaseActivity : AppCompatActivity {
     /**
      * See [ActivityCompat.requireViewById].
      */
-    protected fun <T : View?> requireViewByIdCompat(@IdRes id: Int): T {
+    fun <T : View?> requireViewByIdCompat(@IdRes id: Int): T {
         return ActivityCompat.requireViewById(this, id)
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -278,7 +278,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
             updateHorizontalScrollingProgressLine(shouldShow)
         }
         viewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
-            requireActivity().requireViewById<ComposeView>(R.id.error_message_view).setContent {
+            (requireActivity() as MainActivity).requireViewByIdCompat<ComposeView>(R.id.error_message_view).setContent {
                 errorMessage?.let { ErrorMessage(it) }
             }
         }


### PR DESCRIPTION
# Description
+ `Activity#requireViewById` was added in Android 9 (API 28) https://developer.android.com/reference/android/app/Activity#requireViewById(int)

# Stacktrace
``` java
java.lang.NoSuchMethodError: No virtual method requireViewById(I)Landroid/view/View;
  in class Landroidx/fragment/app/FragmentActivity; or its super classes (declaration
  of 'androidx.fragment.app.FragmentActivity' appears in /data/app/
  info.metadude.android.congress.schedule.debug-kTe9z-9HQ_bn82E5_R3DtQ==/base.apk:classes30.dex)

    at nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment$observeViewModel$4.emit(FahrplanFragment.kt:281)
    at nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment$observeViewModel$4.emit(FahrplanFragment.kt:280)
    at kotlinx.coroutines.flow.StateFlowImpl.collect(StateFlow.kt:401)
    at kotlinx.coroutines.flow.ReadonlyStateFlow.collect(Unknown Source:2)
    at info.metadude.android.eventfahrplan.commons.flow.FlowExtensionsKt$observe$1$1.invokeSuspend(FlowExtensions.kt:14)
    at info.metadude.android.eventfahrplan.commons.flow.FlowExtensionsKt$observe$1$1.invoke(Unknown Source:8)
    at info.metadude.android.eventfahrplan.commons.flow.FlowExtensionsKt$observe$1$1.invoke(Unknown Source:4)
    at androidx.lifecycle.RepeatOnLifecycleKt$repeatOnLifecycle$3$1$1$1$1$1$1.invokeSuspend(RepeatOnLifecycle.kt:110)
    ...
```

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Emulator, Android 8.0 (API 26)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)