### PR TITLE
Revise layout and interaction of schedule changes screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
@@ -4,13 +4,13 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.applyEdgeToEdgeInsets
-import nerd.tuxmobil.fahrplan.congress.extensions.applyToolbar
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
 class ChangeListActivity : BaseActivity(R.layout.activity_generic), OnSessionListClick {
@@ -26,10 +26,14 @@ class ChangeListActivity : BaseActivity(R.layout.activity_generic), OnSessionLis
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
-        applyToolbar(toolbar) {
-            setDisplayHomeAsUpEnabled(true)
+
+        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
+            fitsSystemWindows = false
+            visibility = View.GONE
         }
+
+        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
+        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
 
         val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
         rootLayout.applyEdgeToEdgeInsets()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListFragment.kt
@@ -20,6 +20,8 @@ import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
+import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
+import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper.navigateUp
 
 /**
  * A fragment representing a list of Items.
@@ -66,6 +68,7 @@ class ChangeListFragment : Fragment() {
                 EventFahrplanTheme {
                     SessionChangesScreen(
                         showInSidePane = sidePane,
+                        onBack = ::navigateBack,
                         onNavigateToSession = ::navigateToSession,
                     )
                 }
@@ -77,6 +80,14 @@ class ChangeListFragment : Fragment() {
 
     private fun navigateToSession(sessionId: String) {
         onSessionListClickListener?.onSessionListClick(sessionId)
+    }
+
+    private fun navigateBack() {
+        val activity = requireActivity()
+        when (val listener = activity as? OnSidePaneCloseListener) {
+            null -> activity.navigateUp()
+            else -> listener.onSidePaneClose(FRAGMENT_TAG)
+        }
     }
 
     @MainThread

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
@@ -8,10 +8,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides.Companion.Bottom
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -21,6 +24,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextDecoration
@@ -40,6 +44,7 @@ import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeState.Success
 import nerd.tuxmobil.fahrplan.congress.changes.SessionChangeViewEvent.OnSessionChangeItemClick
 import nerd.tuxmobil.fahrplan.congress.commons.DaySeparatorProperty
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
+import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
@@ -48,6 +53,8 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderSessionList
 import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconVideoRecording
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.Loading
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.NoData
+import nerd.tuxmobil.fahrplan.congress.designsystem.templates.NavigationSection
+import nerd.tuxmobil.fahrplan.congress.designsystem.templates.NavigationSectionWithContent
 import nerd.tuxmobil.fahrplan.congress.designsystem.templates.Scaffold
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextHeadlineContent
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextSupportingContent
@@ -58,20 +65,55 @@ import nerd.tuxmobil.fahrplan.congress.extensions.safeContentHorizontalPadding
 internal fun SessionChangesContent(
     state: SessionChangeState,
     showInSidePane: Boolean,
+    onBack: () -> Unit,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
 ) {
-    Scaffold {
-        Box {
+    val navigationTitle = stringResource(R.string.schedule_changes)
+    Scaffold { _ ->
+        Box(
+            Modifier
+                .fillMaxSize()
+                .semantics { paneTitle = navigationTitle },
+        ) {
             when (state) {
-                Loading -> Loading()
+                Loading -> {
+                    Column(Modifier.fillMaxSize()) {
+                        NavigationSection(
+                            showInSidePane = showInSidePane,
+                            onNavClick = onBack,
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                        ) {
+                            Loading()
+                        }
+                    }
+                }
+
                 is Success -> {
                     val parameters = state.sessionChangeParameters
                     if (parameters.isEmpty()) {
-                        NoScheduleChanges()
+                        Column(Modifier.fillMaxSize()) {
+                            NavigationSection(
+                                showInSidePane = showInSidePane,
+                                onNavClick = onBack,
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxWidth(),
+                            ) {
+                                NoScheduleChanges()
+                            }
+                        }
                     } else {
                         SessionChangesList(
                             parameters = parameters,
                             showInSidePane = showInSidePane,
+                            navigationTitle = navigationTitle,
+                            onBack = onBack,
                             onViewEvent = onViewEvent,
                         )
                     }
@@ -94,16 +136,21 @@ private fun NoScheduleChanges() {
 private fun SessionChangesList(
     parameters: List<SessionChangeParameter>,
     showInSidePane: Boolean,
+    navigationTitle: String,
+    onBack: () -> Unit,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
 ) {
     LazyColumn(
+        modifier = Modifier.fillMaxSize(),
         state = rememberLazyListState(),
-        contentPadding = WindowInsets.navigationBars.only(Bottom).asPaddingValues(),
+        contentPadding = WindowInsets.navigationBars.union(WindowInsets.ime).only(Bottom).asPaddingValues(),
     ) {
-        if (showInSidePane) {
-            item {
-                HeaderSessionList(stringResource(R.string.schedule_changes))
-            }
+        item {
+            NavigationSection(
+                showInSidePane = showInSidePane,
+                navigationTitle = navigationTitle,
+                onNavClick = onBack,
+            )
         }
         itemsIndexed(parameters) { index, parameter ->
             when (parameter) {
@@ -125,12 +172,37 @@ private fun SessionChangesList(
                     )
                     val next = parameters.getOrNull(index + 1)
                     if (index < parameters.size - 1 && next is SessionChange) {
-                        DividerHorizontal(Modifier.padding(horizontal = 12.dp))
+                        DividerHorizontal()
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun NavigationSection(
+    showInSidePane: Boolean,
+    navigationTitle: String,
+    onNavClick: () -> Unit,
+) {
+    NavigationSectionWithContent(
+        showInSidePane = showInSidePane,
+        contentLeftOfCloseButton = {
+            HeaderSessionList(
+                modifier = Modifier.widthIn(max = maxWidth),
+                text = navigationTitle,
+                includeDefaultPadding = false,
+            )
+        },
+        contentRightOfBackButton = {
+            HeaderSessionList(
+                text = navigationTitle,
+                includeDefaultPadding = false,
+            )
+        },
+        onNavClick = onNavClick,
+    )
 }
 
 @Composable
@@ -141,7 +213,8 @@ fun SessionChangeItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(ScreenMetrics.screenContentPaddingValues())
+            .padding(vertical = 8.dp)
     ) {
         Row(
             Modifier.fillMaxWidth(),
@@ -340,6 +413,7 @@ private fun SessionChangesContentPreview() {
                 )
             ),
             showInSidePane = true,
+            onBack = {},
             onViewEvent = {},
         )
     }
@@ -352,6 +426,7 @@ private fun SessionChangesContentEmptyPreview() {
         SessionChangesContent(
             Success(emptyList()),
             showInSidePane = false,
+            onBack = {},
             onViewEvent = {},
         )
     }
@@ -364,6 +439,7 @@ private fun SessionChangesContentLoadingPreview() {
         SessionChangesContent(
             state = Loading,
             showInSidePane = false,
+            onBack = {},
             onViewEvent = {},
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangesScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangesScreen.kt
@@ -20,6 +20,7 @@ import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
 @Composable
 internal fun SessionChangesScreen(
     showInSidePane: Boolean,
+    onBack: () -> Unit,
     onNavigateToSession: (String) -> Unit,
 ) {
     val context = LocalContext.current
@@ -52,6 +53,7 @@ internal fun SessionChangesScreen(
     SessionChangesContent(
         state = state,
         showInSidePane = showInSidePane,
+        onBack = onBack,
         onViewEvent = viewModel::onViewEvent,
     )
 


### PR DESCRIPTION
# Description
+ Move back resp. close navigation from the former top toolbar to the top of the scrollable screen content.
+ Also show the new navigation section on loading and empty states for a consistent screen structure.
+ Expand screen content to be scrollable edge-to-edge (new: below the top system bar on phones).
+ Align schedule change items and section headers with the spacing used by the session list design.
+ Replace the former toolbar-based back handling with a Compose-based navigation callback supporting side pane closing as well.
+ Respect navigation bar and IME insets for the scrollable content at the bottom of the screen.

_Changes sessions in the screenshots are artificially added to capture some content._

# Phone screenshots
| Before | After |
|-----------|---------|
| <img width="270" height="600" alt="phone-changes-light-before" src="https://github.com/user-attachments/assets/ac3818eb-d88c-4c27-99c2-913cb8875a61" /> | <img width="270" height="600" alt="phone-changes-light-after" src="https://github.com/user-attachments/assets/579116a7-7894-44d0-a907-2466b35326f4" /> |
| <img width="270" height="600" alt="phone-changes-dark-before" src="https://github.com/user-attachments/assets/6bd01b51-8823-498c-aa8e-7372f226521b" /> | <img width="270" height="600" alt="phone-changes-dark-after" src="https://github.com/user-attachments/assets/10b4af97-aa0d-4f25-8f1d-ba3fefb6bdf1" /> |
| <img width="600" height="270" alt="phone-changes-light-landscape-before" src="https://github.com/user-attachments/assets/2b6d67f8-f515-4ce0-8147-214d2466b8c5" /> | <img width="600" height="270" alt="phone-changes-light-landscape-after" src="https://github.com/user-attachments/assets/db39f200-ec0c-4f23-98f4-9f40a1376092" /> |

# Tablet screenshots
| Before | After |
|-----------|---------|
| <img width="600" height="375" alt="tablet-changes-dark-landscape-before" src="https://github.com/user-attachments/assets/dffcf143-0896-4697-a029-bec027465815" /> | <img width="600" height="375" alt="tablet-changes-dark-landscape-after" src="https://github.com/user-attachments/assets/42c7a481-a3a0-48a8-b355-5d6ed7ee606e" /> |
| <img width="600" height="375" alt="tablet-changes-light-landscape-before" src="https://github.com/user-attachments/assets/250eab3c-9423-4d3f-9ca4-ccb1793a5417" /> | <img width="600" height="375" alt="tablet-changes-light-landscape-after" src="https://github.com/user-attachments/assets/950fb606-f999-4faa-84de-f589e85e111b" /> |

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---
Relates #569, #894, #895