### PR TITLE
Ease maintaining tests by utilizing Moment type.

### DIFF
--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -20,9 +20,7 @@ class AlarmUpdaterTest {
 
     private companion object {
 
-        val DAY_20151225_235959 = Moment.ofEpochMilli(1451087999000) // 2015-12-25T23:59:59Z
-        val DAY_20151226_000000 = DAY_20151225_235959.plusSeconds(1) // 2015-12-26T00:00:00Z
-        val DAY_20151227_000000 = DAY_20151226_000000.plusDays(1) // 2015-12-27T00:00:00Z
+        val DAY_20151227_000000 = Moment.ofEpochMilli(1451174400000) // 2015-12-27T00:00:00Z
         val DAY_20151227_113000 = DAY_20151227_000000.plusHours(11).plusMinutes(30) // 2015-12-27T11:30:00Z
         val DAY_20151231_000000 = DAY_20151227_000000.plusDays(4) // 2015-12-31T00:00:00Z
 
@@ -99,7 +97,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(ONE_DAY)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(ONE_DAY, LAST_DAY_END_TIME.plusMilliseconds(ONE_DAY))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(ONE_DAY, LAST_DAY_END_TIME.plusDays(1))
     }
 
     // Start <= Time < End
@@ -117,7 +115,7 @@ class AlarmUpdaterTest {
         val interval = alarmUpdater.calculateInterval(DAY_20151227_113000, true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = DAY_20151227_113000.plusMilliseconds(TWO_HOURS)
+        val expectedNextFetch = DAY_20151227_113000.plusHours(2)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, expectedNextFetch)
     }
 
@@ -161,7 +159,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day`() {
-        val interval = alarmUpdater.calculateInterval(DAY_20151226_000000, false)
+        val interval = alarmUpdater.calculateInterval(FIRST_DAY_START_TIME.minusDays(1), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
@@ -169,7 +167,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day initial`() {
-        val interval = alarmUpdater.calculateInterval(DAY_20151226_000000, true)
+        val interval = alarmUpdater.calculateInterval(FIRST_DAY_START_TIME.minusDays(1), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
@@ -179,7 +177,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day`() {
-        val interval = alarmUpdater.calculateInterval(DAY_20151225_235959, false)
+        val interval = alarmUpdater.calculateInterval(FIRST_DAY_START_TIME.minusDays(1).minusSeconds(1), false)
         assertThat(interval).isEqualTo(ONE_DAY)
         // TODO Is this behavior intended?
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -188,10 +186,11 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
-        val interval = alarmUpdater.calculateInterval(DAY_20151225_235959, true)
+        val moment = FIRST_DAY_START_TIME.minusDays(1).minusSeconds(1)
+        val interval = alarmUpdater.calculateInterval(moment, true)
         assertThat(interval).isEqualTo(ONE_DAY)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = DAY_20151225_235959.plusMilliseconds(ONE_DAY)
+        val expectedNextFetch = moment.plusDays(1)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(ONE_DAY, expectedNextFetch)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -20,10 +20,10 @@ class AlarmUpdaterTest {
 
     private companion object {
 
-        // 2015-12-27T00:00:00+0100, in milliseconds: 1451170800000
+        // 2015-12-26T23:00:00Z, in milliseconds: 1451170800000
         val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451170800000L)
 
-        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
+        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
         val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451516400000L)
 
         const val NEVER_USED: Long = -1
@@ -103,7 +103,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day`() {
-        // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
+        // 2015-12-27T10:30:00Z, in milliseconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -112,7 +112,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day initial`() {
-        // 2015-12-27T11:30:00+0100, in milliseconds: 1451212200000
+        // 2015-12-27T10:30:00Z, in milliseconds: 1451212200000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -124,7 +124,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time`() {
-        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
+        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -133,7 +133,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time initial`() {
-        // 2015-12-31T00:00:00+0100, in milliseconds: 1451516400000
+        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -144,7 +144,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day`() {
-        // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
+        // 2015-12-26T22:59:59Z, in milliseconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -153,7 +153,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day initial`() {
-        // 2015-12-26T23:59:59+0100, in milliseconds: 1451170799000
+        // 2015-12-26T22:59:59Z, in milliseconds: 1451170799000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -164,7 +164,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day`() {
-        // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
+        // 2015-12-25T23:00:00Z, in milliseconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -173,7 +173,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one day before first day initial`() {
-        // 2015-12-26T00:00:00+0100, in milliseconds: 1451084400000
+        // 2015-12-25T23:00:00Z, in milliseconds: 1451084400000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
@@ -184,7 +184,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day`() {
-        // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
+        // 2015-12-25T22:59:59Z, in milliseconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), false)
         assertThat(interval).isEqualTo(ONE_DAY)
         // TODO Is this behavior intended?
@@ -194,7 +194,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
-        // 2015-12-25T23:59:59+0100, in milliseconds: 1451084399000
+        // 2015-12-25T22:59:59Z, in milliseconds: 1451084399000
         val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), true)
         assertThat(interval).isEqualTo(ONE_DAY)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -20,11 +20,14 @@ class AlarmUpdaterTest {
 
     private companion object {
 
-        // 2015-12-27T00:00:00Z, in milliseconds: 1451174400000
-        val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451174400000L)
+        val DAY_20151225_235959 = Moment.ofEpochMilli(1451087999000) // 2015-12-25T23:59:59Z
+        val DAY_20151226_000000 = DAY_20151225_235959.plusSeconds(1) // 2015-12-26T00:00:00Z
+        val DAY_20151227_000000 = DAY_20151226_000000.plusDays(1) // 2015-12-27T00:00:00Z
+        val DAY_20151227_113000 = DAY_20151227_000000.plusHours(11).plusMinutes(30) // 2015-12-27T11:30:00Z
+        val DAY_20151231_000000 = DAY_20151227_000000.plusDays(4) // 2015-12-31T00:00:00Z
 
-        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
-        val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451520000000L)
+        val FIRST_DAY_START_TIME = DAY_20151227_000000
+        val LAST_DAY_END_TIME = DAY_20151231_000000
 
         const val NEVER_USED: Long = -1
         val NEVER_USED_MOMENT: Moment = Moment.ofEpochMilli(NEVER_USED)
@@ -103,8 +106,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day`() {
-        // 2015-12-27T11:30:00Z, in milliseconds: 1451215800000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451215800000L), false)
+        val interval = alarmUpdater.calculateInterval(DAY_20151227_113000, false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -112,11 +114,10 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day initial`() {
-        // 2015-12-27T11:30:00Z, in milliseconds: 1451215800000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451215800000L), true)
+        val interval = alarmUpdater.calculateInterval(DAY_20151227_113000, true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = Moment.ofEpochMilli(1451215800000L).plusMilliseconds(TWO_HOURS)
+        val expectedNextFetch = DAY_20151227_113000.plusMilliseconds(TWO_HOURS)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, expectedNextFetch)
     }
 
@@ -124,8 +125,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time`() {
-        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451520000000L), false)
+        val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -133,8 +133,7 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time initial`() {
-        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451520000000L), true)
+        val interval = alarmUpdater.calculateInterval(LAST_DAY_END_TIME, true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -144,48 +143,43 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day`() {
-        // 2015-12-26T23:59:59Z, in milliseconds: 1451174399000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451174399000L), false)
+        val interval = alarmUpdater.calculateInterval(FIRST_DAY_START_TIME.minusSeconds(1), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
     }
 
     @Test
     fun `calculateInterval with time one second before first day initial`() {
-        // 2015-12-26T23:59:59Z, in milliseconds: 1451174399000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451174399000L), true)
+        val interval = alarmUpdater.calculateInterval(FIRST_DAY_START_TIME.minusSeconds(1), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
     }
 
     // Time < Start, diff == 1 day
 
     @Test
     fun `calculateInterval with time one day before first day`() {
-        // 2015-12-26T00:00:00Z, in milliseconds: 1451088000000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451088000000L), false)
+        val interval = alarmUpdater.calculateInterval(DAY_20151226_000000, false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
     }
 
     @Test
     fun `calculateInterval with time one day before first day initial`() {
-        // 2015-12-26T00:00:00Z, in milliseconds: 1451088000000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451088000000L), true)
+        val interval = alarmUpdater.calculateInterval(DAY_20151226_000000, true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, FIRST_DAY_START_TIME)
     }
 
     // Time < Start, diff > 1 day
 
     @Test
     fun `calculateInterval with time more than one day before first day`() {
-        // 2015-12-25T23:59:59Z, in milliseconds: 1451087999000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451087999000L), false)
+        val interval = alarmUpdater.calculateInterval(DAY_20151225_235959, false)
         assertThat(interval).isEqualTo(ONE_DAY)
         // TODO Is this behavior intended?
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -194,11 +188,10 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
-        // 2015-12-25T23:59:59Z, in milliseconds: 1451087999000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451087999000L), true)
+        val interval = alarmUpdater.calculateInterval(DAY_20151225_235959, true)
         assertThat(interval).isEqualTo(ONE_DAY)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = Moment.ofEpochMilli(1451087999000L).plusMilliseconds(ONE_DAY)
+        val expectedNextFetch = DAY_20151225_235959.plusMilliseconds(ONE_DAY)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(ONE_DAY, expectedNextFetch)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmUpdaterTest.kt
@@ -20,11 +20,11 @@ class AlarmUpdaterTest {
 
     private companion object {
 
-        // 2015-12-26T23:00:00Z, in milliseconds: 1451170800000
-        val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451170800000L)
+        // 2015-12-27T00:00:00Z, in milliseconds: 1451174400000
+        val FIRST_DAY_START_TIME = Moment.ofEpochMilli(1451174400000L)
 
-        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
-        val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451516400000L)
+        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
+        val LAST_DAY_END_TIME = Moment.ofEpochMilli(1451520000000L)
 
         const val NEVER_USED: Long = -1
         val NEVER_USED_MOMENT: Moment = Moment.ofEpochMilli(NEVER_USED)
@@ -103,8 +103,8 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day`() {
-        // 2015-12-27T10:30:00Z, in milliseconds: 1451212200000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), false)
+        // 2015-12-27T11:30:00Z, in milliseconds: 1451215800000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451215800000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -112,11 +112,11 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of first day initial`() {
-        // 2015-12-27T10:30:00Z, in milliseconds: 1451212200000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451212200000L), true)
+        // 2015-12-27T11:30:00Z, in milliseconds: 1451215800000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451215800000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = Moment.ofEpochMilli(1451212200000L).plusMilliseconds(TWO_HOURS)
+        val expectedNextFetch = Moment.ofEpochMilli(1451215800000L).plusMilliseconds(TWO_HOURS)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, expectedNextFetch)
     }
 
@@ -124,8 +124,8 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time`() {
-        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), false)
+        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451520000000L), false)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -133,8 +133,8 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time of last day end time initial`() {
-        // 2015-12-30T23:00:00Z, in milliseconds: 1451516400000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451516400000L), true)
+        // 2015-12-31T00:00:00Z, in milliseconds: 1451520000000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451520000000L), true)
         assertThat(interval).isEqualTo(0)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
         verifyInvokedNever(mockListener).onScheduleUpdateAlarm(NEVER_USED, NEVER_USED_MOMENT)
@@ -144,48 +144,48 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time one second before first day`() {
-        // 2015-12-26T22:59:59Z, in milliseconds: 1451170799000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), false)
+        // 2015-12-26T23:59:59Z, in milliseconds: 1451174399000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451174399000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451170800000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
     }
 
     @Test
     fun `calculateInterval with time one second before first day initial`() {
-        // 2015-12-26T22:59:59Z, in milliseconds: 1451170799000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451170799000L), true)
+        // 2015-12-26T23:59:59Z, in milliseconds: 1451174399000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451174399000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451170800000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
     }
 
     // Time < Start, diff == 1 day
 
     @Test
     fun `calculateInterval with time one day before first day`() {
-        // 2015-12-25T23:00:00Z, in milliseconds: 1451084400000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), false)
+        // 2015-12-26T00:00:00Z, in milliseconds: 1451088000000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451088000000L), false)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451170800000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
     }
 
     @Test
     fun `calculateInterval with time one day before first day initial`() {
-        // 2015-12-25T23:00:00Z, in milliseconds: 1451084400000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084400000L), true)
+        // 2015-12-26T00:00:00Z, in milliseconds: 1451088000000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451088000000L), true)
         assertThat(interval).isEqualTo(TWO_HOURS)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451170800000L))
+        verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(TWO_HOURS, Moment.ofEpochMilli(1451174400000L))
     }
 
     // Time < Start, diff > 1 day
 
     @Test
     fun `calculateInterval with time more than one day before first day`() {
-        // 2015-12-25T22:59:59Z, in milliseconds: 1451084399000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), false)
+        // 2015-12-25T23:59:59Z, in milliseconds: 1451087999000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451087999000L), false)
         assertThat(interval).isEqualTo(ONE_DAY)
         // TODO Is this behavior intended?
         verifyInvokedNever(mockListener).onCancelUpdateAlarm()
@@ -194,11 +194,11 @@ class AlarmUpdaterTest {
 
     @Test
     fun `calculateInterval with time more than one day before first day initial`() {
-        // 2015-12-25T22:59:59Z, in milliseconds: 1451084399000
-        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451084399000L), true)
+        // 2015-12-25T23:59:59Z, in milliseconds: 1451087999000
+        val interval = alarmUpdater.calculateInterval(Moment.ofEpochMilli(1451087999000L), true)
         assertThat(interval).isEqualTo(ONE_DAY)
         verifyInvokedOnce(mockListener).onCancelUpdateAlarm()
-        val expectedNextFetch = Moment.ofEpochMilli(1451084399000L).plusMilliseconds(ONE_DAY)
+        val expectedNextFetch = Moment.ofEpochMilli(1451087999000L).plusMilliseconds(ONE_DAY)
         verifyInvokedOnce(mockListener).onScheduleUpdateAlarm(ONE_DAY, expectedNextFetch)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsStateFactoryTest.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.alarms
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.alarms.AlarmsStateFactoryTest.Companion.DAY_20230513_1230
 import nerd.tuxmobil.fahrplan.congress.commons.FormattingDelegate
 import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolving
 import nerd.tuxmobil.fahrplan.congress.models.Alarm
@@ -14,8 +15,10 @@ import org.threeten.bp.ZoneOffset
 
 class AlarmsStateFactoryTest {
 
-    private companion object {
-        val SESSION_STARTS_AT = Moment.ofEpochMilli(1683981000000) // 2023-05-13T12:30:00+00:00
+    internal companion object {
+        val DAY_20210513_1230 = Moment.ofEpochMilli(1620909000000) // 2021-05-13T12:30:00Z
+        val DAY_20230513_1230 = Moment.ofEpochMilli(1683981000000) // 2023-05-13T12:30:00Z
+        val SESSION_STARTS_AT = DAY_20230513_1230
     }
 
     @Nested
@@ -71,7 +74,7 @@ class AlarmsStateFactoryTest {
             val alarms = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmStartsAt = alarmStartsAt.toMilliseconds(),
+                    alarmStartsAt = alarmStartsAt,
                 )
             )
             val sessions = listOf(
@@ -113,7 +116,7 @@ class AlarmsStateFactoryTest {
             val alarms = listOf(
                 createAlarm(
                     sessionId = "s0",
-                    alarmStartsAt = alarmStartsAt.toMilliseconds(),
+                    alarmStartsAt = alarmStartsAt,
                 )
             )
             val sessions = listOf(
@@ -153,12 +156,12 @@ class AlarmsStateFactoryTest {
 
     private fun createAlarm(
         sessionId: String,
-        alarmStartsAt: Long = 1620909000000,
+        alarmStartsAt: Moment = DAY_20210513_1230,
     ) = Alarm(
         dayIndex = 2,
         sessionId = sessionId,
         sessionTitle = "Unused",
-        startTime = Moment.ofEpochMilli(alarmStartsAt),
+        startTime = alarmStartsAt,
     )
 
     private fun calculateAlarmStartsAt(alarmTimeInMin: Int) =
@@ -197,8 +200,8 @@ private class FakeFormattingDelegate : FormattingDelegate {
         moment: Moment,
         timeZoneOffset: ZoneOffset?,
     ) = when (moment) {
-        Moment.ofEpochMilli(1683980400000) -> "May 13, 2023, 12:20 PM"  // 10 minutes before
-        Moment.ofEpochMilli(1683981000000) -> "May 13, 2023, 12:30 PM"  // session start
+        DAY_20230513_1230.minusMinutes(10) -> "May 13, 2023, 12:20 PM"  // 10 minutes before
+        DAY_20230513_1230 -> "May 13, 2023, 12:30 PM"  // session start
         else -> ""
     }
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsViewModelTest.kt
@@ -34,7 +34,9 @@ import org.mockito.kotlin.mock
 class AlarmsViewModelTest {
 
     private companion object {
-        val SESSION_STARTS_AT = Moment.ofEpochMilli(1683981000000) // 2023-05-13T12:30:00+00:00
+        val DAY_20210513_1230 = Moment.ofEpochMilli(1620909000000) // 2021-05-13T12:30:00Z
+        val DAY_20230513_1230 = Moment.ofEpochMilli(1683981000000) // 2023-05-13T12:30:00Z
+        val SESSION_STARTS_AT = DAY_20230513_1230
         const val ALARM_TIME_IN_MIN = 10
         val ALARM_STARTS_AT = SESSION_STARTS_AT.minusMinutes(ALARM_TIME_IN_MIN.toLong())
     }
@@ -201,7 +203,7 @@ class AlarmsViewModelTest {
 
     private fun createAlarm(
         sessionId: String,
-        alarmStartsAt: Moment = Moment.ofEpochMilli(1620909000000),
+        alarmStartsAt: Moment = DAY_20210513_1230,
     ) = Alarm(
         dayIndex = 2,
         sessionId = sessionId,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/dataconverters/SessionsExtensionsToVirtualDaysTest.kt
@@ -2,6 +2,7 @@ package nerd.tuxmobil.fahrplan.congress.dataconverters
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
 import org.junit.jupiter.api.Test
@@ -10,6 +11,14 @@ import org.junit.jupiter.api.Test
  * Covers [SessionsExtensions.toVirtualDays][toVirtualDays].
  */
 class SessionsExtensionsToVirtualDaysTest {
+
+    private companion object {
+        val NATURAL_DAY_1_1000 = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
+        val NATURAL_DAY_2_0200 = NATURAL_DAY_1_1000.plusHours(16) // 2023-12-28T02:00:00Z
+        val NATURAL_DAY_2_1000 = NATURAL_DAY_1_1000.plusDays(1) // 2023-12-28T10:00:00Z
+        val NATURAL_DAY_3_1000 = NATURAL_DAY_1_1000.plusDays(2) // 2023-12-29T10:00:00Z
+        val NATURAL_DAY_4_1000 = NATURAL_DAY_1_1000.plusDays(3) // 2023-12-30T10:00:00Z
+    }
 
     @Test
     fun `toVirtualDays returns empty list of days`() {
@@ -20,11 +29,11 @@ class SessionsExtensionsToVirtualDaysTest {
     @Test
     fun `toVirtualDays returns list of days with sessions broken into virtual days`() {
         val sessions = listOf(
-            createSession("2023-12-27", dayIndex = 1, 1703671200000, Duration.ofMinutes(60)), // 2023-12-27T10:00:00Z
-            createSession("2023-12-27", dayIndex = 1, 1703728800000, Duration.ofMinutes(45)), // 2023-12-28T02:00:00Z
-            createSession("2023-12-28", dayIndex = 2, 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
-            createSession("2023-12-29", dayIndex = 3, 1703844000000, Duration.ofMinutes(60)), // 2023-12-29T10:00:00Z
-            createSession("2023-12-30", dayIndex = 4, 1703930400000, Duration.ofMinutes(60)), // 2023-12-30T10:00:00Z
+            createSession("2023-12-27", dayIndex = 1, NATURAL_DAY_1_1000, Duration.ofMinutes(60)),
+            createSession("2023-12-27", dayIndex = 1, NATURAL_DAY_2_0200, Duration.ofMinutes(45)),
+            createSession("2023-12-28", dayIndex = 2, NATURAL_DAY_2_1000, Duration.ofMinutes(60)),
+            createSession("2023-12-29", dayIndex = 3, NATURAL_DAY_3_1000, Duration.ofMinutes(60)),
+            createSession("2023-12-30", dayIndex = 4, NATURAL_DAY_4_1000, Duration.ofMinutes(60)),
         )
         val virtualDays = sessions.toVirtualDays()
         val expectedVirtualDays = listOf(
@@ -40,7 +49,7 @@ class SessionsExtensionsToVirtualDaysTest {
     @Test
     fun `toVirtualDays returns list of days with correct day indices even if sessions of day 1 are missing`() {
         val sessions = listOf(
-            createSession("2023-12-28", dayIndex = 2, 1703757600000, Duration.ofMinutes(60)), // 2023-12-28T10:00:00Z
+            createSession("2023-12-28", dayIndex = 2, NATURAL_DAY_2_1000, Duration.ofMinutes(60)),
         )
         val virtualDays = sessions.toVirtualDays()
         val expectedVirtualDays = listOf(
@@ -53,13 +62,13 @@ class SessionsExtensionsToVirtualDaysTest {
     private fun createSession(
         dateText: String,
         dayIndex: Int,
-        startsAt: Long,
+        startsAt: Moment,
         duration: Duration,
     ) = Session(
         sessionId = "",
         dateText = dateText,
         dayIndex = dayIndex,
-        dateUTC = startsAt,
+        dateUTC = startsAt.toMilliseconds(),
         duration = duration,
     )
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/SessionTest.kt
@@ -3,7 +3,6 @@ package nerd.tuxmobil.fahrplan.congress.models
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Duration
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.of
@@ -200,7 +199,7 @@ class SessionTest {
             dateUTC = 1584662400000L,
             duration = Duration.ofMinutes(120),
         )
-        val endsAt = Moment.ofEpochMilli(1584662400000L + 120 * MILLISECONDS_OF_ONE_MINUTE)
+        val endsAt = Moment.ofEpochMilli(1584662400000).plusMinutes(120)
         assertThat(session.endsAt).isEqualTo(endsAt)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -44,7 +44,7 @@ class VirtualDayTest {
         assertThat(virtualDay.index).isEqualTo(1)
         assertThat(virtualDay.sessions.size).isEqualTo(3)
         val expectedStartsAt = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
-        val expectedEndsAt = Moment.ofEpochMilli(1703731500000) // 2023-12-28T02:54:00Z
+        val expectedEndsAt = Moment.ofEpochMilli(1703731500000) // 2023-12-28T02:45:00Z
         assertThat(virtualDay.timeFrame).isEqualTo(expectedStartsAt..expectedEndsAt)
     }
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/VirtualDayTest.kt
@@ -7,6 +7,15 @@ import org.junit.jupiter.api.Test
 
 class VirtualDayTest {
 
+    private companion object {
+        val NATURAL_DAY_1_1000 = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
+        val NATURAL_DAY_1_1600 = NATURAL_DAY_1_1000.plusHours(6) // 2023-12-27T16:00:00Z
+        val NATURAL_DAY_2_0200 = Moment.ofEpochMilli(1703728800000) // 2023-12-28T02:00:00Z
+        val NATURAL_DAY_2_0245 = NATURAL_DAY_2_0200.plusMinutes(45) // 2023-12-28T02:45:00Z
+        val NATURAL_DAY_4_0900 = Moment.ofEpochMilli(1703926800000) // 2023-12-30T09:00:00Z
+        val NATURAL_DAY_4_1800 = NATURAL_DAY_4_0900.plusHours(9) // 2023-12-30T18:00:00Z
+    }
+
     @Test
     fun `init throws exception if index less then 1`() {
         try {
@@ -36,16 +45,14 @@ class VirtualDayTest {
         val virtualDay = VirtualDay(
             index = 1,
             sessions = listOf(
-                createSession("2023-12-27", 1703671200000, Duration.ofMinutes(60)), // 2023-12-27T10:00:00Z
-                createSession("2023-12-27", 1703692800000, Duration.ofMinutes(30)), // 2023-12-27T16:00:00Z
-                createSession("2023-12-27", 1703728800000, Duration.ofMinutes(45)), // 2023-12-28T02:00:00Z
+                createSession("2023-12-27", NATURAL_DAY_1_1000, Duration.ofMinutes(60)),
+                createSession("2023-12-27", NATURAL_DAY_1_1600, Duration.ofMinutes(30)),
+                createSession("2023-12-27", NATURAL_DAY_2_0200, Duration.ofMinutes(45)),
             )
         )
         assertThat(virtualDay.index).isEqualTo(1)
         assertThat(virtualDay.sessions.size).isEqualTo(3)
-        val expectedStartsAt = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
-        val expectedEndsAt = Moment.ofEpochMilli(1703731500000) // 2023-12-28T02:45:00Z
-        assertThat(virtualDay.timeFrame).isEqualTo(expectedStartsAt..expectedEndsAt)
+        assertThat(virtualDay.timeFrame).isEqualTo(NATURAL_DAY_1_1000..NATURAL_DAY_2_0245)
     }
 
     @Test
@@ -53,8 +60,8 @@ class VirtualDayTest {
         val virtualDay = VirtualDay(
             index = 4,
             sessions = listOf(
-                createSession("2023-12-30", 1703926800000, Duration.ofMinutes(90)), // 2023-12-30T09:00:00Z
-                createSession("2023-12-30", 1703959200000, Duration.ofMinutes(30)), // 2023-12-30T18:00:00Z
+                createSession("2023-12-30", NATURAL_DAY_4_0900, Duration.ofMinutes(90)),
+                createSession("2023-12-30", NATURAL_DAY_4_1800, Duration.ofMinutes(30)),
             )
         )
         assertThat("$virtualDay").isEqualTo(
@@ -62,11 +69,11 @@ class VirtualDayTest {
         )
     }
 
-    private fun createSession(dateText: String, startsAt: Long, duration: Duration) =
+    private fun createSession(dateText: String, startsAt: Moment, duration: Duration) =
         Session(
             sessionId = "",
             dateText = dateText,
-            dateUTC = startsAt,
+            dateUTC = startsAt.toMilliseconds(),
             duration = duration,
         )
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/repositories/SessionsTransformerTest.kt
@@ -145,12 +145,10 @@ class SessionsTransformerTest {
         sessionId: String,
         roomName: String,
         roomIndex: Int,
-        dateUTC: Long = 0
     ) = Session(
         sessionId = sessionId,
         roomName = roomName,
         roomIndex = roomIndex,
-        dateUTC = dateUTC,
     )
 
     private fun createRoomProvider(

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/ConferenceTest.kt
@@ -11,6 +11,23 @@ import org.threeten.bp.ZoneOffset
 
 class ConferenceTest {
 
+    private companion object {
+        val DAY_20180907_1400 = Moment.ofEpochMilli(1536328800000) // 2018-09-07T14:00:00Z
+        val DAY_20180907_1500 = DAY_20180907_1400.plusHours(1) // 2018-09-07T15:00:00Z
+        val DAY_20180907_1600 = DAY_20180907_1500.plusHours(1) // 2018-09-07T16:00:00Z
+        val DAY_20180909_1445 = Moment.ofEpochMilli(1536504300000) // 2018-09-09T14:45:00Z
+
+        val DAY_20210327_1500 = Moment.ofEpochMilli(1616857200000) // 2021-03-27T15:00:00Z
+        val DAY_20210328_1400 = Moment.ofEpochMilli(1616940000000) // 2021-03-28T14:00:00Z
+
+        val DAY_20211030_1400 = Moment.ofEpochMilli(1635602400000) // 2021-10-30T14:00:00Z
+        val DAY_20211031_1500 = Moment.ofEpochMilli(1635692400000) // 2021-10-31T15:00:00Z
+
+        val DAY_20231227_1000 = Moment.ofEpochMilli(1703671200000) // 2023-12-27T10:00:00Z
+        val DAY_20231228_0400 = Moment.ofEpochMilli(1703736000000) // 2023-12-28T04:00:00Z
+        val DAY_20231228_0500 = DAY_20231228_0400.plusHours(1) // 2023-12-28T05:00:00Z
+    }
+
     @Test
     fun `ofSessions throws exception if empty list is passed`() {
         try {
@@ -23,11 +40,11 @@ class ConferenceTest {
 
     @Test
     fun `ofSession returns time range for one virtual conference day spanning two natural days`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1703671200000, ZoneOffset.of("+00:00")) // 2023-12-27T10:00:00+00:00
-        val dancing = createSession("Dancing", Duration.ofMinutes(60), dateUtc = 1703736000000, ZoneOffset.of("+00:00")) // 2023-12-28T04:00:00+00:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20231227_1000, ZoneOffset.of("+00:00"))
+        val dancing = createSession("Dancing", Duration.ofMinutes(60), dateUtc = DAY_20231228_0400, ZoneOffset.of("+00:00"))
         with(createConference(opening, dancing)) {
-            assertThat(firstSessionStartsAt).isEqualTo(Moment.ofEpochMilli(1703671200000)) // 2023-12-27T10:00:00+00:00
-            assertThat(lastSessionEndsAt).isEqualTo(Moment.ofEpochMilli(1703739600000)) // 2023-12-28T05:00:00+00:00
+            assertThat(firstSessionStartsAt).isEqualTo(DAY_20231227_1000)
+            assertThat(lastSessionEndsAt).isEqualTo(DAY_20231228_0500)
             assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+00:00"))
             assertThat(spansMultipleDays).isTrue()
         }
@@ -35,8 +52,8 @@ class ConferenceTest {
 
     @Test
     fun `ofSessions with frab data spanning multiple days`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = 1536504300000L, ZoneOffset.of("+02:00")) // 2018-09-09T16:45:00+02:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20180907_1500, ZoneOffset.of("+02:00"))
+        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = DAY_20180909_1445, ZoneOffset.of("+02:00"))
         val (timeFrame, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
         val firstSessionStartsAtMinutes = timeFrame.start.minuteOfDay
         val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
@@ -48,8 +65,8 @@ class ConferenceTest {
 
     @Test
     fun `ofSessions with frab data spanning from winter to summer time`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1616857200000L, ZoneOffset.of("+01:00")) // 2021-03-27T16:00:00+01:00
-        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = 1616940000000L, ZoneOffset.of("+02:00")) // 2021-03-28T16:00:00+02:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20210327_1500, ZoneOffset.of("+01:00"))
+        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = DAY_20210328_1400, ZoneOffset.of("+02:00"))
         val (timeFrame, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
         val firstSessionStartsAtMinutes = timeFrame.start.minuteOfDay
         val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
@@ -61,8 +78,8 @@ class ConferenceTest {
 
     @Test
     fun `ofSessions with frab data spanning from summer to winter time`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1635602400000L, ZoneOffset.of("+02:00")) // 2021-10-30T16:00:00+02:00
-        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = 1635692400000L, ZoneOffset.of("+01:00")) // 2021-10-31T16:00:00+01:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20211030_1400, ZoneOffset.of("+02:00"))
+        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = DAY_20211031_1500, ZoneOffset.of("+01:00"))
         val (timeFrame, timeZoneOffset, spansMultipleDays) = createConference(opening, closing)
         val firstSessionStartsAtMinutes = timeFrame.start.minuteOfDay
         val minutesToAdd = if (spansMultipleDays) MINUTES_OF_ONE_DAY else 0
@@ -74,8 +91,8 @@ class ConferenceTest {
 
     @Test
     fun `ofSessions with frab data spanning a single day`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20180907_1500, ZoneOffset.of("+02:00"))
+        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = DAY_20180907_1600, ZoneOffset.of("+02:00"))
         val (timeFrame, timeZoneOffset, _) = createConference(opening, closing)
         assertThat(timeFrame.start.minuteOfDay).isEqualTo(17 * 60 - 2 * 60) // 17:00h -2h zone offset = 15:00h
         assertThat(timeFrame.endInclusive.minuteOfDay).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
@@ -84,25 +101,26 @@ class ConferenceTest {
 
     @Test
     fun `ofSessions with frab data spanning a single day in non-chronological order`() {
-        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = 1536328800000L, ZoneOffset.of("+02:00")) // 2018-09-07T16:00:00+02:00
-        val middle = createSession("Middle", Duration.ofMinutes(20), dateUtc = 1536332400000L, ZoneOffset.of("+02:00")) // 2018-09-07T17:00:00+02:00
-        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = 1536336000000L, ZoneOffset.of("+02:00")) // 2018-09-07T18:00:00+02:00
+        val opening = createSession("Opening", Duration.ofMinutes(30), dateUtc = DAY_20180907_1400, ZoneOffset.of("+02:00"))
+        val middle = createSession("Middle", Duration.ofMinutes(20), dateUtc = DAY_20180907_1500, ZoneOffset.of("+02:00"))
+        val closing = createSession("Closing", Duration.ofMinutes(30), dateUtc = DAY_20180907_1600, ZoneOffset.of("+02:00"))
         val (timeFrame, timeZoneOffset, _) = createConference(opening, closing, middle)
         assertThat(timeFrame.start.minuteOfDay).isEqualTo(16 * 60 - 2 * 60) // 16:00h -2h zone offset = 14:00h
         assertThat(timeFrame.endInclusive.minuteOfDay).isEqualTo(18 * 60 + 30 - 2 * 60) // -> 18:30 -2h zone offset
         assertThat(timeZoneOffset).isEqualTo(ZoneOffset.of("+02:00"))
     }
 
-    private fun createConference(vararg sessions: Session) = Conference.ofSessions(sessions.toList())
+    private fun createConference(vararg sessions: Session) =
+        Conference.ofSessions(sessions.toList())
 
     private fun createSession(
         sessionId: String,
         duration: Duration,
-        dateUtc: Long,
+        dateUtc: Moment,
         timeZoneOffset: ZoneOffset
     ) = Session(
         sessionId = sessionId,
-        dateUTC = dateUtc,
+        dateUTC = dateUtc.toMilliseconds(),
         duration = duration,
         timeZoneOffset = timeZoneOffset,
     )

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.Test
 class NavigationMenuEntriesGeneratorTest {
 
     private companion object {
-        const val DAY_1_AT_8_AM = 1542528000000 // 2018-11-18T08:00:00Z
-        const val DAY_2_AT_230_AM = 1542594600000 // 2018-11-19T02:30:00Z
-        const val DAY_2_AT_8_AM = 1542614400000 // 2018-11-19T08:00:00Z
-        const val DAY_2_AT_810_AM = 1542615000000 // 2018-11-19T08:10:00Z
-        const val DAY_2_AT_830_AM = 1542616200000 // 2018-11-19T08:30:00Z
-        const val DAY_3_AT_8_AM = 1542700800000 // 2018-11-20T08:00:00Z
+        val DAY_1_AT_8_AM = Moment.ofEpochMilli(1542528000000) // 2018-11-18T08:00:00Z
+
+        val DAY_2_AT_230_AM = Moment.ofEpochMilli(1542594600000) // 2018-11-19T02:30:00Z
+        val DAY_2_AT_8_AM = Moment.ofEpochMilli(1542614400000) // 2018-11-19T08:00:00Z
+        val DAY_2_AT_810_AM = Moment.ofEpochMilli(1542615000000) // 2018-11-19T08:10:00Z
+        val DAY_2_AT_830_AM = Moment.ofEpochMilli(1542616200000) // 2018-11-19T08:30:00Z
+
+        val DAY_3_AT_8_AM = Moment.ofEpochMilli(1542700800000) // 2018-11-20T08:00:00Z
     }
 
     private val generator = NavigationMenuEntriesGenerator(
@@ -175,17 +177,17 @@ class NavigationMenuEntriesGeneratorTest {
     private fun createSession(
         dateText: String,
         dayIndex: Int,
-        startsAt: Long,
+        startsAt: Moment,
         duration: Duration,
     ) = Session(
         sessionId = "",
         dateText = dateText,
         dayIndex = dayIndex,
-        dateUTC = startsAt,
+        dateUTC = startsAt.toMilliseconds(),
         duration = duration,
     )
 
-    private fun getDayMenuEntries(numDays: Int, sessions: List<Session>, currentDate: Long) =
-        generator.getDayMenuEntries(numDays, sessions, Moment.ofEpochMilli(currentDate))
+    private fun getDayMenuEntries(numDays: Int, sessions: List<Session>, currentDate: Moment) =
+        generator.getDayMenuEntries(numDays, sessions, currentDate)
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.Test
 class NavigationMenuEntriesGeneratorTest {
 
     private companion object {
-        val DAY_1_AT_8_AM = Moment.ofEpochMilli(1542528000000) // 2018-11-18T08:00:00Z
+        val DAY_20181118_0800 = Moment.ofEpochMilli(1542528000000) // 2018-11-18T08:00:00Z
 
-        val DAY_2_AT_230_AM = Moment.ofEpochMilli(1542594600000) // 2018-11-19T02:30:00Z
-        val DAY_2_AT_8_AM = Moment.ofEpochMilli(1542614400000) // 2018-11-19T08:00:00Z
-        val DAY_2_AT_810_AM = Moment.ofEpochMilli(1542615000000) // 2018-11-19T08:10:00Z
-        val DAY_2_AT_830_AM = Moment.ofEpochMilli(1542616200000) // 2018-11-19T08:30:00Z
+        val DAY_20181119_0230 = Moment.ofEpochMilli(1542594600000) // 2018-11-19T02:30:00Z
+        val DAY_20181119_0800 = Moment.ofEpochMilli(1542614400000) // 2018-11-19T08:00:00Z
+        val DAY_20181119_0810 = Moment.ofEpochMilli(1542615000000) // 2018-11-19T08:10:00Z
+        val DAY_20181119_0830 = Moment.ofEpochMilli(1542616200000) // 2018-11-19T08:30:00Z
 
-        val DAY_3_AT_8_AM = Moment.ofEpochMilli(1542700800000) // 2018-11-20T08:00:00Z
+        val DAY_20181120_0800 = Moment.ofEpochMilli(1542700800000) // 2018-11-20T08:00:00Z
     }
 
     private val generator = NavigationMenuEntriesGenerator(
@@ -30,14 +30,14 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries with today mark`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_20181120_0800, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 3,
             sessions,
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(3)
@@ -49,15 +49,15 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries although one session happens after midnight`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_2_AT_230_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
-            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181119_0230, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_20181120_0800, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 3,
             sessions,
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(3)
@@ -69,14 +69,14 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns three day entries with today mark expecting sessions for day four`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_20181120_0800, duration = Duration.ofMinutes(180)),
         )
         val entries = getDayMenuEntries(
             numDays = 4,
             sessions,
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(3)
@@ -88,12 +88,12 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns a single day entry without today mark because the last session ended`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(10)),
         )
         val entries = getDayMenuEntries(
             numDays = 1,
             sessions,
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(1)
@@ -103,12 +103,12 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries returns a single day entry with today mark matching the session end`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(10)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(10)),
         )
         val entries = getDayMenuEntries(
             numDays = 1,
             sessions,
-            DAY_2_AT_810_AM,
+            DAY_20181119_0810,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(1)
@@ -120,7 +120,7 @@ class NavigationMenuEntriesGeneratorTest {
         val entries = getDayMenuEntries(
             numDays = 1,
             emptyList(),
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(0)
@@ -131,7 +131,7 @@ class NavigationMenuEntriesGeneratorTest {
         val entries = getDayMenuEntries(
             numDays = 0,
             emptyList(),
-            DAY_2_AT_830_AM,
+            DAY_20181119_0830,
         )
         assertThat(entries).isNotNull()
         assertThat(entries.size).isEqualTo(0)
@@ -140,15 +140,15 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries throws exception when numDays is less than 0`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
-            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_3_AT_8_AM, duration = Duration.ofMinutes(180)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-20", dayIndex = 3, startsAt = DAY_20181120_0800, duration = Duration.ofMinutes(180)),
         )
         try {
             getDayMenuEntries(
                 numDays = -1,
                 sessions,
-                DAY_2_AT_830_AM,
+                DAY_20181119_0830,
             )
             fail("Expect an IllegalArgumentException to be thrown.")
         } catch (e: IllegalArgumentException) {
@@ -159,14 +159,14 @@ class NavigationMenuEntriesGeneratorTest {
     @Test
     fun `getDayMenuEntries throws exception when number of days is less than date list items size`() {
         val sessions = listOf(
-            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_1_AT_8_AM, duration = Duration.ofMinutes(60)),
-            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_2_AT_8_AM, duration = Duration.ofMinutes(120)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(120)),
         )
         try {
             getDayMenuEntries(
                 numDays = 1,
                 sessions,
-                DAY_2_AT_830_AM,
+                DAY_20181119_0830,
             )
             fail("Expect an IllegalArgumentException to be thrown.")
         } catch (e: IllegalArgumentException) {

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -115,6 +115,11 @@ class Moment private constructor(private val time: Instant) : Comparable<Moment>
     fun plusMinutes(minutes: Long): Moment = Moment(time.plus(minutes, ChronoUnit.MINUTES))
 
     /**
+     * Returns a moment with the given [hours] added.
+     */
+    fun plusHours(hours: Long): Moment = Moment(time.plus(hours, ChronoUnit.HOURS))
+
+    /**
      * Returns a moment with the given [days] added.
      */
     fun plusDays(days: Long): Moment = Moment(time.plus(days, ChronoUnit.DAYS))

--- a/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
+++ b/commons/src/main/java/info/metadude/android/eventfahrplan/commons/temporal/Moment.kt
@@ -80,6 +80,11 @@ class Moment private constructor(private val time: Instant) : Comparable<Moment>
     fun toZonedDateTime(timeZoneOffset: ZoneOffset): ZonedDateTime = time.atZone(timeZoneOffset)
 
     /**
+     * Returns a moment with the given [days] subtracted.
+     */
+    fun minusDays(days: Long): Moment = Moment(time.minus(days, ChronoUnit.DAYS))
+
+    /**
      * Returns a moment with the given [hours] subtracted.
      */
     fun minusHours(hours: Long): Moment = Moment(time.minus(hours, ChronoUnit.HOURS))

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -281,6 +281,15 @@ class MomentTest {
     }
 
     @Test
+    fun minusDays() {
+        val momentOne = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_DAY).minusDays(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(0)
+
+        val momentTwo = Moment.ofEpochMilli(0).minusDays(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_DAY)
+    }
+
+    @Test
     fun minusHours() {
         val momentOne = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_HOUR).minusHours(1)
         assertThat(momentOne.toMilliseconds()).isEqualTo(0)

--- a/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
+++ b/commons/src/test/java/info/metadude/android/eventfahrplan/commons/temporal/MomentTest.kt
@@ -257,6 +257,15 @@ class MomentTest {
     }
 
     @Test
+    fun plusHours() {
+        val momentOne = Moment.ofEpochMilli(0).plusHours(1)
+        assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_HOUR)
+
+        val momentTwo = Moment.ofEpochMilli(MILLISECONDS_OF_ONE_HOUR).plusHours(-1)
+        assertThat(momentTwo.toMilliseconds()).isEqualTo(0)
+    }
+
+    @Test
     fun plusDays() {
         val momentOne = Moment.ofEpochMilli(0).plusDays(1)
         assertThat(momentOne.toMilliseconds()).isEqualTo(MILLISECONDS_OF_ONE_DAY)


### PR DESCRIPTION
# Description
+ Remove unused `dateUTC` property.
+ Fix typo.
+ Prepare changing time stamp notation to UTC like in other tests.
+ Move timestamps to UTC to ease maintenance.
+ Ease maintaining test by utilizing `Moment` type instead of millisecond values.
+ Ease maintaining `AlarmUpdaterTest` by utilizing `Moment` functions.
+ Use `DAY_yyyyMMdd_HHmm` notation like in other tests.

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)