### PR TITLE
Support filtering sessions which are not favored.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
@@ -36,6 +36,7 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchResultItem
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenBackPress
 import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotFavoriteSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.RecordedSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.WithinSpeakerNamesSearchFilter
@@ -54,6 +55,7 @@ class SearchViewModel(
 
         private val SUPPORTED_SEARCH_FILTERS = listOf(
             IsFavoriteSearchFilter(),
+            NotFavoriteSearchFilter(),
             HasAlarmSearchFilter(),
             NotRecordedSearchFilter(),
             RecordedSearchFilter(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/filters/NotFavoriteSearchFilter.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/filters/NotFavoriteSearchFilter.kt
@@ -1,0 +1,13 @@
+package nerd.tuxmobil.fahrplan.congress.search.filters
+
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.search.SearchFilter
+
+class NotFavoriteSearchFilter : SearchFilter {
+    override val label = R.string.search_filter_not_favorite
+
+    override fun isMatch(session: Session, query: String): Boolean {
+        return !session.isHighlight
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -301,6 +301,7 @@
 
     <!-- Search filters -->
     <string name="search_filter_is_favorite">Ist favorisiert</string>
+    <string name="search_filter_not_favorite">Nicht favorisiert</string>
     <string name="search_filter_has_alarm">Hat Alarm</string>
     <string name="search_filter_not_recorded">Nicht aufgezeichnet</string>
     <string name="search_filter_recorded">Aufgezeichnet</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,6 +330,7 @@
 
     <!-- Search filters -->
     <string name="search_filter_is_favorite">Is favored</string>
+    <string name="search_filter_not_favorite">Not favored</string>
     <string name="search_filter_has_alarm">Has alarm</string>
     <string name="search_filter_not_recorded">Not recorded</string>
     <string name="search_filter_recorded">Recorded</string>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchQueryFilterTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotFavoriteSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.RecordedSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.WithinSpeakerNamesSearchFilter
@@ -99,6 +100,32 @@ class SearchQueryFilterTest {
         val session3 = Session("3", title = "Session 3", isHighlight = true)
         val sessions = listOf(session1, session2, session3)
         val filters = setOf(IsFavoriteSearchFilter())
+
+        val result = filter.filterAll(sessions, query = "", filters)
+
+        assertThat(result).containsExactly(session2, session3)
+    }
+
+    @Test
+    fun `NotFavoriteSearchFilter only returns not starred sessions`() {
+        val session1 = Session("1", title = "Session 1", isHighlight = true)
+        val session2 = Session("2", title = "Session 2", isHighlight = false)
+        val session3 = Session("3", title = "no match", isHighlight = false)
+        val sessions = listOf(session1, session2, session3)
+        val filters = setOf(NotFavoriteSearchFilter())
+
+        val result = filter.filterAll(sessions, query = "session", filters)
+
+        assertThat(result).containsExactly(session2)
+    }
+
+    @Test
+    fun `NotFavoriteSearchFilter with empty query returns not all starred sessions`() {
+        val session1 = Session("1", title = "Session 1", isHighlight = true)
+        val session2 = Session("2", title = "Session 2", isHighlight = false)
+        val session3 = Session("3", title = "Session 3", isHighlight = false)
+        val sessions = listOf(session1, session2, session3)
+        val filters = setOf(NotFavoriteSearchFilter())
 
         val result = filter.filterAll(sessions, query = "", filters)
 


### PR DESCRIPTION
# Description
- Adds a new `Not favored` filter to the search screen.
- This allows to look through sessions which have not already been selected as a favorite.

# Before & After
<img width="270" height="600" alt="search-filter-not-favored-before" src="https://github.com/user-attachments/assets/a7f1ba02-4ae1-41ef-b105-61332d1df9e4" /> <img width="270" height="600" alt="search-filter-not-favored" src="https://github.com/user-attachments/assets/4f92a637-3072-40e5-9e7c-139bbe1a784b" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

# Related
- https://github.com/EventFahrplan/EventFahrplan/issues/815