### PR TITLE
Fix OutOfMemoryError in Cursor#map when processing large datasets.

### DIFF
--- a/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
+++ b/database/src/main/java/info/metadude/android/eventfahrplan/database/extensions/CursorExtensions.kt
@@ -74,8 +74,11 @@ internal inline fun Cursor.getStringOrNull(columnName: String): String? =
  * in the [Cursor]. Closes the Cursor afterwards.
  */
 internal inline fun <T> Cursor.map(transform: (Cursor) -> T): List<T> = this.use {
-    List(count) { index ->
-        moveToPosition(index)
-        transform(this)
+    val result = mutableListOf<T>()
+    if (moveToFirst()) {
+        do {
+            result.add(transform(this))
+        } while (moveToNext())
     }
+    result
 }


### PR DESCRIPTION
# Description
+ Replace `Cursor#map` implementation to use sequential iteration with `moveToNext()` instead of `moveToPosition(index)`. The previous implementation used `List(count)` which forces Android's CursorWindow to load all rows into memory simultaneously, exceeding the ~2MB window limit when processing sessions with large text fields (`ABSTRACT`, `DESCR`, `LINKS`, `SPEAKERS`, etc.).
+ The new implementation processes rows sequentially, allowing the CursorWindow to manage memory efficiently by loading rows on-demand. This maintains the same API and behavior while preventing `OutOfMemoryError` exceptions.

## Stacktrace
``` java
Exception java.lang.OutOfMemoryError:
  at android.database.CursorWindow.nativeGetString
  at android.database.CursorWindow.getString (CursorWindow.java:510)
  at android.database.AbstractWindowedCursor.getString (AbstractWindowedCursor.java:54)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:279)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:280)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:281)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:284)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:287)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:288)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:289)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:291)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:292)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:294)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:295)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:296)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:299)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:300)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:301)
  at info.metadude.android.eventfahrplan.database.extensions.CursorExtensionsKt.getString (CursorExtensions.kt:58)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.query (RealSessionsDatabaseRepository.kt:302)
  at info.metadude.android.eventfahrplan.database.repositories.RealSessionsDatabaseRepository.querySessionsOrderedByDateUtc (RealSessionsDatabaseRepository.kt:243)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.readSessionsOrderedByDateUtc (AppRepository.kt:932)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.loadSessionsForDayIndex (AppRepository.kt:770)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.loadSessionsForAllDays (AppRepository.kt:759)
  at nerd.tuxmobil.fahrplan.congress.repositories.AppRepository.loadSessionsForAllDays (AppRepository.kt:697)
  at nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel.onParsingDone (MainViewModel.kt:151)
  at nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel.toUiState (MainViewModel.kt:102)
  at nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel.access$toUiState (MainViewModel.kt:39)
  at nerd.tuxmobil.fahrplan.congress.schedule.MainViewModel$observeLoadScheduleState$1$1.invokeSuspend (MainViewModel.kt:79)
  ...
```

# Successfully tested
with `ccc39c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)