### PR TITLE
Fix scroll to current session next day bug.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculator.kt
@@ -60,11 +60,11 @@ internal class ScrollAmountCalculator(
             if (columnIndex >= 0 && columnIndex < roomDataList.size) {
                 val roomData = roomDataList[columnIndex]
                 for (session in roomData.sessions) {
-                    if (session.startsAt.minuteOfDay <= time && session.endsAt.minuteOfDay > time) {
+                    if (session.isStillRunningAt(time)) {
                         logging.d(LOG_TAG, session.title)
                         val startTime = session.startsAt.minuteOfDay
                         logging.d(LOG_TAG, "$time $startTime/${session.duration.toWholeMinutes().toInt()}")
-                        scrollAmount -= (time - startTime) / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight
+                        scrollAmount -= startTime.minutesUntil(time) / TIME_GRID_MINIMUM_SEGMENT_HEIGHT * boxHeight
                         time = startTime
                     }
                 }
@@ -72,6 +72,24 @@ internal class ScrollAmountCalculator(
         }
         return scrollAmount
     }
+
+    private fun Session.isStillRunningAt(minuteOfDay: Int): Boolean {
+        val start = startsAt.minuteOfDay
+        val end = endsAt.minuteOfDay
+        return when (start < end) {
+            true -> minuteOfDay in start..<end
+            false -> minuteOfDay !in end..<start
+        }
+    }
+
+    private fun Int.minutesUntil(endTime: Int): Int {
+        var minutes = endTime - this
+        if (endTime < this) {
+            minutes += MINUTES_OF_ONE_DAY
+        }
+        return minutes
+    }
+
 
     /**
      * Returns the scroll amount for the given [session].

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ScrollAmountCalculatorTest.kt
@@ -9,6 +9,8 @@ import nerd.tuxmobil.fahrplan.congress.models.DateInfos
 import nerd.tuxmobil.fahrplan.congress.models.RoomData
 import nerd.tuxmobil.fahrplan.congress.models.ScheduleData
 import nerd.tuxmobil.fahrplan.congress.models.Session
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.Companion.BOX_HEIGHT_MULTIPLIER
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.Companion.FIFTEEN_MINUTES
 import org.junit.jupiter.api.Test
 import org.threeten.bp.ZoneOffset
 
@@ -97,7 +99,64 @@ class ScrollAmountCalculatorTest {
                 currentDayIndex = session.dayIndex
         )
         assertThat(scrollAmount).isEqualTo(408)
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(session.startsAt.minutesUntil(session.endsAt)))
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(session.duration.toWholeMinutes()))
     }
+
+    @Test
+    fun `calculateScrollAmount returns start of 2nd session`() {
+        val s1 = createFirstSession()
+        val s2 = createSecondSession()
+        val scrollAmount = calculateScrollAmount(
+            sessions = listOf(s1, s2),
+            nowMoment = s2.startsAt,
+            currentDayIndex = s1.dayIndex
+        )
+        assertThat(scrollAmount).isEqualTo(816)
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(s1.startsAt.minutesUntil(s2.startsAt)))
+    }
+
+    @Test
+    fun `calculateScrollAmount returns start of late session`() {
+        val s1 = createFirstSession()
+        val s2 = createLateSession()
+        val scrollAmount = calculateScrollAmount(
+            sessions = listOf(s1, s2),
+            nowMoment = s2.startsAt,
+            currentDayIndex = s1.dayIndex
+        )
+        assertThat(scrollAmount).isEqualTo(6324)
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(s1.startsAt.minutesUntil(s2.startsAt)))
+    }
+
+    @Test
+    fun `calculateScrollAmount returns end of late session`() {
+        val s1 = createFirstSession()
+        val s2 = createLateSession()
+        val scrollAmount = calculateScrollAmount(
+            sessions = listOf(s1, s2),
+            nowMoment = s2.endsAt,
+            currentDayIndex = s1.dayIndex
+        )
+        assertThat(scrollAmount).isEqualTo(6732)
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(s1.startsAt.minutesUntil(s2.endsAt)))
+    }
+
+    @Test
+    fun `calculateScrollAmount returns start of 2nd session one minute before it ends the next day`() {
+        val s1 = createFirstSession()   // 08:00..09:00 -> 480..540   -> 0..408
+        val s2 = createLateSession()    // 23:30..00:30 -> 1410..1470 -> 6324..6732
+        val s3 = createNextDaySession() // 02:00..03:00 -> 1560..1620 -> 7344..7752
+        val scrollAmount = calculateScrollAmount(
+            sessions = listOf(s1, s2, s3),
+            nowMoment = s2.endsAt.minusMinutes(1), // March 1, 2020 00:29:00 AM GMT
+            currentDayIndex = s1.dayIndex
+        )
+        assertThat(scrollAmount).isEqualTo(6324)
+        assertThat(scrollAmount).isEqualTo(scrollAmountFor(s1.startsAt.minutesUntil(s2.startsAt)))
+    }
+
+    private fun scrollAmountFor(minutes: Long) = minutes / FIFTEEN_MINUTES * BOX_HEIGHT * BOX_HEIGHT_MULTIPLIER
 
     @Test
     fun `calculateScrollAmount returns 408 for a session crossing the intra-day limit`() {
@@ -129,8 +188,16 @@ class ScrollAmountCalculatorTest {
             Moment.ofEpochMilli(1582963200000L) // February 29, 2020 08:00:00 AM GMT
     )
 
-    private fun createLateSession() = createBaseSession("s2",
+    private fun createSecondSession() = createBaseSession("s2",
+            Moment.ofEpochMilli(1582970400000L) // February 29, 2020 10:00:00 AM GMT
+    )
+
+    private fun createLateSession() = createBaseSession("s3",
             Moment.ofEpochMilli(1583019000000L) // February 29, 2020 11:30:00 PM GMT
+    )
+
+    private fun createNextDaySession() = createBaseSession("s4",
+            Moment.ofEpochMilli(1583028000000L) // March 1, 2020 02:00:00 AM GMT
     )
 
     private fun createBaseSession(sessionId: String, moment: Moment) = Session(


### PR DESCRIPTION
# Description
+ Detect running sessions with a minute-of-day range that supports sessions crossing midnight, instead of `start <= time && end > time`.
+ Compute snap-back offset with minute-of-day-aware minutesUntil so the correction still works when start and matched grid time are on different sides of 00:00.
+ Example: session 23:30..00:30, now 00:29. Matched grid segment is 00:15 (minuteOfDay 15), session start is 1410, so 1410 <= 15 was false and snap-back was skipped. Scroll landed at 6630 (00:15) instead of 6324 (23:30 session start).

   ```
    23:30  ┌─ s2 start (6324) ◄── expected
           │
    00:00  │
           │
    00:15  ├─ grid segment (6630) ◄── actual
           │
    00:29  ●  now
           │
    00:30  └─ s2 end
  
    1410 <= 15 → false → no snap-back
    ```

# Before

When selecting the current day, the schedule view scrolls to the time segment matching the current time.

https://github.com/user-attachments/assets/9f8deed1-4e71-4c8a-bb0d-386a6712e39c

# After

When selecting the current day, the schedule view scrolls to the session matching the current time.

https://github.com/user-attachments/assets/02dba4c3-d50b-4405-9517-7565f882dc70

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/905