### PR TITLE
Visually assist user on settings screen on wide screens.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.alarmTimeToUiString
 import nerd.tuxmobil.fahrplan.congress.designsystem.bars.TopBar
@@ -57,12 +59,13 @@ internal fun SettingsListScreen(
                 .verticalScroll(rememberScrollState())
                 .padding(contentPadding)
         ) {
+            val showDivider = LocalWindowInfo.current.containerDpSize.width > 1000.dp
             if (state.isDevelopmentCategoryVisible) {
-                CategoryDevelopment(state, onViewEvent)
+                CategoryDevelopment(state, showDivider, onViewEvent)
             }
 
-            CategoryGeneral(state, onViewEvent)
-            CategoryAlarms(state, onViewEvent)
+            CategoryGeneral(state, showDivider, onViewEvent)
+            CategoryAlarms(state, showDivider, onViewEvent)
 
             if (state.isEngelsystemCategoryVisible) {
                 CategoryEngelsystem(state, onViewEvent)
@@ -74,12 +77,14 @@ internal fun SettingsListScreen(
 @Composable
 private fun CategoryDevelopment(
     state: SettingsUiState,
+    showDivider: Boolean,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     PreferenceCategory(stringResource(R.string.development_settings)) {
         ClickPreference(
             title = stringResource(R.string.preference_title_schedule_refresh_interval),
             subtitle = state.settings.scheduleRefreshIntervalToUiString(),
+            showDivider = showDivider,
             onClick = { onViewEvent(ScheduleRefreshIntervalClicked) },
         )
 
@@ -94,12 +99,14 @@ private fun CategoryDevelopment(
 @Composable
 private fun CategoryGeneral(
     state: SettingsUiState,
+    showDivider: Boolean,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     PreferenceCategory(stringResource(R.string.general_settings)) {
         EnableAutomaticUpdatesPreference(
             isAutoUpdateEnabled = state.settings.isAutoUpdateEnabled,
             nextFetch = state.nextFetch,
+            showDivider = showDivider,
             onViewEvent = onViewEvent,
         )
 
@@ -107,6 +114,7 @@ private fun CategoryGeneral(
             title = stringResource(R.string.preference_title_show_schedule_update_dialog_enabled),
             subtitle = stringResource(R.string.preference_summary_show_schedule_update_dialog_enabled),
             checked = state.settings.isShowScheduleUpdateDialogEnabled,
+            showDivider = showDivider,
             onCheckedChange = { onViewEvent(ShowScheduleUpdateDialogClicked) },
         )
 
@@ -114,6 +122,7 @@ private fun CategoryGeneral(
             title = stringResource(R.string.preference_title_use_device_time_zone_enabled),
             subtitle = stringResource(R.string.preference_summary_use_device_time_zone_enabled),
             checked = state.settings.isUseDeviceTimeZoneEnabled,
+            showDivider = showDivider,
             onCheckedChange = { onViewEvent(DeviceTimezoneClicked) },
         )
 
@@ -121,6 +130,7 @@ private fun CategoryGeneral(
             ExternalClickPreference(
                 title = stringResource(R.string.preference_title_app_notification_settings),
                 subtitle = stringResource(R.string.preference_summary_app_notification_settings),
+                showDivider = showDivider,
                 onClick = { onViewEvent(CustomizeNotificationsClicked) },
             )
         }
@@ -128,6 +138,7 @@ private fun CategoryGeneral(
         if (state.isAlternativeScheduleUrlVisible) {
             AlternativeScheduleUrlPreference(
                 alternativeScheduleUrl = state.settings.alternativeScheduleUrl,
+                showDivider = showDivider,
                 onViewEvent = onViewEvent,
             )
         }
@@ -136,6 +147,7 @@ private fun CategoryGeneral(
             title = stringResource(R.string.preference_title_alternative_highlighting_enabled),
             subtitle = stringResource(R.string.preference_summary_alternative_highlighting_enabled),
             checked = state.settings.isAlternativeHighlightingEnabled,
+            showDivider = showDivider,
             onCheckedChange = { onViewEvent(AlternativeHighlightingClicked) },
         )
 
@@ -143,6 +155,7 @@ private fun CategoryGeneral(
             title = stringResource(R.string.preference_title_fast_swiping_enabled),
             subtitle = stringResource(R.string.preference_summary_fast_swiping_enabled),
             checked = state.settings.isFastSwipingEnabled,
+            showDivider = showDivider,
             onCheckedChange = { onViewEvent(FastSwipingClicked) },
         )
 
@@ -158,12 +171,14 @@ private fun CategoryGeneral(
 @Composable
 private fun CategoryAlarms(
     state: SettingsUiState,
+    showDivider: Boolean,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     PreferenceCategory(stringResource(R.string.reminders)) {
         ExternalClickPreference(
             title = stringResource(R.string.preference_title_alarm_tone),
             subtitle = stringResource(R.string.preference_summary_alarm_tone),
+            showDivider = showDivider,
             onClick = { onViewEvent(AlarmToneClicked) },
         )
 
@@ -171,6 +186,7 @@ private fun CategoryAlarms(
             title = stringResource(R.string.preference_title_insistent_alarms_enabled),
             subtitle = stringResource(R.string.preference_summary_insistent_alarms_enabled),
             checked = state.settings.isInsistentAlarmsEnabled,
+            showDivider = showDivider,
             onCheckedChange = { onViewEvent(InsistentAlarmClicked) },
         )
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/AlternativeScheduleUrlPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/AlternativeScheduleUrlPreference.kt
@@ -9,6 +9,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AlternativeSchedul
 @Composable
 internal fun AlternativeScheduleUrlPreference(
     alternativeScheduleUrl: String,
+    showDivider: Boolean = false,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     val subtitle = alternativeScheduleUrl.ifEmpty {
@@ -18,6 +19,7 @@ internal fun AlternativeScheduleUrlPreference(
     ClickPreference(
         title = stringResource(R.string.preference_title_alternative_schedule_url),
         subtitle = subtitle,
+        showDivider = showDivider,
         onClick = { onViewEvent(AlternativeScheduleUrlClicked) },
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ClickPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ClickPreference.kt
@@ -13,18 +13,24 @@ internal fun ClickPreference(
     title: String,
     modifier: Modifier = Modifier,
     subtitle: String? = null,
+    showDivider: Boolean = false,
     onClick: () -> Unit,
 ) {
-    PreferenceText(
-        title = title,
-        subtitle = subtitle,
-        modifier = modifier
-            .fillMaxWidth()
-            .minimumInteractiveComponentSize()
-            .clickable(onClick = onClick)
-            .padding(
-                horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
-                vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
-            )
-    )
+    PreferenceItemContainer(
+        modifier = modifier,
+        showDivider = showDivider,
+    ) {
+        PreferenceText(
+            title = title,
+            subtitle = subtitle,
+            modifier = Modifier
+                .fillMaxWidth()
+                .minimumInteractiveComponentSize()
+                .clickable(onClick = onClick)
+                .padding(
+                    horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
+                    vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
+                )
+        )
+    }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/EnableAutomaticUpdatesPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/EnableAutomaticUpdatesPreference.kt
@@ -14,6 +14,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.AutoUpdateClicked
 internal fun EnableAutomaticUpdatesPreference(
     isAutoUpdateEnabled: Boolean,
     nextFetch: NextFetch,
+    showDivider: Boolean = false,
     onViewEvent: (SettingsEvent) -> Unit,
 ) {
     val context = LocalContext.current
@@ -29,6 +30,7 @@ internal fun EnableAutomaticUpdatesPreference(
         title = stringResource(R.string.preference_title_auto_update_enabled),
         subtitle = subtitle,
         checked = isAutoUpdateEnabled,
+        showDivider = showDivider,
         onCheckedChange = { onViewEvent(AutoUpdateClicked) },
     )
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/EngelsystemShiftsUrlPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/EngelsystemShiftsUrlPreference.kt
@@ -18,36 +18,39 @@ import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 @Composable
 internal fun EngelsystemShiftsUrlPreference(
     engelsystemShiftsUrl: String,
+    showDivider: Boolean = false,
     onClick: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .minimumInteractiveComponentSize()
-            .clickable(onClick = onClick)
-            .padding(
-                horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
-                vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
-            )
-    ) {
-        Text(
-            text = stringResource(R.string.preference_title_engelsystem_json_export_url),
-            style = EventFahrplanTheme.typography.preferenceTitle,
-        )
-
-        Text(
-            text = if (engelsystemShiftsUrl.isEmpty()) {
-                AnnotatedString.fromHtml(
-                    stringResource(
-                        R.string.preference_summary_engelsystem_json_export_url,
-                        stringResource(R.string.engelsystem_alias)
-                    )
+    PreferenceItemContainer(showDivider = showDivider) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .minimumInteractiveComponentSize()
+                .clickable(onClick = onClick)
+                .padding(
+                    horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
+                    vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
                 )
-            } else {
-                // Truncate to keep the key private.
-                AnnotatedString("${engelsystemShiftsUrl.dropLast(23)}…")
-            },
-            style = EventFahrplanTheme.typography.bodyMedium,
-        )
+        ) {
+            Text(
+                text = stringResource(R.string.preference_title_engelsystem_json_export_url),
+                style = EventFahrplanTheme.typography.preferenceTitle,
+            )
+
+            Text(
+                text = if (engelsystemShiftsUrl.isEmpty()) {
+                    AnnotatedString.fromHtml(
+                        stringResource(
+                            R.string.preference_summary_engelsystem_json_export_url,
+                            stringResource(R.string.engelsystem_alias)
+                        )
+                    )
+                } else {
+                    // Truncate to keep the key private.
+                    AnnotatedString("${engelsystemShiftsUrl.dropLast(23)}…")
+                },
+                style = EventFahrplanTheme.typography.bodyMedium,
+            )
+        }
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ExternalClickPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/ExternalClickPreference.kt
@@ -20,30 +20,36 @@ internal fun ExternalClickPreference(
     title: String,
     modifier: Modifier = Modifier,
     subtitle: String? = null,
+    showDivider: Boolean = false,
     onClick: () -> Unit,
 ) {
-    Row(
-        verticalAlignment = CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .minimumInteractiveComponentSize()
-            .clickable(onClick = onClick)
-            .padding(
-                horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
-                vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
-            ),
+    PreferenceItemContainer(
+        modifier = modifier,
+        showDivider = showDivider,
     ) {
-        PreferenceText(
-            title = title,
-            subtitle = subtitle,
-            modifier = Modifier.weight(1f),
-        )
+        Row(
+            verticalAlignment = CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .minimumInteractiveComponentSize()
+                .clickable(onClick = onClick)
+                .padding(
+                    horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
+                    vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
+                ),
+        ) {
+            PreferenceText(
+                title = title,
+                subtitle = subtitle,
+                modifier = Modifier.weight(1f),
+            )
 
-        Image(
-            painter = painterResource(R.drawable.ic_open_external),
-            colorFilter = ColorFilter.tint(EventFahrplanTheme.colorScheme.onSurface),
-            contentDescription = null,
-            modifier = Modifier.padding(start = 16.dp),
-        )
+            Image(
+                painter = painterResource(R.drawable.ic_open_external),
+                colorFilter = ColorFilter.tint(EventFahrplanTheme.colorScheme.onSurface),
+                contentDescription = null,
+                modifier = Modifier.padding(start = 16.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/PreferenceItemContainer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/PreferenceItemContainer.kt
@@ -1,0 +1,25 @@
+package nerd.tuxmobil.fahrplan.congress.settings.widgets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
+
+@Composable
+internal fun PreferenceItemContainer(
+    modifier: Modifier = Modifier,
+    showDivider: Boolean = false,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        content()
+        if (showDivider) {
+            DividerHorizontal()
+        }
+    }
+}
+

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/SwitchPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/SwitchPreference.kt
@@ -23,41 +23,47 @@ internal fun SwitchPreference(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     subtitle: String? = null,
+    showDivider: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
 
-    Row(
-        verticalAlignment = CenterVertically,
-        modifier = modifier
-            .fillMaxWidth()
-            .minimumInteractiveComponentSize()
-            .toggleable(
-                value = checked,
-                interactionSource = interactionSource,
-                indication = ripple(),
-                role = Role.Switch,
-                onValueChange = onCheckedChange,
-            )
-            .padding(
-                horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
-                vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
-            )
+    PreferenceItemContainer(
+        modifier = modifier,
+        showDivider = showDivider,
     ) {
-        PreferenceText(
-            title = title,
-            subtitle = subtitle,
-            modifier = Modifier.weight(1f),
-        )
-
-        // The ripple effect is displayed on the Row. Don't show a separate one on the Switch.
-        WithoutRipple {
-            Switch(
-                checked = checked,
-                onCheckedChange = null,
-                // Clicks on the row will highlight the switch thumb
-                interactionSource = interactionSource,
-                modifier = Modifier.padding(start = 16.dp),
+        Row(
+            verticalAlignment = CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .minimumInteractiveComponentSize()
+                .toggleable(
+                    value = checked,
+                    interactionSource = interactionSource,
+                    indication = ripple(),
+                    role = Role.Switch,
+                    onValueChange = onCheckedChange,
+                )
+                .padding(
+                    horizontal = PREFERENCE_HORIZONTAL_PADDING_DP.dp,
+                    vertical = PREFERENCE_VERTICAL_PADDING_DP.dp,
+                )
+        ) {
+            PreferenceText(
+                title = title,
+                subtitle = subtitle,
+                modifier = Modifier.weight(1f),
             )
+
+            // The ripple effect is displayed on the Row. Don't show a separate one on the Switch.
+            WithoutRipple {
+                Switch(
+                    checked = checked,
+                    onCheckedChange = null,
+                    // Clicks on the row will highlight the switch thumb
+                    interactionSource = interactionSource,
+                    modifier = Modifier.padding(start = 16.dp),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
# Description
+ Show horizontal lines on tablets in landscape mode.

# Landscape before & after
Horizontal lines.
<img width="600" height="375" alt="tablet-landscape-before" src="https://github.com/user-attachments/assets/b4316c18-200f-4b47-b122-db9dddfbd47d" /> <img width="600" height="375" alt="tablet-landscape-after" src="https://github.com/user-attachments/assets/9aa0c574-a11c-4f20-9b65-28bb47117af7" />

# Portrait before & after
No change here.
<img width="375" height="600" alt="tablet-portrait-before" src="https://github.com/user-attachments/assets/a0ba78a2-3819-439f-963e-6b6e52d27276" /> <img width="375" height="600" alt="tablet-portrait-after" src="https://github.com/user-attachments/assets/ff269add-285b-4868-a1bd-e824d73c80fa" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)