### PR TITLE
Fix "Event online" links opening with apps which are not the default browser.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ExternalNavigation.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ExternalNavigation.kt
@@ -3,7 +3,8 @@ package nerd.tuxmobil.fahrplan.congress.commons
 interface ExternalNavigation {
 
     fun openMap(locationText: String)
-    fun getBrowsableApps(link: String): List<String>
+    fun getBrowserApps(): List<String>
+    fun getDefaultBrowsableApp(): String?
     fun openLink(link: String)
     fun openLinkWithApp(link: String, packageName: String)
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ExternalNavigator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/commons/ExternalNavigator.kt
@@ -1,7 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.commons
 
 import android.content.Context
-import nerd.tuxmobil.fahrplan.congress.extensions.getBrowsableApps
+import nerd.tuxmobil.fahrplan.congress.extensions.getBrowserApps
+import nerd.tuxmobil.fahrplan.congress.extensions.getDefaultBrowsableApp
 import nerd.tuxmobil.fahrplan.congress.extensions.openLink
 import nerd.tuxmobil.fahrplan.congress.extensions.openLinkWithApp
 import nerd.tuxmobil.fahrplan.congress.extensions.openMap
@@ -11,8 +12,11 @@ class ExternalNavigator(val context: Context) : ExternalNavigation {
     override fun openMap(locationText: String) =
         context.openMap(locationText)
 
-    override fun getBrowsableApps(link: String) =
-        context.getBrowsableApps(link)
+    override fun getDefaultBrowsableApp() =
+        context.getDefaultBrowsableApp()
+
+    override fun getBrowserApps() =
+        context.getBrowserApps()
 
     override fun openLink(link: String) =
         context.openLink(link)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -119,12 +119,16 @@ internal class SessionDetailsViewModel(
     }
 
     private fun openLink(link: String) {
-        val packageNames = externalNavigation.getBrowsableApps(link)
-        val otherPackageNames = packageNames.filter { it != buildConfigProvision.packageName }
-        if (otherPackageNames.isNotEmpty()) {
-            externalNavigation.openLinkWithApp(link = link, packageName = otherPackageNames.first())
-        } else {
+        val defaultBrowser = externalNavigation.getDefaultBrowsableApp()
+        val browsers = externalNavigation.getBrowserApps().filter { it != buildConfigProvision.packageName }
+        val desiredBrowser = when (defaultBrowser in browsers) {
+            true -> defaultBrowser
+            false -> browsers.firstOrNull()
+        }
+        if (desiredBrowser == null) {
             externalNavigation.openLink(link)
+        } else {
+            externalNavigation.openLinkWithApp(link = link, packageName = desiredBrowser)
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/Contexts.kt
@@ -7,6 +7,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager.MATCH_ALL
+import android.content.pm.PackageManager.MATCH_DEFAULT_ONLY
 import android.content.res.Configuration
 import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
@@ -32,9 +33,31 @@ fun Context.startActivity(intent: Intent, onActivityNotFound: () -> Unit) {
     }
 }
 
-fun Context.getBrowsableApps(link: String): List<String> {
-    val intent = Intent(Intent.ACTION_VIEW, link.toUri()).apply {
+/**
+ * Returns the package name for the default browsable app.
+ * Here, intentionally a website which is unrelated to the domain of the event is passed to avoid
+ * returning our own package name which can be registered as an app links handler.
+ */
+fun Context.getDefaultBrowsableApp(): String? {
+    val uri = "https://eventfahrplan.eu".toUri()
+    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
         addCategory(Intent.CATEGORY_BROWSABLE)
+    }
+    val flags = if (SDK_INT < M) 0 else MATCH_DEFAULT_ONLY
+    return packageManager
+        .resolveActivity(intent, flags)
+        ?.activityInfo
+        ?.packageName
+}
+
+/**
+ * Returns a list of package names for all browser apps.
+ * Note [Intent.CATEGORY_APP_BROWSER] is used here compared
+ * to [getDefaultBrowsableApp].
+ */
+fun Context.getBrowserApps(): List<String> {
+    val intent = Intent(Intent.ACTION_MAIN).apply {
+        addCategory(Intent.CATEGORY_APP_BROWSER)
     }
     val flags = if (SDK_INT < M) 0 else MATCH_ALL
     return packageManager


### PR DESCRIPTION
# Description
+ Refactored browser app selection logic to respect the user's default browser preference when opening "Event online" links.
+ Previously, the app would open links using the first available browser app, which could be any installed browser, not necessarily the user's default choice. This change ensures that links open in the user's default browser when available.

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)
- :heavy_check_mark: Emulator, Android 8.0 (API 26)

---
Resolves #846