### PR TITLE
Fix tooltip color for floating toolbar items.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
@@ -16,7 +16,6 @@ internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
     surface = colorResource(android.R.color.transparent), // used by ListItem background
     onSurface = colorResource(R.color.text_primary), // used by ListItem -> headlineContent
     onSurfaceVariant = colorResource(R.color.text_secondary), // used by SearchBarDefaults.InputField placeholder, ListItem -> overlineContent
-    inverseOnSurface = colorResource(R.color.session_item_text_on_highlight_background), // used by SessionCard
     surfaceContainer = colorResource(R.color.colorPrimaryDark), // used by DropdownMenu
     surfaceContainerHigh = colorResource(R.color.background_secondary), // used by AlertDialog background
 ).toColorScheme(
@@ -73,7 +72,6 @@ internal fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     surface = colorResource(android.R.color.transparent),
     onSurface = colorResource(R.color.text_primary_inverted),
     onSurfaceVariant = colorResource(R.color.text_secondary_inverted),
-    inverseOnSurface = colorResource(R.color.session_item_text_on_highlight_background),
     surfaceContainer = colorResource(R.color.colorPrimaryDark),
     surfaceContainerHigh = colorResource(R.color.background_secondary),
 ).toColorScheme(


### PR DESCRIPTION
# Description
+ Text color was unreadable on background color.
+ Session card text color is set via `FahrplanFragment#prepareRoomColumnData`, hence default values can be used for `inverseOnSurface`.

# Before
<img width="270" height="600" alt="20260608_221003" src="https://github.com/user-attachments/assets/66256002-d21c-4d9a-9eb4-ddc581663596" /> <img width="270" height="600" alt="20260608_220949" src="https://github.com/user-attachments/assets/e579e878-c246-4ae2-b946-be8a7536b98f" />


# After
<img width="270" height="600" alt="20260608_220850" src="https://github.com/user-attachments/assets/16ae6b9b-174a-4c24-9196-91fad0e241aa" /> <img width="270" height="600" alt="20260608_220916" src="https://github.com/user-attachments/assets/598a9772-623d-4964-bfb0-2798244a0300" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)