### PR TITLE
Use JDK 21.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
             
       - name: Build the app
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
-          java-version: '17'
+          java-version: '21'
           cache: 'gradle'
 
       - name: Instrumentation Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: jammy
 
 language: java
 
-jdk: openjdk17
+jdk: openjdk21
 
 env:
   global:

--- a/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/nerd/tuxmobil/fahrplan/congress/Dependencies.kt
@@ -5,7 +5,7 @@ package nerd.tuxmobil.fahrplan.congress
 import org.gradle.api.JavaVersion
 
 object Config {
-    val compatibleJavaVersion = JavaVersion.VERSION_17
+    val compatibleJavaVersion = JavaVersion.VERSION_21
 }
 
 object Android {


### PR DESCRIPTION
# Successfully tested
with `ccc39c3` flavor, `release` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)