### PR TITLE
Fix back navigation when any search filter is selected.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFiltersState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchFiltersState.kt
@@ -1,0 +1,83 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.RecordedSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.WithinSpeakerNamesSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.WithinTitleSubtitleSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.WithinTrackNameSearchFilter
+
+internal val SUPPORTED_SEARCH_FILTERS = listOf(
+    IsFavoriteSearchFilter(),
+    NotFavoriteSearchFilter(),
+    HasAlarmSearchFilter(),
+    NotRecordedSearchFilter(),
+    RecordedSearchFilter(),
+    WithinSpeakerNamesSearchFilter(),
+    WithinTitleSubtitleSearchFilter(),
+    WithinTrackNameSearchFilter(),
+)
+
+internal data class SearchFiltersState(
+    private val filters: Map<SearchFilter, Boolean>,
+    private val selectedFilterLabels: List<Int>,
+) {
+
+    companion object {
+        fun of(searchFilters: List<SearchFilter>) = SearchFiltersState(
+            filters = searchFilters.associateWith { false },
+            selectedFilterLabels = emptyList(),
+        )
+    }
+
+    val activeFilters: Set<SearchFilter>
+        get() = filters
+            .asSequence()
+            .filter { it.value }
+            .map { it.key }
+            .toSet()
+
+    val uiState: ImmutableList<SearchFilterUiState>
+        get() = filters.map { (filter, selected) ->
+            SearchFilterUiState(filter.label, selected)
+        }.toImmutableList()
+
+    val hasSelectedFilters: Boolean
+        get() = selectedFilterLabels.isNotEmpty()
+
+    fun toggle(filter: SearchFilterUiState): SearchFiltersState {
+        val isSelected = filters
+            .entries
+            .firstOrNull { (searchFilter, _) -> searchFilter.label == filter.label }
+            ?.value
+            ?: return this
+
+        return copy(
+            filters = filters.mapValues { (searchFilter, selected) ->
+                if (searchFilter.label == filter.label) !selected else selected
+            },
+            selectedFilterLabels = if (isSelected) {
+                selectedFilterLabels - filter.label
+            } else {
+                selectedFilterLabels
+                    .filterNot { it == filter.label }
+                    .plus(filter.label)
+            },
+        )
+    }
+
+    fun unselectLastSelected(): SearchFiltersState {
+        val lastLabel = selectedFilterLabels.lastOrNull() ?: return this
+        return copy(
+            filters = filters.mapValues { (filter, selected) ->
+                if (filter.label == lastLabel) false else selected
+            },
+            selectedFilterLabels = selectedFilterLabels.dropLast(1),
+        )
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
@@ -73,7 +73,12 @@ class SearchViewModel(
 
     private val searchQuery = MutableStateFlow("")
 
-    private val searchFiltersState = MutableStateFlow(searchFilters.associateWith { false })
+    private val searchFiltersState = MutableStateFlow(
+        SearchFiltersState(
+            filters = searchFilters.associateWith { false },
+            selectedFilterLabels = emptyList(),
+        )
+    )
 
     private val useDeviceTimeZone: Boolean
         get() = repository.readUseDeviceTimeZoneEnabled()
@@ -84,7 +89,8 @@ class SearchViewModel(
             searchFiltersState,
             repository.sessions,
             searchHistoryManager.searchHistory,
-        ) { query, filters, sessions, searchHistory ->
+        ) { query, searchFiltersState, sessions, searchHistory ->
+            val filters = searchFiltersState.filters
             val activeFilters = filters
                 .asSequence()
                 .filter { it.value }
@@ -120,7 +126,7 @@ class SearchViewModel(
         .stateIn(
             scope = viewModelScope,
             initialValue = SearchUiState(
-                filters = searchFiltersState.value.toUiState(),
+                filters = searchFiltersState.value.filters.toUiState(),
             ),
             started = WhileSubscribed(5_000)
         )
@@ -136,9 +142,19 @@ class SearchViewModel(
 
     fun onViewEvent(viewEvent: SearchViewEvent) {
         when (viewEvent) {
-            OnBackPress -> sendEffect(NavigateBack)
+            OnBackPress -> {
+                if (!unselectLastSelectedSearchFilter()) {
+                    sendEffect(NavigateBack)
+                }
+            }
+
             OnBackIconClick -> searchQuery.value = ""
-            OnSearchSubScreenBackPress -> searchQuery.value = ""
+            OnSearchSubScreenBackPress -> {
+                if (!unselectLastSelectedSearchFilter()) {
+                    searchQuery.value = ""
+                }
+            }
+
             is OnSearchResultItemClick -> sendEffect(NavigateToSession(viewEvent.sessionId))
             is OnSearchHistoryItemClick -> searchQuery.value = viewEvent.searchQuery
             OnSearchHistoryClear -> searchHistoryManager.clear(viewModelScope)
@@ -149,16 +165,45 @@ class SearchViewModel(
     }
 
     private fun toggleSearchFilter(filter: SearchFilterUiState) {
-        searchFiltersState.update { filters ->
-            filters.mapValues { (key, value) ->
-                if (key.label == filter.label) {
-                    !value
+        searchFiltersState.update { state ->
+            val isSelected = state.filters
+                .entries
+                .firstOrNull { (searchFilter, _) -> searchFilter.label == filter.label }
+                ?.value
+                ?: return@update state
+
+            state.copy(
+                filters = state.filters.mapValues { (searchFilter, selected) ->
+                    if (searchFilter.label == filter.label) !selected else selected
+                },
+                selectedFilterLabels = if (isSelected) {
+                    state.selectedFilterLabels - filter.label
                 } else {
-                    value
-                }
-            }
+                    state.selectedFilterLabels
+                        .filterNot { it == filter.label }
+                        .plus(filter.label)
+                },
+            )
         }
     }
+
+    private fun unselectLastSelectedSearchFilter(): Boolean {
+        val lastLabel = searchFiltersState.value.selectedFilterLabels.lastOrNull() ?: return false
+        searchFiltersState.update { state ->
+            state.copy(
+                filters = state.filters.mapValues { (filter, selected) ->
+                    if (filter.label == lastLabel) false else selected
+                },
+                selectedFilterLabels = state.selectedFilterLabels.dropLast(1),
+            )
+        }
+        return true
+    }
+
+    private data class SearchFiltersState(
+        val filters: Map<SearchFilter, Boolean>,
+        val selectedFilterLabels: List<Int>,
+    )
 
     private fun sendEffect(effect: SearchEffect) {
         viewModelScope.launch {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModel.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.search
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
@@ -34,14 +33,6 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryChang
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryClear
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchResultItemClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenBackPress
-import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.NotFavoriteSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.RecordedSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.WithinSpeakerNamesSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.WithinTitleSubtitleSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.WithinTrackNameSearchFilter
 import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(FlowPreview::class)
@@ -55,17 +46,6 @@ class SearchViewModel(
 
     private companion object {
         val FINISH_TYPING_SEARCH_QUERY_DELAY = 1_000.milliseconds
-
-        private val SUPPORTED_SEARCH_FILTERS = listOf(
-            IsFavoriteSearchFilter(),
-            NotFavoriteSearchFilter(),
-            HasAlarmSearchFilter(),
-            NotRecordedSearchFilter(),
-            RecordedSearchFilter(),
-            WithinSpeakerNamesSearchFilter(),
-            WithinTitleSubtitleSearchFilter(),
-            WithinTrackNameSearchFilter(),
-        )
     }
 
     private val mutableEffects = Channel<SearchEffect>()
@@ -74,10 +54,7 @@ class SearchViewModel(
     private val searchQuery = MutableStateFlow("")
 
     private val searchFiltersState = MutableStateFlow(
-        SearchFiltersState(
-            filters = searchFilters.associateWith { false },
-            selectedFilterLabels = emptyList(),
-        )
+        SearchFiltersState.of(searchFilters)
     )
 
     private val useDeviceTimeZone: Boolean
@@ -90,13 +67,7 @@ class SearchViewModel(
             repository.sessions,
             searchHistoryManager.searchHistory,
         ) { query, searchFiltersState, sessions, searchHistory ->
-            val filters = searchFiltersState.filters
-            val activeFilters = filters
-                .asSequence()
-                .filter { it.value }
-                .map { it.key }
-                .toSet()
-
+            val activeFilters = searchFiltersState.activeFilters
             val resultsState = if (query.isEmpty() && activeFilters.isEmpty()) {
                 if (searchHistory.isEmpty()) {
                     NoSearchResults(backEvent = OnBackPress)
@@ -119,14 +90,14 @@ class SearchViewModel(
 
             SearchUiState(
                 query = query,
-                filters = filters.toUiState(),
+                filters = searchFiltersState.uiState,
                 resultsState = resultsState,
             )
         }
         .stateIn(
             scope = viewModelScope,
             initialValue = SearchUiState(
-                filters = searchFiltersState.value.filters.toUiState(),
+                filters = searchFiltersState.value.uiState,
             ),
             started = WhileSubscribed(5_000)
         )
@@ -159,61 +130,20 @@ class SearchViewModel(
             is OnSearchHistoryItemClick -> searchQuery.value = viewEvent.searchQuery
             OnSearchHistoryClear -> searchHistoryManager.clear(viewModelScope)
             is OnSearchQueryChange -> searchQuery.value = viewEvent.updatedQuery
-            is OnFilterToggled -> toggleSearchFilter(viewEvent.filter)
+            is OnFilterToggled -> searchFiltersState.update { it.toggle(viewEvent.filter) }
             OnSearchQueryClear -> searchQuery.value = ""
         }
     }
 
-    private fun toggleSearchFilter(filter: SearchFilterUiState) {
-        searchFiltersState.update { state ->
-            val isSelected = state.filters
-                .entries
-                .firstOrNull { (searchFilter, _) -> searchFilter.label == filter.label }
-                ?.value
-                ?: return@update state
-
-            state.copy(
-                filters = state.filters.mapValues { (searchFilter, selected) ->
-                    if (searchFilter.label == filter.label) !selected else selected
-                },
-                selectedFilterLabels = if (isSelected) {
-                    state.selectedFilterLabels - filter.label
-                } else {
-                    state.selectedFilterLabels
-                        .filterNot { it == filter.label }
-                        .plus(filter.label)
-                },
-            )
-        }
-    }
-
     private fun unselectLastSelectedSearchFilter(): Boolean {
-        val lastLabel = searchFiltersState.value.selectedFilterLabels.lastOrNull() ?: return false
-        searchFiltersState.update { state ->
-            state.copy(
-                filters = state.filters.mapValues { (filter, selected) ->
-                    if (filter.label == lastLabel) false else selected
-                },
-                selectedFilterLabels = state.selectedFilterLabels.dropLast(1),
-            )
-        }
+        if (!searchFiltersState.value.hasSelectedFilters) return false
+        searchFiltersState.update { it.unselectLastSelected() }
         return true
     }
-
-    private data class SearchFiltersState(
-        val filters: Map<SearchFilter, Boolean>,
-        val selectedFilterLabels: List<Int>,
-    )
 
     private fun sendEffect(effect: SearchEffect) {
         viewModelScope.launch {
             mutableEffects.send(effect)
         }
     }
-}
-
-private fun Map<SearchFilter, Boolean>.toUiState(): ImmutableList<SearchFilterUiState> {
-    return map { (filter, selected) ->
-        SearchFilterUiState(filter.label, selected)
-    }.toImmutableList()
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchFiltersStateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchFiltersStateTest.kt
@@ -1,0 +1,96 @@
+package nerd.tuxmobil.fahrplan.congress.search
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
+import org.junit.jupiter.api.Test
+
+class SearchFiltersStateTest {
+
+    @Test
+    fun `all search filters are initially unselected`() {
+        val favoriteFilter = IsFavoriteSearchFilter()
+        val alarmFilter = HasAlarmSearchFilter()
+
+        val state = SearchFiltersState.of(
+            searchFilters = listOf(favoriteFilter, alarmFilter),
+        )
+
+        assertThat(state.uiState).containsExactly(
+            SearchFilterUiState(label = favoriteFilter.label, selected = false),
+            SearchFilterUiState(label = alarmFilter.label, selected = false),
+        ).inOrder()
+        assertThat(state.activeFilters).isEmpty()
+        assertThat(state.hasSelectedFilters).isFalse()
+    }
+
+    @Test
+    fun `toggle selects and deselects search filter`() {
+        val filter = IsFavoriteSearchFilter()
+        val initialState = SearchFiltersState.of(searchFilters = listOf(filter))
+
+        val selectedState = initialState.toggle(
+            SearchFilterUiState(label = filter.label, selected = false)
+        )
+
+        assertThat(selectedState.uiState).containsExactly(
+            SearchFilterUiState(label = filter.label, selected = true)
+        )
+        assertThat(selectedState.activeFilters).containsExactly(filter)
+        assertThat(selectedState.hasSelectedFilters).isTrue()
+
+        val deselectedState = selectedState.toggle(
+            SearchFilterUiState(label = filter.label, selected = true)
+        )
+
+        assertThat(deselectedState.uiState).containsExactly(
+            SearchFilterUiState(label = filter.label, selected = false)
+        )
+        assertThat(deselectedState.activeFilters).isEmpty()
+        assertThat(deselectedState.hasSelectedFilters).isFalse()
+    }
+
+    @Test
+    fun `unselectLastSelected unselects selected filters in reverse selection order`() {
+        val favoriteFilter = IsFavoriteSearchFilter()
+        val alarmFilter = HasAlarmSearchFilter()
+        val notRecordedFilter = NotRecordedSearchFilter()
+        val selectedState = SearchFiltersState
+            .of(searchFilters = listOf(favoriteFilter, alarmFilter, notRecordedFilter))
+            .toggle(SearchFilterUiState(label = favoriteFilter.label, selected = false))
+            .toggle(SearchFilterUiState(label = alarmFilter.label, selected = false))
+            .toggle(SearchFilterUiState(label = notRecordedFilter.label, selected = false))
+
+        val notRecordedUnselectedState = selectedState.unselectLastSelected()
+        assertThat(notRecordedUnselectedState.uiState).containsExactly(
+            SearchFilterUiState(label = favoriteFilter.label, selected = true),
+            SearchFilterUiState(label = alarmFilter.label, selected = true),
+            SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+        ).inOrder()
+
+        val alarmUnselectedState = notRecordedUnselectedState.unselectLastSelected()
+        assertThat(alarmUnselectedState.uiState).containsExactly(
+            SearchFilterUiState(label = favoriteFilter.label, selected = true),
+            SearchFilterUiState(label = alarmFilter.label, selected = false),
+            SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+        ).inOrder()
+
+        val favoriteUnselectedState = alarmUnselectedState.unselectLastSelected()
+        assertThat(favoriteUnselectedState.uiState).containsExactly(
+            SearchFilterUiState(label = favoriteFilter.label, selected = false),
+            SearchFilterUiState(label = alarmFilter.label, selected = false),
+            SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+        ).inOrder()
+        assertThat(favoriteUnselectedState.activeFilters).isEmpty()
+        assertThat(favoriteUnselectedState.hasSelectedFilters).isFalse()
+    }
+
+    @Test
+    fun `unselectLastSelected keeps state unchanged when no filter is selected`() {
+        val filter = IsFavoriteSearchFilter()
+        val state = SearchFiltersState.of(searchFilters = listOf(filter))
+
+        assertThat(state.unselectLastSelected()).isEqualTo(state)
+    }
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelTest.kt
@@ -23,6 +23,7 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.SearchHistory
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.SearchResults
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnBackIconClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnBackPress
+import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnFilterToggled
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchHistoryClear
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchHistoryItemClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryChange
@@ -31,6 +32,7 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchResultItem
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenBackPress
 import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
 import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
+import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -274,7 +276,7 @@ class SearchViewModelTest {
                 val initialState = awaitItem()
 
                 // Select filter
-                viewModel.onViewEvent(SearchViewEvent.OnFilterToggled(initialState.filters.first()))
+                viewModel.onViewEvent(OnFilterToggled(initialState.filters.first()))
 
                 val filterSelectedState = awaitItem()
                 assertThat(filterSelectedState.filters).containsExactly(
@@ -282,8 +284,68 @@ class SearchViewModelTest {
                 )
 
                 // Deselect filter
-                viewModel.onViewEvent(SearchViewEvent.OnFilterToggled(filterSelectedState.filters.first()))
+                viewModel.onViewEvent(OnFilterToggled(filterSelectedState.filters.first()))
 
+                assertThat(awaitItem().filters).containsExactly(
+                    SearchFilterUiState(label = filter.label, selected = false)
+                )
+            }
+        }
+
+        @Test
+        fun `back press unselects selected filters in reverse selection order`() = runTest {
+            val favoriteFilter = IsFavoriteSearchFilter()
+            val alarmFilter = HasAlarmSearchFilter()
+            val notRecordedFilter = NotRecordedSearchFilter()
+            val viewModel = createViewModel(
+                searchFilters = listOf(favoriteFilter, alarmFilter, notRecordedFilter),
+            )
+
+            viewModel.uiState.test {
+                val initialState = awaitItem()
+                viewModel.onViewEvent(OnFilterToggled(initialState.filters[0]))
+                awaitItem()
+                viewModel.onViewEvent(OnFilterToggled(initialState.filters[1]))
+                awaitItem()
+                viewModel.onViewEvent(OnFilterToggled(initialState.filters[2]))
+                awaitItem()
+
+                viewModel.onViewEvent(OnSearchSubScreenBackPress)
+                assertThat(awaitItem().filters).containsExactly(
+                    SearchFilterUiState(label = favoriteFilter.label, selected = true),
+                    SearchFilterUiState(label = alarmFilter.label, selected = true),
+                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+                ).inOrder()
+
+                viewModel.onViewEvent(OnSearchSubScreenBackPress)
+                assertThat(awaitItem().filters).containsExactly(
+                    SearchFilterUiState(label = favoriteFilter.label, selected = true),
+                    SearchFilterUiState(label = alarmFilter.label, selected = false),
+                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+                ).inOrder()
+
+                viewModel.onViewEvent(OnSearchSubScreenBackPress)
+                assertThat(awaitItem().filters).containsExactly(
+                    SearchFilterUiState(label = favoriteFilter.label, selected = false),
+                    SearchFilterUiState(label = alarmFilter.label, selected = false),
+                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
+                ).inOrder()
+            }
+        }
+
+        @Test
+        fun `root back press unselects selected filter`() = runTest {
+            val filter = IsFavoriteSearchFilter()
+            val viewModel = createViewModel(
+                searchFilters = listOf(filter),
+            )
+
+            viewModel.uiState.test {
+                val initialState = awaitItem()
+                viewModel.onViewEvent(OnFilterToggled(initialState.filters.first()))
+                awaitItem()
+
+                viewModel.onViewEvent(OnBackPress)
                 assertThat(awaitItem().filters).containsExactly(
                     SearchFilterUiState(label = filter.label, selected = false)
                 )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/search/SearchViewModelTest.kt
@@ -23,16 +23,12 @@ import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.SearchHistory
 import nerd.tuxmobil.fahrplan.congress.search.SearchResultState.SearchResults
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnBackIconClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnBackPress
-import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnFilterToggled
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchHistoryClear
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchHistoryItemClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryChange
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchQueryClear
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchResultItemClick
 import nerd.tuxmobil.fahrplan.congress.search.SearchViewEvent.OnSearchSubScreenBackPress
-import nerd.tuxmobil.fahrplan.congress.search.filters.HasAlarmSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.IsFavoriteSearchFilter
-import nerd.tuxmobil.fahrplan.congress.search.filters.NotRecordedSearchFilter
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -247,112 +243,6 @@ class SearchViewModelTest {
 
     }
 
-    @Nested
-    inner class Filters {
-        @Test
-        fun `all search filters are initially unselected`() = runTest {
-            val favoriteFilter = IsFavoriteSearchFilter()
-            val alarmFilter = HasAlarmSearchFilter()
-            val viewModel = createViewModel(
-                searchFilters = listOf(favoriteFilter, alarmFilter),
-            )
-
-            viewModel.uiState.test {
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = favoriteFilter.label, selected = false),
-                    SearchFilterUiState(label = alarmFilter.label, selected = false),
-                ).inOrder()
-            }
-        }
-
-        @Test
-        fun `clicking search filter toggles its selected state`() = runTest {
-            val filter = IsFavoriteSearchFilter()
-            val viewModel = createViewModel(
-                searchFilters = listOf(filter),
-            )
-
-            viewModel.uiState.test {
-                val initialState = awaitItem()
-
-                // Select filter
-                viewModel.onViewEvent(OnFilterToggled(initialState.filters.first()))
-
-                val filterSelectedState = awaitItem()
-                assertThat(filterSelectedState.filters).containsExactly(
-                    SearchFilterUiState(label = filter.label, selected = true)
-                )
-
-                // Deselect filter
-                viewModel.onViewEvent(OnFilterToggled(filterSelectedState.filters.first()))
-
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = filter.label, selected = false)
-                )
-            }
-        }
-
-        @Test
-        fun `back press unselects selected filters in reverse selection order`() = runTest {
-            val favoriteFilter = IsFavoriteSearchFilter()
-            val alarmFilter = HasAlarmSearchFilter()
-            val notRecordedFilter = NotRecordedSearchFilter()
-            val viewModel = createViewModel(
-                searchFilters = listOf(favoriteFilter, alarmFilter, notRecordedFilter),
-            )
-
-            viewModel.uiState.test {
-                val initialState = awaitItem()
-                viewModel.onViewEvent(OnFilterToggled(initialState.filters[0]))
-                awaitItem()
-                viewModel.onViewEvent(OnFilterToggled(initialState.filters[1]))
-                awaitItem()
-                viewModel.onViewEvent(OnFilterToggled(initialState.filters[2]))
-                awaitItem()
-
-                viewModel.onViewEvent(OnSearchSubScreenBackPress)
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = favoriteFilter.label, selected = true),
-                    SearchFilterUiState(label = alarmFilter.label, selected = true),
-                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
-                ).inOrder()
-
-                viewModel.onViewEvent(OnSearchSubScreenBackPress)
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = favoriteFilter.label, selected = true),
-                    SearchFilterUiState(label = alarmFilter.label, selected = false),
-                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
-                ).inOrder()
-
-                viewModel.onViewEvent(OnSearchSubScreenBackPress)
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = favoriteFilter.label, selected = false),
-                    SearchFilterUiState(label = alarmFilter.label, selected = false),
-                    SearchFilterUiState(label = notRecordedFilter.label, selected = false),
-                ).inOrder()
-            }
-        }
-
-        @Test
-        fun `root back press unselects selected filter`() = runTest {
-            val filter = IsFavoriteSearchFilter()
-            val viewModel = createViewModel(
-                searchFilters = listOf(filter),
-            )
-
-            viewModel.uiState.test {
-                val initialState = awaitItem()
-                viewModel.onViewEvent(OnFilterToggled(initialState.filters.first()))
-                awaitItem()
-
-                viewModel.onViewEvent(OnBackPress)
-                assertThat(awaitItem().filters).containsExactly(
-                    SearchFilterUiState(label = filter.label, selected = false)
-                )
-            }
-        }
-    }
-
     private fun createSearchHistoryManager(): SearchHistoryManager {
         return SearchHistoryManager(InMemorySearchRepository())
     }
@@ -360,14 +250,13 @@ class SearchViewModelTest {
     private fun createViewModel(
         searchHistoryManager: SearchHistoryManager = createSearchHistoryManager(),
         sessionsFlow: Flow<List<Session>> = flowOf(emptyList()),
-        searchFilters: List<SearchFilter> = emptyList(),
     ): SearchViewModel {
         return SearchViewModel(
             repository = createRepository(sessionsFlow),
             searchQueryFilter = SearchQueryFilter(),
             searchHistoryManager = searchHistoryManager,
             searchResultParameterFactory = FakeSearchResultParameterFactory(),
-            searchFilters = searchFilters,
+            searchFilters = emptyList(),
         )
     }
 


### PR DESCRIPTION
# Description
+ Until now, back navigation would not work when one or more search filters are selected. Nothing happened, so users would have to manually unselect all the search filters.
+ Now, the back navigation functions like an undo action: starting with the last selected filter, each is unselected, one by one.
+ Reduce complexity of `SearchViewModel` by extracting `SearchFiltersState`.

# Screen recording

https://github.com/user-attachments/assets/f130a7d2-1778-424e-a8c0-6bfb0eb67ba6

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

---

Resolves #867