### PR TITLE
Dimm past sessions in the list of search results.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorScheme.kt
@@ -63,6 +63,7 @@ data class ColorScheme(
     val searchBarDivider: Color,
     val sessionListHeaderDayDate: Color,
     val textLink: Color,
+    val textPastContent: Color,
     val appBarContainer: Color,
     val appBarTitleText: Color,
     val appBarNavigationIcon: Color,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
@@ -23,6 +23,7 @@ internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
     searchBarDivider = colorResource(R.color.colorAccent),
     sessionListHeaderDayDate = colorResource(R.color.session_list_header_day_date),
     textLink = colorResource(R.color.text_link_on_dark),
+    textPastContent = colorResource(R.color.text_past_content_on_dark),
     // AppBar
     appBarContainer = colorResource(R.color.colorPrimary),
     appBarTitleText = colorResource(R.color.text_primary),
@@ -70,6 +71,7 @@ internal fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     searchBarDivider = colorResource(R.color.colorAccent),
     sessionListHeaderDayDate = colorResource(R.color.session_list_header_day_date),
     textLink = colorResource(R.color.text_link_on_light),
+    textPastContent = colorResource(R.color.text_past_content_on_light),
     // AppBar
     appBarContainer = colorResource(R.color.colorPrimary),
     appBarTitleText = colorResource(R.color.text_primary),
@@ -111,6 +113,7 @@ private fun Material3ColorScheme.toColorScheme(
     searchBarDivider: Color,
     sessionListHeaderDayDate: Color,
     textLink: Color,
+    textPastContent: Color,
     appBarContainer: Color,
     appBarTitleText: Color,
     appBarNavigationIcon: Color,
@@ -191,6 +194,7 @@ private fun Material3ColorScheme.toColorScheme(
         searchBarDivider = searchBarDivider,
         sessionListHeaderDayDate = sessionListHeaderDayDate,
         textLink = textLink,
+        textPastContent = textPastContent,
         appBarContainer = appBarContainer,
         appBarTitleText = appBarTitleText,
         appBarNavigationIcon = appBarNavigationIcon,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/texts/TextOverline.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/texts/TextOverline.kt
@@ -2,15 +2,18 @@ package nerd.tuxmobil.fahrplan.congress.designsystem.texts
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.material3.Text as Material3Text
 
 @Composable
 fun TextOverline(
     text: String,
     modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
 ) {
     Material3Text(
         text = text,
         modifier = modifier,
+        color = color,
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/DefaultSearchResultParameterFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/DefaultSearchResultParameterFactory.kt
@@ -18,6 +18,7 @@ class DefaultSearchResultParameterFactory(
     private val contentDescriptionFormatting: ContentDescriptionFormatting,
     private val daySeparatorFactory: DaySeparatorFactory,
     private val formattingDelegate: FormattingDelegate,
+    private val tenseTypeProvision: TenseTypeProvision,
 ) : SearchResultParameterFactory, FormattingDelegate by formattingDelegate {
 
     override fun createSearchResults(
@@ -62,6 +63,7 @@ class DefaultSearchResultParameterFactory(
             session.startsAt,
             session.timeZoneOffset,
         )
+        val tenseType = tenseTypeProvision.getTenseType(session)
 
         return SearchResult(
             id = session.sessionId,
@@ -69,16 +71,19 @@ class DefaultSearchResultParameterFactory(
                 value = title,
                 contentDescription = contentDescriptionFormatting
                     .getTitleContentDescription(session.title),
+                tenseType = tenseType,
             ),
             speakerNames = SearchResultProperty(
                 value = speakers,
                 contentDescription = contentDescriptionFormatting
                     .getSpeakersContentDescription(session.speakers.size, formattedSpeakerNames),
+                tenseType = tenseType,
             ),
             startsAt = SearchResultProperty(
                 value = startsAtText,
                 contentDescription = contentDescriptionFormatting
                     .getStartTimeContentDescription(startsAtText),
+                tenseType = tenseType,
             ),
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -84,6 +85,8 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryChang
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryClear
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchResultItemClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenBackPress
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.FUTURE
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.PAST
 
 @Composable
 fun SearchScreen(
@@ -329,6 +332,7 @@ private fun SearchResultItem(
                     contentDescription = searchResult.startsAt.contentDescription
                 },
                 text = searchResult.startsAt.value,
+                color = searchResult.startsAt.tenseType.color(),
             )
         },
         headlineContent = {
@@ -337,6 +341,7 @@ private fun SearchResultItem(
                     contentDescription = searchResult.title.contentDescription
                 },
                 text = searchResult.title.value,
+                color = searchResult.title.tenseType.color(),
             )
         },
         supportingContent = {
@@ -346,10 +351,17 @@ private fun SearchResultItem(
                         contentDescription = searchResult.speakerNames.contentDescription
                     },
                     text = searchResult.speakerNames.value,
+                    color = searchResult.speakerNames.tenseType.color(),
                 )
             }
         },
     )
+}
+
+@Composable
+private fun TenseType.color() = when (this) {
+    PAST -> EventFahrplanTheme.colorScheme.textPastContent
+    FUTURE -> Color.Unspecified
 }
 
 @Composable

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultProperty.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchResultProperty.kt
@@ -1,6 +1,9 @@
 package nerd.tuxmobil.fahrplan.congress.search
 
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.FUTURE
+
 data class SearchResultProperty<T>(
     val value: T,
     val contentDescription: String,
+    val tenseType: TenseType = FUTURE,
 )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelFactory.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.search
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider.Factory
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.commons.DateFormatterDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorFactory
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
@@ -35,6 +36,7 @@ class SearchViewModelFactory(
                     contentDescriptionFormatting = contentDescriptionFormatting,
                 ),
                 formattingDelegate = formattingDelegate,
+                tenseTypeProvision = TenseTypeProvider(Moment.now()),
             ),
         ) as T
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseType.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseType.kt
@@ -1,0 +1,6 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+enum class TenseType {
+    PAST,
+    FUTURE,
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProvider.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProvider.kt
@@ -1,0 +1,15 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.FUTURE
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.PAST
+
+class TenseTypeProvider(val now: Moment) : TenseTypeProvision {
+
+    override fun getTenseType(session: Session) = when (session.endsAt.isBefore(now)) {
+        true -> PAST
+        false -> FUTURE
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProvision.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProvision.kt
@@ -1,0 +1,7 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+import nerd.tuxmobil.fahrplan.congress.models.Session
+
+interface TenseTypeProvision {
+    fun getTenseType(session: Session): TenseType
+}

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,6 +13,8 @@
     <color name="foreground">#888</color>
     <color name="text_link_on_light">@color/colorAccent</color>
     <color name="text_link_on_dark">@color/colorAccent</color>
+    <color name="text_past_content_on_light">#808080</color>
+    <color name="text_past_content_on_dark">#808080</color>
     <color name="text_link_pressed_background_on_light">#aafec700</color>
     <color name="divider">#88888888</color>
 
@@ -68,7 +70,7 @@
     <color name="schedule_change_canceled_on_light">#B71C1C</color>
 
     <!-- Favorites -->
-    <color name="favorites_past_session_text">#808080</color>
+    <color name="favorites_past_session_text">@color/text_past_content_on_light</color>
     <color name="favorites_background">@color/windowBackground</color>
 
     <!-- Session item (favorites + schedule changes) -->

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/DefaultSearchResultParameterFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/DefaultSearchResultParameterFactoryTest.kt
@@ -7,6 +7,7 @@ import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.FUTURE
 import nerd.tuxmobil.fahrplan.congress.utils.ContentDescriptionFormatter
 import nerd.tuxmobil.fahrplan.congress.utils.SessionPropertiesFormatting
 import org.junit.jupiter.api.Test
@@ -119,6 +120,7 @@ class DefaultSearchResultParameterFactoryTest {
             contentDescriptionFormatting = ContentDescriptionFormatter(CompleteResourceResolver),
             daySeparatorFactory = daySeparatorFactory,
             formattingDelegate = formattingDelegate,
+            tenseTypeProvision = FutureTenseProvider,
         )
     }
 
@@ -159,3 +161,8 @@ private object CompleteResourceResolver : ResourceResolving {
             else -> fail("Unknown quantity string id : $id")
         }
 }
+
+private object FutureTenseProvider : TenseTypeProvision {
+    override fun getTenseType(session: Session) = FUTURE
+}
+

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProviderTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/TenseTypeProviderTest.kt
@@ -1,0 +1,43 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.FUTURE
+import nerd.tuxmobil.fahrplan.congress.search.TenseType.PAST
+import org.junit.jupiter.api.Test
+
+class TenseTypeProviderTest {
+
+    private companion object {
+        val SOME_MOMENT = Moment.ofEpochMilli(1766876400000) // 27.12.2025 11:00:00 PM
+    }
+
+    private val provider = TenseTypeProvider(SOME_MOMENT)
+
+    @Test
+    fun `getTenseType returns FUTURE for current session`() {
+        val session = createSession(SOME_MOMENT.minusMinutes(30))
+        assertThat(provider.getTenseType(session)).isEqualTo(FUTURE)
+    }
+
+    @Test
+    fun `getTenseType returns PAST for past session`() {
+        val session = createSession(SOME_MOMENT.minusMinutes(31))
+        assertThat(provider.getTenseType(session)).isEqualTo(PAST)
+    }
+
+    @Test
+    fun `getTenseType returns FUTURE for future session`() {
+        val session = createSession(SOME_MOMENT.minusMinutes(29))
+        assertThat(provider.getTenseType(session)).isEqualTo(FUTURE)
+    }
+
+    private fun createSession(startsAt: Moment) = Session(
+        sessionId = "",
+        dateUTC = startsAt.toMilliseconds(),
+        duration = Duration.ofMinutes(30),
+    )
+
+}


### PR DESCRIPTION
# Description
+ Sessions which already took place are shown with a **dimmed text color** to visually distinguish them from current and upcoming sessions.
+ Checked for both light and dark modes.

# Before & after screenshots
<img width="270" height="600" alt="search-before" src="https://github.com/user-attachments/assets/a06994f6-bc1d-495b-9d56-5b62acdab559" /> <img width="270" height="600" alt="search-after" src="https://github.com/user-attachments/assets/5b61c360-5f44-41ce-bcc7-4c09b74c98c1" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)