### PR TITLE
Adjust multi-select and ButtonNavigation colors. 

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/colors/ColorSchemes.kt
@@ -18,6 +18,7 @@ internal fun darkColorScheme() = androidx.compose.material3.darkColorScheme(
     onSurfaceVariant = colorResource(R.color.text_secondary), // used by SearchBarDefaults.InputField placeholder, ListItem -> overlineContent
     surfaceContainer = colorResource(R.color.colorPrimaryDark), // used by DropdownMenu
     surfaceContainerHigh = colorResource(R.color.background_secondary), // used by AlertDialog background
+    surfaceContainerHighest = colorResource(R.color.colorPrimaryDark), // used by ButtonBox background -> ButtonNavigation
 ).toColorScheme(
     listItemPrefixSymbol = colorResource(R.color.session_details_list_item_prefix_symbol),
     divider = colorResource(R.color.divider),
@@ -74,6 +75,7 @@ internal fun lightColorScheme() = androidx.compose.material3.lightColorScheme(
     onSurfaceVariant = colorResource(R.color.text_secondary_inverted),
     surfaceContainer = colorResource(R.color.colorPrimaryDark),
     surfaceContainerHigh = colorResource(R.color.background_secondary),
+    surfaceContainerHighest = colorResource(R.color.colorPrimaryDark),
 ).toColorScheme(
     listItemPrefixSymbol = colorResource(R.color.session_details_list_item_prefix_symbol),
     divider = colorResource(R.color.divider),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
@@ -293,8 +293,8 @@ private fun CheckableItem(
     onClick: () -> Unit,
     content: @Composable () -> Unit,
 ) {
-    val backgroundColor = if (checked) EventFahrplanTheme.colorScheme.multiChoiceBackground else EventFahrplanTheme.colorScheme.background
-    val selectionIndicatorColor = EventFahrplanTheme.colorScheme.primary
+    val backgroundColor = if (checked) EventFahrplanTheme.colorScheme.multiChoiceBackground.copy(alpha = 0.7f) else EventFahrplanTheme.colorScheme.background
+    val selectionIndicatorColor = EventFahrplanTheme.colorScheme.onPrimary
     val selectionIndicatorWidth by animateDpAsState(
         targetValue = if (checked) 6.dp else 0.dp,
         label = "selectionIndicatorWidth",


### PR DESCRIPTION
# Description

## Improve multi-select colors.
+ Ensure selection indication uses distinct color.
+ Ensure multi-select toolbar button has enough contrast on multi-select background - not the same color.

## Customize `ButtonNavigation` background color.
+ Some default color was used: gray with some red mixed in.

# Before and after screenshots
<img width="270" height="600" alt="favorites-before" src="https://github.com/user-attachments/assets/d658b856-2890-419e-970c-b7960727fcac" /> <img width="270" height="600" alt="favorites-after" src="https://github.com/user-attachments/assets/df413a48-e4d9-47d2-b7ae-bdd8b2e8f60e" />

<img width="600" height="270" alt="favorites-landscape-before" src="https://github.com/user-attachments/assets/e3fd4241-698a-4001-907a-a656dac0e95b" /> <img width="600" height="270" alt="favorites-landscape-after" src="https://github.com/user-attachments/assets/e4894571-0a19-41de-84c3-b4224fcfae05" />


# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)