### PR TITLE
Fix SnackEngage snackbars not being swipe-dismissible.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/Engagements.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/engagements/Engagements.kt
@@ -2,14 +2,15 @@
 
 package nerd.tuxmobil.fahrplan.congress.engagements
 
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.navigation.C3navSnack
 import org.ligi.snackengage.SnackEngage
 
 @Suppress("KotlinConstantConditions")
-fun AppCompatActivity.initUserEngagement() {
-    val snackEngageBuilder = SnackEngage.from(this)
+fun AppCompatActivity.initUserEngagement(view: View) {
+    val snackEngageBuilder = SnackEngage.from(view)
     if (BuildConfig.ENGAGE_GOOGLE_PLAY_RATING) {
         snackEngageBuilder.withSnack(RateSnack(this))
     }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -164,7 +164,7 @@ class MainActivity : BaseActivity(),
         if (findViewById<View>(R.id.detail) == null) {
             removeFragment(SessionDetailsFragment.FRAGMENT_TAG)
         }
-        initUserEngagement()
+        initUserEngagement(rootLayout)
         observeViewModel()
         onSessionAlarmNotificationTapped(intent)
         onScheduleUpdateNotificationTapped(intent)


### PR DESCRIPTION
# Description
+ `SnackEngage.from(Activity)` resolves to `android.R.id.content`, a `FrameLayout` that sits above the activity's `CoordinatorLayout` in the view tree.
+ `Snackbar.make()` walks upward from the anchor view looking for a `CoordinatorLayout` parent; because the `CoordinatorLayout` is a child of that `FrameLayout`, not an ancestor, the walk never finds it. The snackbar is then added to the `FrameLayout` without `SwipeDismissBehavior` attached.
+ Pass `rootLayout` to `initUserEngagement()` so the walk starts inside the `CoordinatorLayout` and swipe-to-dismiss works.

# Before
Snack message cannot be dismissed by swiping

https://github.com/user-attachments/assets/e9808004-5670-4602-97e9-6b1071ce5d8b

# After
Snack message can be dismissed by swiping

https://github.com/user-attachments/assets/d9c82197-2034-40b9-804d-2194aa163a67

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)