### PR TITLE
Show error message to users if parsing Engelsystem URL fails.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParser.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParser.kt
@@ -1,7 +1,18 @@
 package nerd.tuxmobil.fahrplan.congress.engelsystem
 
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Empty
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.API_KEY_INVALID
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.HOST_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.PATH_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.QUERY_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.SCHEME_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.URL_MALFORMED
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Parsed
+import nerd.tuxmobil.fahrplan.congress.engelsystem.PartialResult.Failure
+import nerd.tuxmobil.fahrplan.congress.engelsystem.PartialResult.Success
 import java.net.URI
-import java.net.URISyntaxException
 
 class EngelsystemUriParser {
 
@@ -10,57 +21,77 @@ class EngelsystemUriParser {
     }
 
     /**
-     * Returns the corresponding [EngelsystemUri] for the given [url].
-     * @throws URISyntaxException
+     * Returns the corresponding [EngelsystemUri] wrapped in an [EngelsystemUriParsingResult]
+     * for the given [url].
      */
-    fun parseUri(url: String): EngelsystemUri {
+    fun parseUri(url: String): EngelsystemUriParsingResult {
         if (url.isEmpty()) {
-            throw ParsingException("Empty URL")
+            return Empty
         }
-        val uri = URI.create(url)
-        return EngelsystemUri(
-            parseBaseUrl(uri),
-            parsePathPart(uri.path),
-            parseApiKey(uri.query))
+        val uri = try {
+            URI.create(url)
+        } catch (_: IllegalArgumentException) {
+            return Error(URL_MALFORMED, url)
+        }
+        return when (val baseUrl = parseBaseUrl(uri)) {
+            is Failure -> Error(baseUrl.type, url)
+            is Success -> when (val pathPart = parsePathPart(uri.path)) {
+                is Failure -> Error(pathPart.type, url)
+                is Success -> when (val apiKey = parseApiKey(uri.query)) {
+                    is Failure -> Error(apiKey.type, url)
+                    is Success -> Parsed(EngelsystemUri(baseUrl.value, pathPart.value, apiKey.value))
+                }
+            }
+        }
     }
 
     /**
      * The base URL, e.g. https://example.com or https://example.com:3000
      */
-    private fun parseBaseUrl(uri: URI): String {
-        val schemePart = if (uri.scheme != null) "${uri.scheme}://" else throw ParsingException("Scheme is missing: $uri")
-        val hostPart = uri.host ?: throw ParsingException("Host is missing: $uri")
+    private fun parseBaseUrl(uri: URI): PartialResult {
+        val schemePart = if (uri.scheme != null) "${uri.scheme}://" else return Failure(SCHEME_MISSING)
+        val hostPart = uri.host ?: return Failure(HOST_MISSING)
         val portPart = if (NO_PORT_DEFINED == uri.port) "" else ":${uri.port}"
-        return "$schemePart$hostPart$portPart"
+        return Success("$schemePart$hostPart$portPart")
     }
 
     /**
      * The URL path, e.g. /some/folder/file.json
      */
-    private fun parsePathPart(path: String?) =
-        if (path.isNullOrEmpty()) throw ParsingException("Path is missing")
-        else path.trimStart('/')
+    private fun parsePathPart(path: String?): PartialResult =
+        if (path.isNullOrEmpty()) Failure(PATH_MISSING)
+        else Success(path.trimStart('/'))
 
     /**
      * The API key provided as a query parameter value, as in: ?key=a1b2c3
      */
-    private fun parseApiKey(query: String?) = try {
-        val queryPart = query ?: throw ParsingException("Query is missing")
-        val keyValuePairs = queryPart.split("=")
-        if (keyValuePairs.size % 2 != 0) {
-            throw ApiKeyMissingException(query)
+    private fun parseApiKey(query: String?): PartialResult {
+        val queryPart = query ?: return Failure(QUERY_MISSING)
+        val valuesByKeys = queryPart.split("&").associate { param ->
+            val valueByKey = param.split("=", limit = 2)
+            if (valueByKey.size == 2) {
+                valueByKey[0] to valueByKey[1]
+            } else {
+                valueByKey[0] to ""
+            }
         }
-        keyValuePairs.last()
-    } catch (_: NoSuchElementException) {
-        throw ApiKeyMissingException(query)
-    } catch (_: IllegalArgumentException) {
-        throw ApiKeyMissingException(query)
+        val apiKey = valuesByKeys["key"]
+        // Valid API keys should be alphanumeric (and possibly contain some special chars like - or _)
+        // but definitely should not contain protocol separators, slashes, or query parameter syntax.
+        return when (apiKey.isNullOrEmpty() || !isValidApiKey(apiKey)) {
+            true -> Failure(API_KEY_INVALID)
+            false -> Success(apiKey)
+        }
     }
 
+    /**
+     * Validates that the API key contains only allowed characters.
+     * Rejects keys that contain URL-like patterns which might indicate a malformed/doubled URL.
+     */
+    private fun isValidApiKey(apiKey: String) = "://" !in apiKey && "/" !in apiKey && "?" !in apiKey
 }
 
-private class ApiKeyMissingException(query: String?)
-    : ParsingException("API key is missing: $query")
-
-private open class ParsingException(messageSuffix: String)
-    : URISyntaxException(messageSuffix, "Parsing failure")
+private sealed interface PartialResult {
+    data class Success(val value: String) : PartialResult
+    data class Failure(val type: Type) : PartialResult
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParsingResult.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParsingResult.kt
@@ -1,0 +1,21 @@
+package nerd.tuxmobil.fahrplan.congress.engelsystem
+
+sealed interface EngelsystemUriParsingResult {
+
+    data object Empty : EngelsystemUriParsingResult
+
+    data class Parsed(val uri: EngelsystemUri) : EngelsystemUriParsingResult
+
+    data class Error(val type: Type, val url: String) : EngelsystemUriParsingResult {
+
+        enum class Type {
+            URL_MALFORMED,
+            SCHEME_MISSING,
+            HOST_MISSING,
+            PATH_MISSING,
+            QUERY_MISSING,
+            API_KEY_INVALID,
+        }
+
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/errors/ErrorMessage.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/net/errors/ErrorMessage.kt
@@ -2,6 +2,13 @@ package nerd.tuxmobil.fahrplan.congress.net.errors
 
 import android.content.Context
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.API_KEY_INVALID
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.HOST_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.PATH_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.QUERY_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.SCHEME_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.URL_MALFORMED
 import nerd.tuxmobil.fahrplan.congress.net.HttpStatus
 import nerd.tuxmobil.fahrplan.congress.net.ParseResult
 import nerd.tuxmobil.fahrplan.congress.net.ParseScheduleResult
@@ -93,6 +100,23 @@ sealed interface ErrorMessage {
             }
             check(message.isNotEmpty()) { "Unknown parsing result: $parseResult" }
             return SimpleMessage(message)
+        }
+
+        /**
+         * Returns a [TitledMessage] based on the given [error].
+         */
+        fun getMessageForEngelsystemUrlError(error: EngelsystemUriParsingResult.Error): TitledMessage {
+            val url = error.url
+            val message = when (error.type) {
+                URL_MALFORMED -> context.getString(R.string.engelsystem_url_error_url, url)
+                SCHEME_MISSING -> context.getString(R.string.engelsystem_url_error_scheme, url)
+                HOST_MISSING -> context.getString(R.string.engelsystem_url_error_host, url)
+                PATH_MISSING -> context.getString(R.string.engelsystem_url_error_path, url)
+                QUERY_MISSING -> context.getString(R.string.engelsystem_url_error_query, url)
+                API_KEY_INVALID -> context.getString(R.string.engelsystem_url_error_api_key, url)
+            }
+            val title = context.getString(R.string.engelsystem_url_error_title, context.getString(R.string.engelsystem_alias))
+            return TitledMessage(title, message)
         }
 
         private fun getMessageForScheduleVersion(scheduleVersion: String) = when {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -71,6 +71,7 @@ internal class MainViewModel(
 
     init {
         observeLoadScheduleState()
+        observeEngelsystemUriParsingErrorState()
     }
 
     private fun observeLoadScheduleState() {
@@ -79,6 +80,17 @@ internal class MainViewModel(
                 val uiState = state.toUiState()
                 mutableLoadScheduleUiState.sendOneTimeEvent(uiState)
                 state.handleFailureStates()
+            }
+        }
+    }
+
+    private fun observeEngelsystemUriParsingErrorState() {
+        launch {
+            repository.engelsystemUriParsingErrorState.collectLatest { errorState ->
+                mutableErrorMessage.value = when (errorState == null) {
+                    true -> null
+                    false -> errorMessageFactory.getMessageForEngelsystemUrlError(errorState)
+                }
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -306,4 +306,14 @@
     <string name="search_filter_not_recorded">Nicht aufgezeichnet</string>
     <string name="search_filter_recorded">Aufgezeichnet</string>
     <string name="search_filter_within_speaker_names">In Namen von Sprecher*innen</string>
+
+    <!-- Engelsystem URL error -->
+    <string name="engelsystem_url_error_title">Fehler bei Einlesen der <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> JSON Export URL</string>
+    <string name="engelsystem_url_error_url">Ungültige URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_scheme">Fehlender Schema-Teil in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_host">Fehlender Host-Teil in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_path">Fehlender Pfad-Teil in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_query">Fehlender Query-Teil in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_api_key">Ungültiger API-Key-Teil in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,4 +335,14 @@
     <string name="search_filter_not_recorded">Not recorded</string>
     <string name="search_filter_recorded">Recorded</string>
     <string name="search_filter_within_speaker_names">Within speaker names</string>
+
+    <!-- Engelsystem URL error -->
+    <string name="engelsystem_url_error_title">Error parsing <xliff:g example="Engelsystem" id="engelsystemAlias">%s</xliff:g> JSON Export URL</string>
+    <string name="engelsystem_url_error_url">Malformed URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_scheme">Missing scheme part in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_host">Missing host part in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_path">Missing path part in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_query">Missing query part in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+    <string name="engelsystem_url_error_api_key">Invalid API key part in URL: <xliff:g example="https://example.com" id="url">%s</xliff:g></string>
+
 </resources>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParserTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/engelsystem/EngelsystemUriParserTest.kt
@@ -1,88 +1,99 @@
 package nerd.tuxmobil.fahrplan.congress.engelsystem
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Assertions.fail
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Empty
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.API_KEY_INVALID
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.HOST_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.PATH_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.QUERY_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.SCHEME_MISSING
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Error.Type.URL_MALFORMED
+import nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParsingResult.Parsed
 import org.junit.jupiter.api.Test
-import java.net.URISyntaxException
 
 class EngelsystemUriParserTest {
 
     private val uriParser = EngelsystemUriParser()
 
     @Test
-    fun `parseUri throws exception if url is empty`() {
-        try {
-            uriParser.parseUri("")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("Empty URL")
-        }
+    fun `parseUri returns Empty if url is empty`() {
+        assertThat(uriParser.parseUri("")).isEqualTo(Empty)
     }
 
     @Test
-    fun `parseUri throws exception if url lacks a scheme`() {
-        try {
-            uriParser.parseUri("example.com")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("Scheme is missing")
-        }
+    fun `parseUri returns Error if url is malformed`() {
+        assertThat(uriParser.parseUri("https://example.com/path with spaces"))
+            .isEqualTo(Error(URL_MALFORMED, "https://example.com/path with spaces"))
     }
 
     @Test
-    fun `parseUri throws exception if url lacks a host`() {
-        try {
-            uriParser.parseUri("https://?key=a1b2c3")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("Host is missing")
-        }
+    fun `parseUri returns Error if url lacks a scheme`() {
+        assertThat(uriParser.parseUri("example.com"))
+            .isEqualTo(Error(SCHEME_MISSING, "example.com"))
     }
 
     @Test
-    fun `parseUri throws exception if url lacks a path`() {
-        try {
-            uriParser.parseUri("https://example.com?key=a1b2c3")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("Path is missing")
-        }
+    fun `parseUri returns Error if url lacks a host`() {
+        assertThat(uriParser.parseUri("https://?key=a1b2c3"))
+            .isEqualTo(Error(HOST_MISSING, "https://?key=a1b2c3"))
     }
 
     @Test
-    fun `parseUri throws exception if url lacks a query`() {
-        try {
-            uriParser.parseUri("https://example.com/foo/file.json")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("Query is missing")
-        }
+    fun `parseUri returns Error if url lacks a path`() {
+        assertThat(uriParser.parseUri("https://example.com?key=a1b2c3"))
+            .isEqualTo(Error(PATH_MISSING, "https://example.com?key=a1b2c3"))
     }
 
     @Test
-    fun `parseUri throws exception if url lacks an API key`() {
-        try {
-            uriParser.parseUri("https://example.com/foo/file.json?key")
-            failExpectingUriSyntaxException()
-        } catch (e: URISyntaxException) {
-            assertThat(e.message).contains("API key is missing")
-        }
-    }
-
-    private fun failExpectingUriSyntaxException() {
-        fail<Unit>("Expect a URISyntaxException to be thrown.")
+    fun `parseUri returns Error if url lacks a query`() {
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json"))
+            .isEqualTo(Error(QUERY_MISSING, "https://example.com/foo/file.json"))
     }
 
     @Test
-    fun `parseUri returns valid EngelsystemUri if url is complete`() {
+    fun `parseUri returns Error if url lacks an API key`() {
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?key"))
+            .isEqualTo(Error(API_KEY_INVALID, "https://example.com/foo/file.json?key"))
+    }
+
+    @Test
+    fun `parseUri returns Error if url has been pasted twice`() {
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?key=a1b2c3https://example.com/foo/file.json?key=a1b2c3"))
+            .isEqualTo(Error(API_KEY_INVALID, "https://example.com/foo/file.json?key=a1b2c3https://example.com/foo/file.json?key=a1b2c3"))
+    }
+
+    @Test
+    fun `parseUri returns Error if url has different query parameter`() {
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?foo=bar"))
+            .isEqualTo(Error(API_KEY_INVALID, "https://example.com/foo/file.json?foo=bar"))
+    }
+
+    @Test
+    fun `parseUri returns Error if url has key parameter with empty value`() {
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?key="))
+            .isEqualTo(Error(API_KEY_INVALID, "https://example.com/foo/file.json?key="))
+    }
+
+    @Test
+    fun `parseUri returns Parsed if url is complete`() {
         val uri = EngelsystemUri("https://example.com", "foo/file.json", "a1b2c3")
-        assertThat(uriParser.parseUri("https://example.com/foo/file.json?key=a1b2c3")).isEqualTo(uri)
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?key=a1b2c3"))
+            .isEqualTo(Parsed(uri))
     }
 
     @Test
-    fun `parseUri returns valid EngelsystemUri if url is complete and port is present`() {
+    fun `parseUri returns Parsed if url is complete and port is present`() {
         val uri = EngelsystemUri("https://example.com:3000", "foo/file.json", "a1b2c3")
-        assertThat(uriParser.parseUri("https://example.com:3000/foo/file.json?key=a1b2c3")).isEqualTo(uri)
+        assertThat(uriParser.parseUri("https://example.com:3000/foo/file.json?key=a1b2c3"))
+            .isEqualTo(Parsed(uri))
+    }
+
+    @Test
+    fun `parseUri returns Parsed if url has multiple query parameters including key`() {
+        val uri = EngelsystemUri("https://example.com", "foo/file.json", "a1b2c3")
+        assertThat(uriParser.parseUri("https://example.com/foo/file.json?foo=bar&key=a1b2c3"))
+            .isEqualTo(Parsed(uri))
     }
 
 }


### PR DESCRIPTION
# Description
+ Fix crash which occurred when the URL has been pasted twice.
+ Cover the crash scenario with a unit test.
+ Extend coverage for other cases.

## Stacktrace
``` java
Caused by: nerd.tuxmobil.fahrplan.congress.engelsystem.ApiKeyMissingException: Parsing failure: 
API key is missing: key=123chttps://engel.events.ccc.de/shifts-json-export?key=123
  at nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParser.parseApiKey(SourceFile:51)
  at nerd.tuxmobil.fahrplan.congress.engelsystem.EngelsystemUriParser.parseUri(SourceFile:24)
  ...
```

# After
<img width="270" height="600" alt="engelsystem-url-parsing-error" src="https://github.com/user-attachments/assets/633f7713-6dbb-4974-800c-e01685313dea" />


# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)