### PR TITLE
Fix scroll to current session timezone offset bug.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -62,7 +62,7 @@ internal class ScrollAmountCalculator(
                 for (session in roomData.sessions) {
                     if (session.startsAt.minuteOfDay <= time && session.endsAt.minuteOfDay > time) {
                         logging.d(LOG_TAG, session.title)
-                        val startTime = session.startTime.toWholeMinutes().toInt()
+                        val startTime = session.startsAt.minuteOfDay
                         logging.d(LOG_TAG, "$time $startTime/${session.duration.toWholeMinutes().toInt()}")
                         scrollAmount -= (time - startTime) / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight
                         time = startTime

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -55,6 +55,18 @@ class ScrollAmountCalculatorTest {
     }
 
     @Test
+    fun `calculateScrollAmount returns start of second session with timezone offset data`() {
+        val s1 = createFirstTimezoneOffsetSession()
+        val s2 = createSecondTimezoneOffsetSession()
+        val scrollAmount = calculateScrollAmount(
+                sessions = listOf(s1, s2),
+                nowMoment = s2.startsAt, // 10:00 UTC -> 816 UTC minutes
+                currentDayIndex = s1.dayIndex
+        )
+        assertThat(scrollAmount).isEqualTo(816)
+    }
+
+    @Test
     fun `calculateScrollAmount returns 0 if conference starts now`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
@@ -127,6 +139,28 @@ class ScrollAmountCalculatorTest {
         dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString(),
         dateUTC = moment.toMilliseconds(),
         startTime = Duration.ofMinutes(moment.minuteOfDay),
+        duration = Duration.ofMinutes(60),
+        roomName = "Main hall",
+    )
+
+    private fun createFirstTimezoneOffsetSession() = createTimezoneOffsetSession("first legacy",
+        Moment.ofEpochMilli(1582963200000L), // February 29, 2020 08:00:00 AM GMT
+        60 * 10, // simulating +02:00 timezone offset as in JSON/XML data
+    )
+
+    private fun createSecondTimezoneOffsetSession() = createTimezoneOffsetSession("second legacy",
+        Moment.ofEpochMilli(1582970400000L), // February 29, 2020 10:00:00 AM GMT
+        60 * 12, // simulating +02:00 timezone offset as in JSON/XML data
+    )
+
+    // In JSON/XML the "start" property value is independent of the UTC value in the "date" property.
+    // The "start" value comes in the local timezone of the event.
+    private fun createTimezoneOffsetSession(sessionId: String, moment: Moment, startTime: Int) = Session(
+        sessionId = sessionId,
+        dayIndex = 0,
+        dateText = moment.toZonedDateTime(ZoneOffset.UTC).toLocalDate().toString(),
+        dateUTC = moment.toMilliseconds(),
+        startTime = Duration.ofMinutes(startTime),
         duration = Duration.ofMinutes(60),
         roomName = "Main hall",
     )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -23,7 +23,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if room index preceeds the valid column indices`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.startsAt,
                 currentDayIndex = session.dayIndex,
                 columnIndex = -1
@@ -35,7 +35,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if room index exceeds the valid column indices`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.startsAt,
                 currentDayIndex = session.dayIndex,
                 columnIndex = COLUMN_INDEX + 1
@@ -47,7 +47,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if conference has not started but it will today`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.startsAt.minusMinutes(1),
                 currentDayIndex = session.dayIndex
         )
@@ -58,7 +58,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if conference starts now`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.startsAt,
                 currentDayIndex = session.dayIndex
         )
@@ -69,7 +69,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 0 if first session is almost done`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.endsAt.minusMinutes(1),
                 currentDayIndex = session.dayIndex
         )
@@ -80,7 +80,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns end of session if first session is done`() {
         val session = createFirstSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.endsAt,
                 currentDayIndex = session.dayIndex
         )
@@ -91,7 +91,7 @@ class ScrollAmountCalculatorTest {
     fun `calculateScrollAmount returns 408 for a session crossing the intra-day limit`() {
         val session = createLateSession()
         val scrollAmount = calculateScrollAmount(
-                session = session,
+                sessions = listOf(session),
                 nowMoment = session.endsAt,
                 currentDayIndex = session.dayIndex
         )
@@ -99,12 +99,12 @@ class ScrollAmountCalculatorTest {
     }
 
     private fun calculateScrollAmount(
-            session: Session,
+            sessions: List<Session>,
             nowMoment: Moment,
             currentDayIndex: Int,
             columnIndex: Int = COLUMN_INDEX
     ): Int {
-        val sessions = listOf(session)
+        val session = sessions.first()
         val roomData = RoomData(roomName = session.roomName, sessions = sessions)
         val scheduleData = ScheduleData(dayIndex = session.dayIndex, roomDataList = listOf(roomData))
         val conference = Conference.ofSessions(sessions)


### PR DESCRIPTION
# Description
+ Use the session's absolute start moment so the scroll correction uses the same UTC-based minute-of-day values as the surrounding calculation.
+ `startTime` stores local wall-clock minutes, e.g. 14:30 as 870 minutes, while `startsAt.minuteOfDay` is derived from `dateUTC`, e.g. 2026-06-05T14:30:00+02:00 as 12:30 UTC / 750 minutes.
+ The bug only occurs with schedule data which comes with non-UTC timestamps (e.g. `+02:00`) and `date` and `start` JSON/XML properties being set independent from each other.

# Before

When selecting the current day, the schedule view scrolls to the bottom of the screen.

https://github.com/user-attachments/assets/04d02509-2c2e-4b9f-a1f7-8202405c45c5

# After

When selecting the current day, the schedule view scrolls to the session matching the current time.

https://github.com/user-attachments/assets/cf986f6f-fbe8-45e4-a728-5d8f609ccd2e

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)