### PR TITLE
Fix double marking of time column segments.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
@@ -30,7 +30,7 @@ internal class NavigationMenuEntriesGenerator(
      *
      * If the [currentDate] is within the time frame of a generated day then the corresponding
      * day will be suffixed with the given [todayString]. Example: ["Day 1", "Day 2 - Today", "Day 3"]
-     * An [IllegalArgumentException] is thrown the parameter restrictions are not met.
+     * An [IllegalArgumentException] is thrown if the parameter restrictions are not met.
      *
      * @param numDays Expected number of days as outlined in the schedule. Sessions or days
      * might still be missing. Must be 0 or more.

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -14,11 +14,7 @@ import org.threeten.bp.ZoneOffset
  * The given moment is normalized. The minutes of the day value is rounded to fit
  * into the time grid determined by [TIME_GRID_MINIMUM_SEGMENT_HEIGHT].
  */
-internal class TimeSegment private constructor(
-
-        moment: Moment
-
-) {
+internal class TimeSegment private constructor(moment: Moment) {
 
     companion object {
 
@@ -49,7 +45,7 @@ internal class TimeSegment private constructor(
 
     /**
      * Returns true if the given [otherMoment] matches the internal rounded moment taken the
-     * [minutesOffset] into account. Otherwise false.
+     * [minutesOffset] into account. Otherwise, false.
      */
     fun isMatched(otherMoment: Moment, minutesOffset: Int) =
             otherMoment.hour == roundedMoment.hour &&

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegment.kt
@@ -6,13 +6,13 @@ import nerd.tuxmobil.fahrplan.congress.schedule.TimeSegment.Companion.TIME_GRID_
 import org.threeten.bp.ZoneOffset
 
 /**
- * Holds the minutes of the day which represent a time segment (hours and minutes).
- * Day, month and year are not considered here.
+ * Represents a time column segment in the main schedule screen.
  *
- * The value is rendered in the time column in the main schedule view.
+ * The given [moment] is rounded down to the nearest grid boundary determined by
+ * [TIME_GRID_MINIMUM_SEGMENT_HEIGHT]. The full date and time are retained so matching does
+ * not accidentally include the same clock time on another day.
  *
- * The given moment is normalized. The minutes of the day value is rounded to fit
- * into the time grid determined by [TIME_GRID_MINIMUM_SEGMENT_HEIGHT].
+ * The [formatted value][getFormattedText] is rendered in the time column in the main schedule view.
  */
 internal class TimeSegment private constructor(moment: Moment) {
 
@@ -27,6 +27,14 @@ internal class TimeSegment private constructor(moment: Moment) {
 
     }
 
+    /**
+     * Moment rounded down to the nearest time grid segment.
+     *
+     * Examples with a [TIME_GRID_MINIMUM_SEGMENT_HEIGHT] of 5 minutes:
+     * - 10:00 remains 10:00.
+     * - 10:04 becomes 10:00.
+     * - 10:07 becomes 10:05.
+     */
     private val roundedMoment: Moment
 
     init {
@@ -44,13 +52,18 @@ internal class TimeSegment private constructor(moment: Moment) {
         DateFormatter.newInstance(useDeviceTimeZone).getFormattedTime24Hour(roundedMoment, sessionZoneOffset)
 
     /**
-     * Returns true if the given [otherMoment] matches the internal rounded moment taken the
-     * [minutesOffset] into account. Otherwise, false.
+     * Returns true if the given [otherMoment] is inside the half-open interval
+     * `[roundedMoment, roundedMoment + minutesOffset)`. Otherwise, false.
+     * Consequently, a [minutesOffset] of 0 spans an empty interval which never matches.
+     * An [IllegalArgumentException] is thrown if [minutesOffset] is negative.
      */
-    fun isMatched(otherMoment: Moment, minutesOffset: Int) =
-            otherMoment.hour == roundedMoment.hour &&
-                    otherMoment.minute >= roundedMoment.minute &&
-                    otherMoment.minute < roundedMoment.minute + minutesOffset
+    fun isMatched(otherMoment: Moment, minutesOffset: Int): Boolean {
+        require(minutesOffset >= 0) { "Minutes offset is $minutesOffset but must be 0 or more." }
+        if (otherMoment.isBefore(roundedMoment)) {
+            return false
+        }
+        return otherMoment.isBefore(roundedMoment.plusMinutes(minutesOffset.toLong()))
+    }
 
     override fun toString() = roundedMoment.toString()
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/TimeSegmentTest.kt
@@ -2,18 +2,164 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 
 import com.google.common.truth.Truth.assertThat
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
-import info.metadude.android.eventfahrplan.commons.temporal.Moment.Companion.MILLISECONDS_OF_ONE_MINUTE
+import nerd.tuxmobil.fahrplan.congress.schedule.FahrplanFragment.Companion.FIFTEEN_MINUTES
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class TimeSegmentTest {
 
-    @Test
-    fun `isMatched returns true for moment starting 15 minutes later`() {
-        val minute = 25
-        val actualMoment = Moment.ofEpochMilli((minute * MILLISECONDS_OF_ONE_MINUTE).toLong())
-        val segment = TimeSegment.ofMoment(actualMoment)
-        val moment = Moment.ofEpochMilli((minute * MILLISECONDS_OF_ONE_MINUTE).toLong())
-        assertThat(segment.isMatched(moment, 15)).isEqualTo(true)
+    private companion object {
+        val DAY_20181118_0800 = Moment.ofEpochMilli(1542528000000) // 2018-11-18T08:00:00Z
+        val DAY_20181119_0800 = Moment.ofEpochMilli(1542614400000) // 2018-11-19T08:00:00Z
+    }
+
+    @Nested
+    inner class SameMomentMatching {
+
+        @Test
+        fun `isMatched returns false for moment matching time and date because an offset of 0 spans an empty interval`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            assertThat(segment.isMatched(DAY_20181118_0800, minutesOffset = 0)).isFalse()
+        }
+
+        @Test
+        fun `isMatched returns true for moment matching time and date`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            assertThat(segment.isMatched(DAY_20181118_0800, minutesOffset = FIFTEEN_MINUTES)).isTrue()
+        }
+
+    }
+
+    @Nested
+    inner class DifferentDayMatching {
+
+        @Test
+        fun `isMatched returns false for moment matching time but not day, no offset`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            assertThat(segment.isMatched(DAY_20181119_0800, minutesOffset = 0)).isFalse()
+        }
+
+        @Test
+        fun `isMatched returns false for moment matching time but not day`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            assertThat(segment.isMatched(DAY_20181119_0800, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+    }
+
+    @Nested
+    inner class OffsetBoundary {
+
+        @Test
+        fun `isMatched returns false for moment exactly at the offset boundary`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.plusMinutes(15)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+        @Test
+        fun `isMatched returns false for moment one minute past the offset boundary`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.plusMinutes(16)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+    }
+
+    @Nested
+    inner class MomentBeforeSegment {
+
+        @Test
+        fun `isMatched returns false for moment before the segment, no offset`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.minusMinutes(1)
+            assertThat(segment.isMatched(moment, minutesOffset = 0)).isFalse()
+        }
+
+        @Test
+        fun `isMatched returns false for moment before the segment with a non-zero offset`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.minusMinutes(1)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+    }
+
+    @Nested
+    inner class DayBoundaryCrossing {
+
+        @Test
+        fun `isMatched returns true for moment on the next calendar day within the offset`() {
+            val lateNight = DAY_20181118_0800.plusHours(15).plusMinutes(50) // 2018-11-18T23:50:00Z
+            val segment = TimeSegment.ofMoment(lateNight)
+            val nextDay = lateNight.plusMinutes(14) // 2018-11-19T00:04:00Z
+            assertThat(segment.isMatched(nextDay, minutesOffset = FIFTEEN_MINUTES)).isTrue()
+        }
+
+        @Test
+        fun `isMatched returns false for moment on the next calendar day beyond the offset`() {
+            val lateNight = DAY_20181118_0800.plusHours(15).plusMinutes(50) // 2018-11-18T23:50:00Z
+            val segment = TimeSegment.ofMoment(lateNight)
+            val nextDay = lateNight.plusMinutes(16) // 2018-11-19T00:06:00Z
+            assertThat(segment.isMatched(nextDay, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+    }
+
+    @Nested
+    inner class SubMinutePrecision {
+
+        @Test
+        fun `isMatched returns false for moment before the segment with sub-minute precision`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.minusSeconds(30)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
+        @Test
+        fun `isMatched returns true for moment within the segment with sub-minute precision`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            val moment = DAY_20181118_0800.plusMinutes(14).plusSeconds(59)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isTrue()
+        }
+
+    }
+
+    @Nested
+    inner class NegativeOffset {
+
+        @Test
+        fun `isMatched throws exception for a negative offset`() {
+            val segment = TimeSegment.ofMoment(DAY_20181118_0800)
+            try {
+                segment.isMatched(DAY_20181118_0800, minutesOffset = -1)
+                fail("Expect an IllegalArgumentException to be thrown.")
+            } catch (e: IllegalArgumentException) {
+                assertThat(e.message).isEqualTo("Minutes offset is -1 but must be 0 or more.")
+            }
+        }
+
+    }
+
+    @Nested
+    inner class RoundedSegmentMoment {
+
+        @Test
+        fun `isMatched returns true for unrounded moment within rounded segment`() {
+            val moment = DAY_20181118_0800.plusMinutes(3)
+            val segment = TimeSegment.ofMoment(moment)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isTrue()
+        }
+
+        @Test
+        fun `isMatched uses the rounded segment moment, not the original unrounded moment`() {
+            val unroundedMoment = DAY_20181118_0800.plusMinutes(3) // 08:03
+            val segment = TimeSegment.ofMoment(unroundedMoment) // rounds down to 08:00
+            val moment = DAY_20181118_0800.plusMinutes(16)
+            assertThat(segment.isMatched(moment, minutesOffset = FIFTEEN_MINUTES)).isFalse()
+        }
+
     }
 
 }


### PR DESCRIPTION
# Description
+ Compare moments using the full date and time, not only hour and minute. Before, the same time on another day could match too, causing the time column to be marked twice.
+ A time segment matches only if "now" is inside its half-open time range [start, start + offset), using millisecond-precise comparison.

  ```
  [start ================= end)
          ^
         now
  ```
  not here:
  ```
  now   [start ================= end)
   ^
  no match
  ```
  and not here:
  ```
  [start ================= end)   now
                                  ^
                                no match
  ```


# Before

https://github.com/user-attachments/assets/26902e8f-827e-4146-96fe-6425de113c0c

# After

https://github.com/user-attachments/assets/1cd473e3-b2ab-48d1-8300-e51446ad4eb6

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

---
Resolves #33
