### PR TITLE
Fix multiple day menu entries being marked as "today".

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/NavigationMenuDay.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/models/NavigationMenuDay.kt
@@ -1,0 +1,21 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+
+/**
+ * Represents the [time frame][timeFrame] used to determine whether a [virtual day][VirtualDay] is
+ * marked as "today" in the navigation menu. The time frame starts at the natural day containing
+ * the first session and ends at the end of the last session.
+ */
+@ConsistentCopyVisibility
+data class NavigationMenuDay private constructor(
+    val index: Int,
+    val timeFrame: ClosedRange<Moment>,
+) {
+
+    constructor(virtualDay: VirtualDay) : this(
+        index = virtualDay.index,
+        timeFrame = virtualDay.timeFrame.start.startOfDay()..virtualDay.timeFrame.endInclusive,
+    )
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGenerator.kt
@@ -3,6 +3,7 @@ package nerd.tuxmobil.fahrplan.congress.schedule
 import info.metadude.android.eventfahrplan.commons.logging.Logging
 import info.metadude.android.eventfahrplan.commons.temporal.Moment
 import nerd.tuxmobil.fahrplan.congress.dataconverters.toVirtualDays
+import nerd.tuxmobil.fahrplan.congress.models.NavigationMenuDay
 import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.models.VirtualDay
 
@@ -51,7 +52,7 @@ internal class NavigationMenuEntriesGenerator(
             "Expected maximum $numDays day(s) but days list contains ${virtualDays.size} items."
         }
         logging.d(LOG_TAG, "Today is $currentDate")
-        val menuEntries = virtualDays.toMenuEntries(
+        val menuEntries = virtualDays.toNavigationMenuDays().toMenuEntries(
             dayString = dayString,
             todayString = todayString,
             currentDate = currentDate
@@ -61,14 +62,19 @@ internal class NavigationMenuEntriesGenerator(
 
 }
 
-private fun List<VirtualDay>.toMenuEntries(
+private fun List<VirtualDay>.toNavigationMenuDays() = map(::NavigationMenuDay)
+
+private fun List<NavigationMenuDay>.toMenuEntries(
     dayString: String,
     todayString: String,
     currentDate: Moment
 ): List<String> {
-    return map { day ->
+    // Append the "today" suffix to the last day entry that contains the current date.
+    // If no day contains the current date then no suffix is appended.
+    val indexOfLast = indexOfLast { currentDate in it.timeFrame }
+    return mapIndexed { index, day ->
         var entry = "$dayString ${day.index}"
-        if (currentDate in day.timeFrame) {
+        if (index == indexOfLast) {
             entry += " - $todayString"
         }
         entry

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/NavigationMenuDayTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/models/NavigationMenuDayTest.kt
@@ -1,0 +1,59 @@
+package nerd.tuxmobil.fahrplan.congress.models
+
+import com.google.common.truth.Truth.assertThat
+import info.metadude.android.eventfahrplan.commons.temporal.Duration
+import info.metadude.android.eventfahrplan.commons.temporal.Moment
+import org.junit.jupiter.api.Test
+
+class NavigationMenuDayTest {
+
+    private companion object {
+        val NATURAL_DAY_1_0000 = Moment.ofEpochMilli(1703635200000) // 2023-12-27T00:00:00Z
+        val NATURAL_DAY_1_1000 = NATURAL_DAY_1_0000.plusHours(10) // 2023-12-27T10:00:00Z
+        val NATURAL_DAY_1_1600 = NATURAL_DAY_1_0000.plusHours(16) // 2023-12-27T16:00:00Z
+        val NATURAL_DAY_1_1630 = NATURAL_DAY_1_1600.plusMinutes(30) // 2023-12-27T16:30:00Z
+        val NATURAL_DAY_2_0200 = NATURAL_DAY_1_0000.plusDays(1).plusHours(2) // 2023-12-28T02:00:00Z
+        val NATURAL_DAY_2_0245 = NATURAL_DAY_2_0200.plusMinutes(45) // 2023-12-28T02:45:00Z
+    }
+
+    @Test
+    fun `timeFrame spans from the start of the natural day containing the first session till the end of the last session on the same natural day`() {
+        val virtualDay = VirtualDay(
+            index = 1,
+            sessions = listOf(
+                createSession("2023-12-27", NATURAL_DAY_1_1000, Duration.ofMinutes(60)),
+                createSession("2023-12-27", NATURAL_DAY_1_1600, Duration.ofMinutes(30)),
+            ),
+        )
+        val menuDay = NavigationMenuDay(virtualDay)
+        assertThat(menuDay.index).isEqualTo(1)
+        assertThat(menuDay.timeFrame).isEqualTo(NATURAL_DAY_1_0000..NATURAL_DAY_1_1630)
+    }
+
+    @Test
+    fun `timeFrame spans from the start of the natural day containing the first session till the end of the last session on the next natural day`() {
+        val virtualDay = VirtualDay(
+            index = 1,
+            sessions = listOf(
+                createSession("2023-12-27", NATURAL_DAY_1_1000, Duration.ofMinutes(60)),
+                createSession("2023-12-27", NATURAL_DAY_1_1600, Duration.ofMinutes(30)),
+                createSession("2023-12-27", NATURAL_DAY_2_0200, Duration.ofMinutes(45)),
+            ),
+        )
+        val menuDay = NavigationMenuDay(virtualDay)
+        assertThat(menuDay.index).isEqualTo(1)
+        assertThat(menuDay.timeFrame).isEqualTo(NATURAL_DAY_1_0000..NATURAL_DAY_2_0245)
+    }
+
+    private fun createSession(
+        @Suppress("SameParameterValue") dateText: String,
+        startsAt: Moment,
+        duration: Duration,
+    ) = Session(
+        sessionId = "",
+        dateText = dateText,
+        dateUTC = startsAt.toMilliseconds(),
+        duration = duration,
+    )
+
+}

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/NavigationMenuEntriesGeneratorTest.kt
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.Test
 class NavigationMenuEntriesGeneratorTest {
 
     private companion object {
+        val DAY_20181118_0000 = Moment.ofEpochMilli(1542499200000) // 2018-11-18T00:00:00Z
         val DAY_20181118_0800 = Moment.ofEpochMilli(1542528000000) // 2018-11-18T08:00:00Z
+        val DAY_20181118_2300 = Moment.ofEpochMilli(1542582000000) // 2018-11-18T23:00:00Z
 
+        val DAY_20181119_0000 = Moment.ofEpochMilli(1542585600000) // 2018-11-19T00:00:00Z
         val DAY_20181119_0230 = Moment.ofEpochMilli(1542594600000) // 2018-11-19T02:30:00Z
+        val DAY_20181119_0331 = Moment.ofEpochMilli(1542598260000) // 2018-11-19T03:31:00Z
         val DAY_20181119_0800 = Moment.ofEpochMilli(1542614400000) // 2018-11-19T08:00:00Z
         val DAY_20181119_0810 = Moment.ofEpochMilli(1542615000000) // 2018-11-19T08:10:00Z
         val DAY_20181119_0830 = Moment.ofEpochMilli(1542616200000) // 2018-11-19T08:30:00Z
@@ -172,6 +176,60 @@ class NavigationMenuEntriesGeneratorTest {
         } catch (e: IllegalArgumentException) {
             assertThat(e.message).isEqualTo("Expected maximum 1 day(s) but days list contains 2 items.")
         }
+    }
+
+    @Test
+    fun `getDayMenuEntries marks day as today before its first session once the natural day has started`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            sessions,
+            DAY_20181118_0000,
+        )
+        assertThat(entries).containsExactly("Day 1 - Today")
+    }
+
+    @Test
+    fun `getDayMenuEntries keeps marking day at final session ending at midnight`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_2300, duration = Duration.ofMinutes(60)),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            sessions,
+            DAY_20181119_0000,
+        )
+        assertThat(entries).containsExactly("Day 1 - Today")
+    }
+
+    @Test
+    fun `getDayMenuEntries marks the last matching day when day ranges overlap at midnight`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_2300, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-19", dayIndex = 2, startsAt = DAY_20181119_0800, duration = Duration.ofMinutes(60)),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 2,
+            sessions,
+            DAY_20181119_0000,
+        )
+        assertThat(entries).containsExactly("Day 1", "Day 2 - Today").inOrder()
+    }
+
+    @Test
+    fun `getDayMenuEntries stops marking day after final session ending after midnight`() {
+        val sessions = listOf(
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181118_0800, duration = Duration.ofMinutes(60)),
+            createSession(dateText = "2018-11-18", dayIndex = 1, startsAt = DAY_20181119_0230, duration = Duration.ofMinutes(60)),
+        )
+        val entries = getDayMenuEntries(
+            numDays = 1,
+            sessions,
+            DAY_20181119_0331,
+        )
+        assertThat(entries).containsExactly("Day 1")
     }
 
     private fun createSession(


### PR DESCRIPTION
# Description
+ Introduce `NavigationMenuDay`. Its time frame starts at the **natural** day containing the first session and ends at the end of the last session.
+ Append the "today" suffix to the **last** `NavigationMenuDay` entry that contains the current date.

# Before

https://github.com/user-attachments/assets/1d71e175-ee46-4298-89de-464641a5482b

# After

https://github.com/user-attachments/assets/30a041c7-5489-4e6a-82db-d213b79d0a89

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

---
Resolves #851