### PR TITLE
Revise layout and interaction of alarms screen.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
@@ -4,13 +4,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.base.OnSessionItemClickListener
 import nerd.tuxmobil.fahrplan.congress.details.SessionDetailsActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.applyEdgeToEdgeInsets
-import nerd.tuxmobil.fahrplan.congress.extensions.applyToolbar
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 
 class AlarmsActivity : BaseActivity(R.layout.activity_generic), OnSessionItemClickListener {
@@ -25,10 +25,14 @@ class AlarmsActivity : BaseActivity(R.layout.activity_generic), OnSessionItemCli
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val toolbar = requireViewByIdCompat<Toolbar>(R.id.toolbar)
-        applyToolbar(toolbar) {
-            setDisplayHomeAsUpEnabled(true)
+
+        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
+            fitsSystemWindows = false
+            visibility = View.GONE
         }
+
+        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
+        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
 
         val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
         rootLayout.applyEdgeToEdgeInsets()

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsActivity.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.base.OnSessionItemClickListener
@@ -25,17 +23,7 @@ class AlarmsActivity : BaseActivity(R.layout.activity_generic), OnSessionItemCli
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
-            fitsSystemWindows = false
-            visibility = View.GONE
-        }
-
-        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
-        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
-
-        val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
-        rootLayout.applyEdgeToEdgeInsets()
+        requireViewByIdCompat<View>(R.id.root_layout).applyEdgeToEdgeInsets()
 
         if (savedInstanceState == null) {
             addFragment(R.id.fragment_container_view, AlarmsFragment(), AlarmsFragment.FRAGMENT_TAG)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -2,25 +2,34 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides.Companion.Bottom
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment.Companion.BottomCenter
+import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
@@ -29,14 +38,19 @@ import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsState.Success
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsViewEvent.OnDeleteItemClick
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsViewEvent.OnItemClick
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
+import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
+import nerd.tuxmobil.fahrplan.congress.commons.ToolbarMetrics
+import nerd.tuxmobil.fahrplan.congress.commons.useVerticalFloatingToolbar
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderSessionList
 import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconBoxed
-import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDecorative
+import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDelete
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.Loading
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.NoData
 import nerd.tuxmobil.fahrplan.congress.designsystem.templates.ListItem
+import nerd.tuxmobil.fahrplan.congress.designsystem.templates.NavigationSection
+import nerd.tuxmobil.fahrplan.congress.designsystem.templates.NavigationSectionWithContent
 import nerd.tuxmobil.fahrplan.congress.designsystem.templates.Scaffold
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextHeadlineContent
@@ -44,25 +58,62 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextOverline
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.TextSupportingContent
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.extensions.safeContentHorizontalPadding
+import nerd.tuxmobil.fahrplan.congress.utils.compose.ScrollPosition
+import nerd.tuxmobil.fahrplan.congress.utils.compose.rememberAutoHideOnScrollDown
 
 @Composable
 internal fun AlarmsContent(
     state: AlarmsState,
     showInSidePane: Boolean,
+    onBack: () -> Unit,
     onViewEvent: (AlarmsViewEvent) -> Unit,
 ) {
-    Scaffold {
-        Box {
+    val title = stringResource(R.string.reminders)
+    Scaffold { _ ->
+        Box(
+            Modifier
+                .fillMaxSize()
+                .semantics { paneTitle = title },
+        ) {
             when (state) {
-                Loading -> Loading()
+                Loading -> {
+                    Column(Modifier.fillMaxSize()) {
+                        NavigationSection(
+                            showInSidePane = showInSidePane,
+                            onNavClick = onBack,
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                        ) {
+                            Loading()
+                        }
+                    }
+                }
+
                 is Success -> {
                     val parameters = state.sessionAlarmParameters
                     if (parameters.isEmpty()) {
-                        NoAlarms()
+                        Column(Modifier.fillMaxSize()) {
+                            NavigationSection(
+                                showInSidePane = showInSidePane,
+                                onNavClick = onBack,
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxWidth(),
+                            ) {
+                                NoAlarms()
+                            }
+                        }
                     } else {
                         SessionAlarmsList(
                             parameters = parameters,
                             showInSidePane = showInSidePane,
+                            title = title,
+                            onBack = onBack,
                             onViewEvent = onViewEvent,
                         )
                     }
@@ -85,75 +136,130 @@ private fun NoAlarms() {
 private fun SessionAlarmsList(
     parameters: List<SessionAlarmParameter>,
     showInSidePane: Boolean,
+    title: String,
+    onBack: () -> Unit,
     onViewEvent: (AlarmsViewEvent) -> Unit,
 ) {
-    LazyColumn(
-        state = rememberLazyListState(),
-        contentPadding = WindowInsets.navigationBars.only(Bottom).asPaddingValues(),
-    ) {
-        if (showInSidePane) {
+    val useVerticalToolbar = useVerticalFloatingToolbar(showInSidePane)
+    val listState = rememberLazyListState()
+    val showToolbar by rememberAutoHideOnScrollDown(
+        source = ScrollPosition.LazyList(listState),
+        enabled = !useVerticalToolbar,
+    )
+
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = WindowInsets.navigationBars.union(WindowInsets.ime).only(Bottom).asPaddingValues(),
+        ) {
             item {
-                HeaderSessionList(stringResource(R.string.reminders))
+                NavigationSection(
+                    showInSidePane = showInSidePane,
+                    title = title,
+                    onNavClick = onBack,
+                )
+            }
+            itemsIndexed(parameters) { index, item ->
+                SessionAlarmItem(
+                    useVerticalToolbar = useVerticalToolbar,
+                    parameter = item,
+                    onViewEvent = onViewEvent,
+                )
+                if (index < parameters.size - 1) {
+                    DividerHorizontal()
+                }
             }
         }
-        itemsIndexed(parameters) { index, item ->
-            SessionAlarmItem(
-                modifier = Modifier.safeContentHorizontalPadding(),
-                parameter = item,
-                onViewEvent = onViewEvent,
-            )
-            if (index < parameters.size - 1) {
-                DividerHorizontal(Modifier.padding(horizontal = 12.dp))
-            }
-        }
+        AlarmsToolbar(
+            modifier = Modifier
+                .align(if (useVerticalToolbar) CenterEnd else BottomCenter),
+            visible = showToolbar,
+            useVerticalToolbar = useVerticalToolbar,
+            onViewEvent = onViewEvent,
+        )
     }
 }
 
 @Composable
+private fun NavigationSection(
+    showInSidePane: Boolean,
+    title: String,
+    onNavClick: () -> Unit,
+) {
+    NavigationSectionWithContent(
+        showInSidePane = showInSidePane,
+        contentLeftOfCloseButton = {
+            HeaderSessionList(
+                modifier = Modifier.widthIn(max = maxWidth),
+                text = title,
+                includeDefaultPadding = false,
+            )
+        },
+        contentRightOfBackButton = {
+            HeaderSessionList(
+                text = title,
+                includeDefaultPadding = false,
+            )
+        },
+        onNavClick = onNavClick,
+    )
+}
+
+@Composable
 private fun SessionAlarmItem(
-    modifier: Modifier = Modifier,
+    useVerticalToolbar: Boolean,
     parameter: SessionAlarmParameter,
     onViewEvent: (AlarmsViewEvent) -> Unit,
 ) {
-    ListItem(
-        modifier = modifier
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
             .clickable(
                 onClickLabel = stringResource(R.string.alarms_item_on_click_label),
-                onClick = { onViewEvent(OnItemClick(parameter.sessionId)) }
-            ),
-        leadingContent = {
-            AlarmIcon(parameter.alarmOffsetInMin, parameter.alarmOffsetContentDescription)
-        },
-        overlineContent = {
-            TextOverline(
-                modifier = Modifier.semantics {
-                    contentDescription = parameter.firesAtContentDescription
-                },
-                text = parameter.firesAtText,
+                onClick = { onViewEvent(OnItemClick(parameter.sessionId)) },
             )
-        },
-        headlineContent = {
-            TextHeadlineContent(
-                modifier = Modifier.semantics {
-                    contentDescription = parameter.titleContentDescription
-                },
-                text = parameter.title,
-            )
-        },
-        supportingContent = {
-            if (parameter.subtitle.isNotEmpty()) {
-                TextSupportingContent(
+            .safeContentHorizontalPadding()
+            .padding(ToolbarMetrics.searchResultItemPaddingValues(useVerticalToolbar)),
+    ) {
+        ListItem(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(ScreenMetrics.listItemPaddingValues()),
+            leadingContent = {
+                AlarmIcon(parameter.alarmOffsetInMin, parameter.alarmOffsetContentDescription)
+            },
+            overlineContent = {
+                TextOverline(
                     modifier = Modifier.semantics {
-                        contentDescription = parameter.subtitleContentDescription
+                        contentDescription = parameter.firesAtContentDescription
                     },
-                    text = parameter.subtitle,
+                    text = parameter.firesAtText,
                 )
-            }
-        },
-        trailingContent = {
-            DeleteIcon(parameter, onViewEvent)
-        },
-    )
+            },
+            headlineContent = {
+                TextHeadlineContent(
+                    modifier = Modifier.semantics {
+                        contentDescription = parameter.titleContentDescription
+                    },
+                    text = parameter.title,
+                )
+            },
+            supportingContent = {
+                if (parameter.subtitle.isNotEmpty()) {
+                    TextSupportingContent(
+                        modifier = Modifier.semantics {
+                            contentDescription = parameter.subtitleContentDescription
+                        },
+                        text = parameter.subtitle,
+                    )
+                }
+            },
+            trailingContent = {
+                DeleteIcon(parameter, onViewEvent)
+            },
+        )
+    }
 }
 
 @Composable
@@ -180,6 +286,7 @@ private fun DeleteIcon(
     onViewEvent: (AlarmsViewEvent) -> Unit,
 ) {
     val label = stringResource(R.string.alarms_item_delete_icon_on_click_label)
+    val deleteContentDescription = stringResource(R.string.menu_item_title_delete_alarm)
     ButtonIcon(
         onClick = {
             onViewEvent(
@@ -192,6 +299,7 @@ private fun DeleteIcon(
             )
         },
         modifier = Modifier.semantics {
+            contentDescription = deleteContentDescription
             onClick(label) {
                 onViewEvent(
                     OnDeleteItemClick(
@@ -205,9 +313,7 @@ private fun DeleteIcon(
             }
         }
     ) {
-        IconDecorative(
-            icon = R.drawable.ic_delete,
-        )
+        IconDelete()
     }
 }
 
@@ -260,6 +366,7 @@ private fun AlarmsContentPreview() {
                 ),
             ),
             showInSidePane = true,
+            onBack = {},
             onViewEvent = {},
         )
     }
@@ -274,6 +381,7 @@ private fun AlarmsContentEmptyPreview() {
                 emptyList(),
             ),
             showInSidePane = false,
+            onBack = {},
             onViewEvent = {},
         )
     }
@@ -286,6 +394,7 @@ private fun AlarmsContentLoadingPreview() {
         AlarmsContent(
             state = Loading,
             showInSidePane = false,
+            onBack = {},
             onViewEvent = {},
         )
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsFragment.kt
@@ -3,29 +3,22 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
-import android.view.MenuItem
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
-import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.fragment.compose.content
-import androidx.lifecycle.Lifecycle.State.RESUMED
-import info.metadude.android.eventfahrplan.commons.flow.observe
-import nerd.tuxmobil.fahrplan.congress.R
-import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsViewEvent.OnDeleteAllWithConfirmationClick
 import nerd.tuxmobil.fahrplan.congress.base.OnSessionItemClickListener
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.extensions.replaceFragment
 import nerd.tuxmobil.fahrplan.congress.extensions.withArguments
+import nerd.tuxmobil.fahrplan.congress.sidepane.OnSidePaneCloseListener
+import nerd.tuxmobil.fahrplan.congress.utils.ActivityHelper.navigateUp
 
-class AlarmsFragment : Fragment(), MenuProvider {
+class AlarmsFragment : Fragment() {
 
     companion object {
         const val FRAGMENT_TAG = "ALARMS_FRAGMENT_TAG"
@@ -47,7 +40,6 @@ class AlarmsFragment : Fragment(), MenuProvider {
 
     private val viewModel: AlarmsViewModel by viewModels { AlarmsViewModelFactory(requireContext()) }
     private var sidePane = false
-    private var hasAlarms = false
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -59,7 +51,6 @@ class AlarmsFragment : Fragment(), MenuProvider {
         arguments?.let {
             sidePane = it.getBoolean(BundleKeys.SIDEPANE)
         }
-        requireActivity().addMenuProvider(this, this, RESUMED)
     }
 
     override fun onCreateView(
@@ -71,44 +62,22 @@ class AlarmsFragment : Fragment(), MenuProvider {
             AlarmsScreen(
                 viewModel = viewModel,
                 showInSidePane = sidePane,
+                onBack = ::navigateBack,
                 onNavigateToSession = ::navigateToSession,
             )
         }
     }.also { it.isClickable = true }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        observeViewModel()
-    }
-
-    private fun observeViewModel() {
-        viewModel.hasAlarms.observe(this) {
-            hasAlarms = it
-            requireActivity().invalidateOptionsMenu()
+    private fun navigateBack() {
+        val activity = requireActivity()
+        when (val listener = activity as? OnSidePaneCloseListener) {
+            null -> activity.navigateUp()
+            else -> listener.onSidePaneClose(FRAGMENT_TAG)
         }
     }
 
     private fun navigateToSession(sessionId: String) {
         (requireContext() as OnSessionItemClickListener).onSessionItemClick(sessionId)
-    }
-
-    override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-        menu.clear()
-        menuInflater.inflate(R.menu.alarms_menu, menu)
-        val item = menu.findItem(R.id.menu_item_delete_all_alarms)
-        if (item != null && !hasAlarms) {
-            item.isVisible = false
-        }
-    }
-
-    override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-        when (menuItem.itemId) {
-            R.id.menu_item_delete_all_alarms -> {
-                viewModel.onViewEvent(OnDeleteAllWithConfirmationClick)
-                return true
-            }
-        }
-        return false
     }
 
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsScreen.kt
@@ -23,6 +23,7 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.dialogs.ConfirmationDialog
 internal fun AlarmsScreen(
     viewModel: AlarmsViewModel,
     showInSidePane: Boolean,
+    onBack: () -> Unit,
     onNavigateToSession: (String) -> Unit,
 ) {
     val navController = rememberNavController()
@@ -47,6 +48,7 @@ internal fun AlarmsScreen(
             AlarmsContent(
                 state = state,
                 showInSidePane = showInSidePane,
+                onBack = onBack,
                 onViewEvent = viewModel::onViewEvent,
             )
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsToolbar.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsToolbar.kt
@@ -1,0 +1,57 @@
+package nerd.tuxmobil.fahrplan.congress.alarms
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsViewEvent.OnDeleteAllWithConfirmationClick
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.GenericFloatingToolbar
+import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDeleteAll
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+
+@Composable
+internal fun AlarmsToolbar(
+    visible: Boolean,
+    useVerticalToolbar: Boolean,
+    modifier: Modifier = Modifier,
+    onViewEvent: (AlarmsViewEvent) -> Unit,
+) {
+    val deleteAllLabel = stringResource(R.string.menu_item_title_delete_all)
+    GenericFloatingToolbar(
+        visible = visible,
+        useVerticalToolbar = useVerticalToolbar,
+        modifier = modifier,
+        toolbarContent = {
+            clickableItem(
+                onClick = { onViewEvent(OnDeleteAllWithConfirmationClick) },
+                enabled = true,
+                label = deleteAllLabel,
+                icon = { IconDeleteAll() },
+            )
+        },
+    )
+}
+
+@PreviewLightDark
+@Composable
+private fun AlarmsToolbarHorizontalPreview() {
+    AlarmsToolbar(useVerticalToolbar = false)
+}
+
+@PreviewLightDark
+@Composable
+private fun AlarmsToolbarVerticalPreview() {
+    AlarmsToolbar(useVerticalToolbar = true)
+}
+
+@Composable
+private fun AlarmsToolbar(useVerticalToolbar: Boolean) {
+    EventFahrplanTheme {
+        AlarmsToolbar(
+            visible = true,
+            useVerticalToolbar = useVerticalToolbar,
+            onViewEvent = {},
+        )
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModel.kt
@@ -7,9 +7,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsDestination.ConfirmDeleteAll
@@ -41,10 +39,6 @@ internal class AlarmsViewModel(
 
     private val mutableAlarmsState = MutableStateFlow<AlarmsState>(Loading)
     val alarmsState = mutableAlarmsState.asStateFlow()
-
-    val hasAlarms = alarmsState
-        .filterIsInstance<Success>()
-        .map { it.sessionAlarmParameters.isNotEmpty() }
 
     init {
         combine(repository.alarms, repository.sessions) { alarms, sessions ->

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/ChangeListActivity.kt
@@ -4,8 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
@@ -26,17 +24,7 @@ class ChangeListActivity : BaseActivity(R.layout.activity_generic), OnSessionLis
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
-            fitsSystemWindows = false
-            visibility = View.GONE
-        }
-
-        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
-        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
-
-        val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
-        rootLayout.applyEdgeToEdgeInsets()
+        requireViewByIdCompat<View>(R.id.root_layout).applyEdgeToEdgeInsets()
 
         if (savedInstanceState == null) {
             val fragment = ChangeListFragment.newInstance(sidePane = false)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/icons/IconActionable.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/icons/IconActionable.kt
@@ -16,15 +16,15 @@ import androidx.compose.material3.Icon as Material3Icon
 @Composable
 fun IconActionable(
     @DrawableRes icon: Int,
-    @StringRes contentDescription: Int,
     modifier: Modifier = Modifier,
+    @StringRes contentDescription: Int? = null,
     tint: Color = LocalContentColor.current,
 ) {
     Material3Icon(
         modifier = modifier,
         tint = tint,
         painter = painterResource(icon),
-        contentDescription = stringResource(contentDescription),
+        contentDescription = if (contentDescription == null || contentDescription == 0) null else stringResource(contentDescription),
     )
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/icons/IconDelete.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/icons/IconDelete.kt
@@ -8,11 +8,10 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 
 @Composable
-fun IconDelete() {
+fun IconDelete(modifier: Modifier = Modifier) {
     IconActionable(
-        modifier = Modifier.size(EventFahrplanTheme.dimensions.iconSize),
+        modifier = modifier.size(EventFahrplanTheme.dimensions.iconSize),
         icon = R.drawable.ic_delete,
-        contentDescription = R.string.menu_item_title_delete_favorite,
     )
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsActivity.kt
@@ -4,8 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
 import nerd.tuxmobil.fahrplan.congress.extensions.applyEdgeToEdgeInsets
@@ -38,16 +36,7 @@ class SessionDetailsActivity : BaseActivity(R.layout.activity_generic) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
-            fitsSystemWindows = false
-            visibility = View.GONE
-        }
-
-        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
-        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
-
-        val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
-        rootLayout.applyEdgeToEdgeInsets()
+        requireViewByIdCompat<View>(R.id.root_layout).applyEdgeToEdgeInsets()
 
         if (savedInstanceState == null) {
             val fragment = SessionDetailsFragment.newInstance(sidePane = false)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListActivity.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.google.android.material.appbar.AppBarLayout
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.base.AbstractListFragment.OnSessionListClick
 import nerd.tuxmobil.fahrplan.congress.base.BaseActivity
@@ -25,17 +23,7 @@ class StarredListActivity : BaseActivity(R.layout.activity_generic), OnSessionLi
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        requireViewByIdCompat<AppBarLayout>(R.id.app_bar_layout).apply {
-            fitsSystemWindows = false
-            visibility = View.GONE
-        }
-
-        val fragmentContainer = requireViewByIdCompat<View>(R.id.fragment_container_view)
-        (fragmentContainer.layoutParams as CoordinatorLayout.LayoutParams).behavior = null
-
-        val rootLayout = requireViewByIdCompat<View>(R.id.root_layout)
-        rootLayout.applyEdgeToEdgeInsets()
+        requireViewByIdCompat<View>(R.id.root_layout).applyEdgeToEdgeInsets()
 
         if (savedInstanceState == null) {
             addFragment(R.id.fragment_container_view, StarredListFragment(), StarredListFragment.FRAGMENT_TAG)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListToolbar.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListToolbar.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
@@ -52,6 +54,7 @@ internal fun StarredListToolbar(
     val deleteSelectedLabel = stringResource(R.string.menu_item_title_delete_favorite)
     val deleteAllLabel = stringResource(R.string.menu_item_title_delete_all)
     val shareLabel = stringResource(R.string.menu_item_title_share_favorites)
+    val deleteSelectedContentDescription = stringResource(R.string.menu_item_title_delete_favorite)
 
     GenericFloatingToolbar(
         visible = visible,
@@ -62,7 +65,13 @@ internal fun StarredListToolbar(
         toolbarContent = {
             if (multiselect) {
                 clickableItem(
-                    icon = { IconDelete() },
+                    icon = {
+                        IconDelete(
+                            Modifier.semantics {
+                                contentDescription = deleteSelectedContentDescription
+                            }
+                        )
+                    },
                     enabled = true,
                     label = deleteSelectedLabel,
                     onClick = { onViewEvent(OnDeleteSelectedClick) },

--- a/app/src/main/res/layout/activity_generic.xml
+++ b/app/src/main/res/layout/activity_generic.xml
@@ -1,26 +1,11 @@
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/app_bar_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
-
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
-    </com.google.android.material.appbar.AppBarLayout>
-
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior" />
+        android:layout_height="match_parent" />
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</FrameLayout>

--- a/app/src/main/res/menu/alarms_menu.xml
+++ b/app/src/main/res/menu/alarms_menu.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item
-        android:id="@+id/menu_item_delete_all_alarms"
-        android:icon="@drawable/ic_delete"
-        android:title="@string/menu_item_title_delete_all"
-        app:showAsAction="ifRoom" />
-</menu>

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -86,64 +86,6 @@ class AlarmsViewModelTest {
     }
 
     @Nested
-    inner class HasAlarms {
-
-        @Test
-        fun `hasAlarms never emits when no alarms nor sessions are present`() = runTest {
-            val repository = createRepository(
-                alarms = emptyList(),
-                sessions = emptyFlow(),
-            )
-            val viewModel = createViewModel(repository)
-            viewModel.hasAlarms.test {
-                expectNoEvents()
-            }
-        }
-
-        @Test
-        fun `hasAlarms emits false when no alarms present`() = runTest {
-            val repository = createRepository(
-                alarms = emptyList(),
-                sessions = flowOf(emptyList()),
-            )
-            val viewModel = createViewModel(
-                repository = repository,
-                alarmsStateFactory = createAlarmsStateFactory(emptyList())
-            )
-            viewModel.hasAlarms.test {
-                assertThat(awaitItem()).isFalse()
-            }
-        }
-
-        @Test
-        fun `hasAlarms emits true when at least one alarm is present`() = runTest {
-            val repository = createRepository(
-                alarms = listOf(
-                    createAlarm(
-                        sessionId = "s0",
-                        alarmStartsAt = ALARM_STARTS_AT
-                    )
-                ),
-                sessions = flowOf(
-                    listOf(
-                        Session(
-                            sessionId = "s0",
-                            title = "Title",
-                            subtitle = "Subtitle",
-                            dateUTC = SESSION_STARTS_AT.toMilliseconds(),
-                        )
-                    )
-                ),
-            )
-            val viewModel = createViewModel(repository)
-            viewModel.hasAlarms.test {
-                assertThat(awaitItem()).isTrue()
-            }
-        }
-
-    }
-
-    @Nested
     inner class OnViewEvent {
 
         @Test


### PR DESCRIPTION
# Description
## Revise layout and interaction
+ Phones / tablet portrait: Move delete-all toolbar action to the bottom of the screen, comfortable to reach when using the device one-handed.
+ Tablets landscape: Move delete-all toolbar action to the right side of the screen, comfortable to reach when holding the device with two hands.
+ Present new delete-all toolbar as floatable element.
+ When shown as a horizontal toolbar then it shows/hides in respect to the scroll direction.
+ Move back resp. close navigation from the former top toolbar to the top of the scrollable screen content.
+ Also show the new navigation section on loading and empty states for a consistent screen structure.
+ Expand screen content to be scrollable edge-to-edge (new: below the top system bar on phones).
+ Align alarm list items with the spacing used by the session list design.
+ Replace the former fragment menu with a Compose-based toolbar while keeping per-item delete actions directly available in the list.

## Additional
+ Simplify `activity_generic` layout because the coordinator toolbar became unused.
+ Those activities always hid the app bar and cleared the fragment container’s `ScrollingViewBehavior`, so the `CoordinatorLayout` + `AppBar` + `Toolbar` added complexity without effect. Use a plain root + fragment container so the layout matches actual behavior and setup stays minimal.

# Phone screenshots
| Before | After |
|-----------|---------|
| <img width="270" height="600" alt="phone-alarms-light-before" src="https://github.com/user-attachments/assets/05857690-2151-4984-95aa-83f5d9fa30d0" /> | <img width="270" height="600" alt="phone-alarms-light-after" src="https://github.com/user-attachments/assets/60797112-15ae-4eef-bd0c-a6bcd741d376" /> |
| <img width="270" height="600" alt="phone-alarms-dark-before" src="https://github.com/user-attachments/assets/e1cee7a4-3dc0-4c7d-8f88-cef7f84dd66a" /> | <img width="270" height="600" alt="phone-alarms-dark-after" src="https://github.com/user-attachments/assets/62f8f66b-a5b7-4af9-8af5-d88477649754" /> |
| <img width="600" height="270" alt="phone-alarms-light-landscape-before" src="https://github.com/user-attachments/assets/4b6bb1ca-b0f8-465a-906e-00ac55430f88" /> | <img width="600" height="270" alt="phone-alarms-light-landscape-after" src="https://github.com/user-attachments/assets/46e65173-3516-48e4-a4c0-27ad63f3aeb7" /> |

# Tablet screenshots
| Before | After |
|-----------|---------|
| <img width="600" height="375" alt="tablet-alarms-dark-landscape-before" src="https://github.com/user-attachments/assets/edb1541f-0acb-4529-85df-319def0ef317" /> | <img width="600" height="375" alt="tablet-alarms-dark-landscape-after" src="https://github.com/user-attachments/assets/93d799ac-3450-4c44-859e-f633c63b6c0a" /> |
| <img width="600" height="375" alt="tablet-alarms-light-landscape-before" src="https://github.com/user-attachments/assets/b814d7cd-5b06-4804-9a06-efda4e2cae85" /> | <img width="600" height="375" alt="tablet-alarms-light-landscape-after" src="https://github.com/user-attachments/assets/552ce30f-8d2b-4e47-ae6f-9e757579bad3" /> |



# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

---
Relates #569, #894, #895, #896