### PR TITLE
Random housekeeping (alternative schedule URL, opt-in cleanup, preview rendering).

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopBar.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopBar.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.sp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
@@ -52,12 +52,14 @@ fun TopBar(
     )
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun TopBarPreview() {
-    TopBar(
-        title = "TopBar Title",
-        onBack = {},
-        actions = {},
-    )
+    EventFahrplanTheme {
+        TopBar(
+            title = "TopBar Title",
+            onBack = {},
+            actions = {},
+        )
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/chips/FilterChip.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/chips/FilterChip.kt
@@ -1,6 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.designsystem.chips
 
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.FilterChipDefaults.filterChipBorder
 import androidx.compose.material3.FilterChipDefaults.filterChipColors
@@ -8,6 +10,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import androidx.compose.material3.FilterChip as Material3FilterChip
 
@@ -51,4 +55,17 @@ fun FilterChip(
         },
     )
 
+}
+
+@PreviewLightDark
+@Composable
+private fun FilterChipPreview() {
+    EventFahrplanTheme {
+        FilterChip(
+            selected = true,
+            onClick = {},
+            selectedIcon = Icons.Filled.Done,
+            label = { Text("Lorem ipsum") },
+        )
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderDayDate.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
@@ -36,8 +36,10 @@ fun HeaderDayDate(text: String, contentDescription: String) {
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun HeaderDayDatePreview() {
-    HeaderDayDate("Day 1 - 31.02.2023", "")
+    EventFahrplanTheme {
+        HeaderDayDate("Day 1 - 31.02.2023", "")
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderSessionList.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/headers/HeaderSessionList.kt
@@ -5,11 +5,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 
 @Composable
 fun HeaderSessionList(text: String) {
@@ -21,8 +22,10 @@ fun HeaderSessionList(text: String) {
     )
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun HeaderSessionListScheduleChangesPreview() {
-    HeaderSessionList(stringResource(R.string.schedule_changes))
+    EventFahrplanTheme {
+        HeaderSessionList(stringResource(R.string.schedule_changes))
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/modifiers/WithoutRipple.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/modifiers/WithoutRipple.kt
@@ -1,11 +1,9 @@
 package nerd.tuxmobil.fahrplan.congress.designsystem.modifiers
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WithoutRipple(
     content: @Composable () -> Unit,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
@@ -14,11 +14,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.extensions.toTextUnit
 
 @Composable
@@ -56,12 +57,14 @@ fun NoData(
     }
 }
 
-@Preview
+@PreviewLightDark
 @Composable
 private fun NoDataNoSchedulePreview() {
-    NoData(
-        emptyContent = R.drawable.no_schedule,
-        title = stringResource(R.string.schedule_no_schedule_data_title),
-        subtitle = stringResource(R.string.schedule_no_schedule_data_subtitle),
-    )
+    EventFahrplanTheme {
+        NoData(
+            emptyContent = R.drawable.no_schedule,
+            title = stringResource(R.string.schedule_no_schedule_data_title),
+            subtitle = stringResource(R.string.schedule_no_schedule_data_subtitle),
+        )
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/ScheduleUrlDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/ScheduleUrlDialog.kt
@@ -9,11 +9,15 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.PreferenceTextInputDialog
+import nerd.tuxmobil.fahrplan.congress.utils.ScheduleFileFormat
+import nerd.tuxmobil.fahrplan.congress.utils.ScheduleFileFormat.SCHEDULE_V1_JSON
+import nerd.tuxmobil.fahrplan.congress.utils.ScheduleFileFormat.SCHEDULE_V1_XML
 import nerd.tuxmobil.fahrplan.congress.utils.UrlValidator
 
 @Composable
 internal fun ScheduleUrlDialog(
     currentValue: String,
+    scheduleFileFormat: ScheduleFileFormat,
     onValueChanged: (String) -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -26,10 +30,14 @@ internal fun ScheduleUrlDialog(
         )
     }
 
+    val placeholder = when (scheduleFileFormat) {
+        SCHEDULE_V1_JSON -> R.string.preference_hint_alternative_schedule_json_url
+        SCHEDULE_V1_XML -> R.string.preference_hint_alternative_schedule_xml_url
+    }
     PreferenceTextInputDialog(
         title = stringResource(R.string.preference_title_alternative_schedule_url),
         value = currentValue,
-        placeholder = stringResource(R.string.preference_hint_alternative_schedule_url),
+        placeholder = stringResource(placeholder),
         validator = urlValidator,
         onValueChanged = onValueChanged,
         onDismiss = onDismiss,
@@ -41,6 +49,7 @@ internal fun ScheduleUrlDialog(
 internal fun ScheduleUrlDialogPreview() {
     EventFahrplanTheme {
         ScheduleUrlDialog(
+            scheduleFileFormat = SCHEDULE_V1_XML,
             currentValue = "",
             onValueChanged = {},
             onDismiss = {},

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -21,6 +22,7 @@ import androidx.navigation.compose.rememberNavController
 import info.metadude.android.eventfahrplan.commons.flow.observe
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.AlarmTimePickerDialog
+import nerd.tuxmobil.fahrplan.congress.commons.BuildConfigProvider
 import nerd.tuxmobil.fahrplan.congress.schedulestatistic.ScheduleStatisticActivity
 import nerd.tuxmobil.fahrplan.congress.settings.AlarmToneResult.AlarmToneUri
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.LaunchNotificationSettingsScreen
@@ -89,8 +91,10 @@ internal fun SettingsScreen(
             activityClass = ScheduleStatisticActivity::class
         }
         dialog(route = AlternativeScheduleUrl.route) {
+            val scheduleFileFormat = remember { BuildConfigProvider().scheduleFileFormat }
             ScheduleUrlDialog(
                 currentValue = state.settings.alternativeScheduleUrl,
+                scheduleFileFormat = scheduleFileFormat,
                 onValueChanged = { viewModel.onViewEvent(SetAlternativeScheduleUrl(it)) },
                 onDismiss = { navController.popBackStack() },
             )

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -71,9 +71,8 @@
     <string name="preference_summary_show_on_lockscreen_enabled">Allows interacting with the app even when the device is locked.</string>
 
     <!-- Alternative schedule URL -->
-    <string name="preference_hint_alternative_schedule_url" translatable="false">
-        https://yourhost/schedule.xml
-    </string>
+    <string name="preference_hint_alternative_schedule_json_url" translatable="false">https://yourhost/schedule.json</string>
+    <string name="preference_hint_alternative_schedule_xml_url" translatable="false">https://yourhost/schedule.xml</string>
     <string name="preference_title_alternative_schedule_url">Configure alternative schedule URL</string>
     <string name="preference_summary_alternative_schedule_url">Enter a backup URL if the preconfigured server cannot be reached.</string>
     <string name="preference_url_type_friendly_name_alternative_schedule">alternative schedule</string>


### PR DESCRIPTION
# Description
+ Fix misleading hint for alternative schedule URL when requiring JSON.
+ Remove unneeded opt-in.
+ Improve preview rendering.

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/889