### PR TITLE
Fix crash when launching the app (release build) with webserver supporting zstd.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,8 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules/proguard-project.txt",
                 "proguard-rules/okhttp3.pro",
-                "proguard-rules/okio.pro"
+                "proguard-rules/okio.pro",
+                "proguard-rules/zstd.pro",
             )
         }
     }

--- a/app/proguard-rules/zstd.pro
+++ b/app/proguard-rules/zstd.pro
@@ -1,0 +1,13 @@
+# Related:
+# https://github.com/square/zstd-kmp/issues/108
+# https://github.com/lysine-dev/okhttp/issues/9591
+
+-keep class com.squareup.zstd.ZstdCompressor {
+    int inputBytesProcessed;
+    int outputBytesProcessed;
+}
+
+-keep class com.squareup.zstd.ZstdDecompressor {
+    int inputBytesProcessed;
+    int outputBytesProcessed;
+}


### PR DESCRIPTION
# Description
+ https://github.com/square/zstd-kmp/issues/108
+ https://github.com/lysine-dev/okhttp/issues/9591

## adb log (debug build):

``` sh
nativeloader    D Load /lib/arm64/libzstd-kmp.so using class loader ns clns-6 (caller=/base.apk): ok
ossgis.schedule A thread.cc:2867] Throwing new exception 'no "I" field "inputBytesProcessed" in class 
"Lcom/squareup/zstd/ZstdCompressor;" or its superclasses' with unexpected pending exception: 
java.lang.NoSuchFieldError: no "I" field "outputBytesProcessed" in class "Lcom/squareup/zstd/ZstdCompressor;" or its superclasses

   at long com.squareup.zstd.JniZstdKt.createJniZstd() (SourceFile:-2)
   at void com.squareup.zstd.JniZstdKt.<clinit>() (SourceFile:20)
   at void com.squareup.zstd.JniZstdDecompressor.<init>() (SourceFile:20)
   at com.squareup.zstd.ZstdDecompressor com.squareup.zstd.Zstd__Zstd_jniKt.zstdDecompressor() (SourceFile:25)
   at com.squareup.zstd.ZstdDecompressor com.squareup.zstd.Zstd.zstdDecompressor() ((null):1)
   at okio.Source com.squareup.zstd.okio.OkioZstd.zstdDecompress(okio.Source) (SourceFile:32)
   at okio.Source okhttp3.zstd.Zstd.decompress(okio.BufferedSource) (SourceFile:29)
   at okhttp3.Response okhttp3.CompressionInterceptor.decompress$okhttp(okhttp3.Response) (SourceFile:72)
   at okhttp3.Response okhttp3.CompressionInterceptor.intercept(okhttp3.Interceptor$Chain) (SourceFile:54)
   at okhttp3.Response okhttp3.internal.http.RealInterceptorChain.proceed(okhttp3.Request) (SourceFile:126)
   at okhttp3.Response okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp() (SourceFile:226)
   at okhttp3.Response okhttp3.internal.connection.RealCall.execute() (SourceFile:178)
   at info.metadude.android.eventfahrplan.network.fetching.HttpStatus info.metadude.android.eventfahrplan.network.fetching.FetchFahrplanTask.fetch(java.lang.String, java.lang.String, java.lang.String) (SourceFile:130)
   at info.metadude.android.eventfahrplan.network.fetching.HttpStatus info.metadude.android.eventfahrplan.network.fetching.FetchFahrplanTask.doInBackground(java.lang.String[]) (SourceFile:83)
   at java.lang.Object info.metadude.android.eventfahrplan.network.fetching.FetchFahrplanTask.doInBackground(java.lang.Object[]) (SourceFile:45)
   at java.lang.Object android.os.AsyncTask$3.call() (AsyncTask.java:394)
   ...
```

# Successfully tested
with `ccc39c3` flavor, `release` build with FOSSGIS 2026 URL
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/823