### PR TITLE
Use compileSdk & targetSdk 36 (Android 16).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,6 @@
 
     <application
         android:name="nerd.tuxmobil.fahrplan.congress.MyApp"
-        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:localeConfig="@xml/locales_config"

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -10,9 +10,9 @@ object Config {
 
 object Android {
     const val buildToolsVersion = "36.0.0"
-    const val compileSdkVersion = 35
+    const val compileSdkVersion = 36
     const val minSdkVersion = 23
-    const val targetSdkVersion = 35
+    const val targetSdkVersion = 36
 }
 
 object Compose {


### PR DESCRIPTION
# Description
* `android:enableOnBackInvokedCallback` is `true` by default.
* Use `compileSdk` 36.
* Use `targetSdk` 36.

# Test scenarios
- Fresh install
- App update

# Preliminary work
- https://github.com/EventFahrplan/EventFahrplan/pull/898

# Successfully tested
with `ccc39c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/789

---
Resolves #893