### PR TITLE
Improve readability of system bar information and screen content reaching device edges.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/alarms/AlarmsComposables.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterEnd
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -35,6 +36,8 @@ import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.ToolbarMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.useVerticalFloatingToolbar
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.StatusBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderSessionList
@@ -168,6 +171,10 @@ private fun SessionAlarmsList(
                 )
             }
         }
+        if (!showInSidePane) {
+            StatusBarProtection(Modifier.align(TopCenter))
+        }
+        NavigationBarProtection(Modifier.align(BottomCenter))
         AlarmsToolbar(
             modifier = Modifier
                 .align(if (useVerticalToolbar) CenterEnd else BottomCenter),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/changes/SessionChangeComposables.kt
@@ -14,7 +14,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -41,6 +43,8 @@ import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Available
 import nerd.tuxmobil.fahrplan.congress.commons.VideoRecordingState.Drawable.Unavailable
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.StatusBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.dividers.DividerHorizontal
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderDayDate
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderSessionList
@@ -135,47 +139,53 @@ private fun SessionChangesList(
     onBack: () -> Unit,
     onViewEvent: (SessionChangeViewEvent) -> Unit,
 ) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        state = rememberLazyListState(),
-        contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
-    ) {
-        item {
-            NavigationSection(
-                showInSidePane = showInSidePane,
-                navigationTitle = navigationTitle,
-                onNavClick = onBack,
-            )
-        }
-        itemsIndexed(
-            items = parameters,
-            key = { _, parameter -> parameter.hashCode() },
-        ) { index, parameter ->
-            when (parameter) {
-                is Separator -> HeaderDayDate(
-                    modifier = Modifier.animateItem(),
-                    text = parameter.daySeparator.value,
-                    contentDescription = parameter.daySeparator.contentDescription,
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = rememberLazyListState(),
+            contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
+        ) {
+            item {
+                NavigationSection(
+                    showInSidePane = showInSidePane,
+                    navigationTitle = navigationTitle,
+                    onNavClick = onBack,
                 )
-
-                is SessionChange -> {
-                    val next = parameters.getOrNull(index + 1)
-                    val showDivider = index < parameters.size - 1 && next is SessionChange
-                    SessionChangeItem(
-                        session = parameter,
-                        showDivider = showDivider,
-                        modifier = Modifier
-                            .animateItem()
-                            .safeContentHorizontalPadding()
-                            .clickable {
-                                if (!parameter.isCanceled) {
-                                    onViewEvent(OnSessionChangeItemClick(parameter.id))
-                                }
-                            }
+            }
+            itemsIndexed(
+                items = parameters,
+                key = { _, parameter -> parameter.hashCode() },
+            ) { index, parameter ->
+                when (parameter) {
+                    is Separator -> HeaderDayDate(
+                        modifier = Modifier.animateItem(),
+                        text = parameter.daySeparator.value,
+                        contentDescription = parameter.daySeparator.contentDescription,
                     )
+
+                    is SessionChange -> {
+                        val next = parameters.getOrNull(index + 1)
+                        val showDivider = index < parameters.size - 1 && next is SessionChange
+                        SessionChangeItem(
+                            session = parameter,
+                            showDivider = showDivider,
+                            modifier = Modifier
+                                .animateItem()
+                                .safeContentHorizontalPadding()
+                                .clickable {
+                                    if (!parameter.isCanceled) {
+                                        onViewEvent(OnSessionChangeItemClick(parameter.id))
+                                    }
+                                }
+                        )
+                    }
                 }
             }
         }
+        if (!showInSidePane) {
+            StatusBarProtection(Modifier.align(TopCenter))
+        }
+        NavigationBarProtection(Modifier.align(BottomCenter))
     }
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/NavigationBarProtection.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/NavigationBarProtection.kt
@@ -1,0 +1,75 @@
+package nerd.tuxmobil.fahrplan.congress.designsystem.bars
+
+import android.provider.Settings
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+
+/**
+ * Gradient protection drawn behind the system navigation bar so that
+ * scrolling content stays legible, as recommended by the edge-to-edge
+ * guidance, see https://developer.android.com/develop/ui/compose/system/system-bars#system-bar-protection
+ *
+ * Overlay this composable at the bottom of a full screen container which
+ * content is drawn edge-to-edge, e.g. in a [androidx.compose.foundation.layout.Box],
+ * after drawing the main content.
+ */
+@Composable
+fun NavigationBarProtection(
+    modifier: Modifier = Modifier,
+    color: Color = EventFahrplanTheme.colorScheme.background,
+) {
+    if (!isGestureNavigationActive()) return
+
+    Spacer(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(
+                with(LocalDensity.current) {
+                    (WindowInsets.navigationBars.getBottom(this) * 1.2f).toDp()
+                }
+            )
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        Color.Transparent,
+                        color.copy(alpha = 0.8f),
+                        color.copy(alpha = 1f),
+                    )
+                )
+            ),
+    )
+}
+
+@Composable
+private fun isGestureNavigationActive(): Boolean {
+    val context = LocalContext.current
+    return remember(context) {
+        Settings.Secure.getInt(
+            context.contentResolver,
+            NAVIGATION_MODE_KEY,
+            NAVIGATION_MODE_FULLY_GESTURAL,
+        ) == NAVIGATION_MODE_FULLY_GESTURAL
+    }
+}
+
+/**
+ * See value of `NAVIGATION_MODE` in [Settings.Secure].
+ */
+private const val NAVIGATION_MODE_KEY = "navigation_mode"
+
+/**
+ * See values documented by `NAVIGATION_MODE` in [Settings.Secure].
+ */
+private const val NAVIGATION_MODE_FULLY_GESTURAL = 2

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/StatusBarProtection.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/StatusBarProtection.kt
@@ -1,0 +1,49 @@
+package nerd.tuxmobil.fahrplan.congress.designsystem.bars
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+
+/**
+ * Gradient protection drawn behind the system status bar so that
+ * scrolling content stays legible, as recommended by the edge-to-edge
+ * guidance, see https://developer.android.com/develop/ui/compose/system/system-bars#system-bar-protection
+ *
+ * Overlay this composable at the top of a full screen container which
+ * content is drawn edge-to-edge, e.g. in a [androidx.compose.foundation.layout.Box],
+ * after drawing the main content.
+ */
+@Composable
+fun StatusBarProtection(
+    modifier: Modifier = Modifier,
+    color: Color = EventFahrplanTheme.colorScheme.background,
+) {
+    Spacer(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(
+                with(LocalDensity.current) {
+                    (WindowInsets.statusBars.getTop(this) * 1.2f).toDp()
+                }
+            )
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        color.copy(alpha = 1f),
+                        color.copy(alpha = 0.8f),
+                        Color.Transparent,
+                    )
+                )
+            ),
+    )
+}
+

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsComposables.kt
@@ -6,17 +6,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides.Companion.Bottom
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsComposables.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Alignment.Companion.TopStart
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -65,6 +66,8 @@ import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.ToolbarMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.useVerticalFloatingToolbar
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.StatusBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonBox
 import nerd.tuxmobil.fahrplan.congress.designsystem.icons.IconDecorative
 import nerd.tuxmobil.fahrplan.congress.designsystem.resources.floatResource
@@ -178,6 +181,10 @@ internal fun SessionDetailsContent(
                 source = ScrollPosition.Scroll(scrollState),
                 enabled = toolbarActions.isNotEmpty() && !useVerticalToolbar,
             )
+            if (!showInSidePane) {
+                StatusBarProtection(Modifier.align(TopCenter))
+            }
+            NavigationBarProtection(Modifier.align(BottomCenter))
             if (toolbarActions.isNotEmpty()) {
                 SessionDetailsToolbar(
                     modifier = Modifier

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterEnd
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.res.stringResource
@@ -36,6 +37,8 @@ import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.ToolbarMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.createSearchResultPreviewData
 import nerd.tuxmobil.fahrplan.congress.commons.useVerticalFloatingToolbar
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.StatusBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderDayDate
 import nerd.tuxmobil.fahrplan.congress.designsystem.headers.HeaderSessionList
 import nerd.tuxmobil.fahrplan.congress.designsystem.screenstates.Loading
@@ -219,6 +222,10 @@ private fun StarredSessionsList(
                 },
             )
         }
+        if (!showInSidePane) {
+            StatusBarProtection(Modifier.align(TopCenter))
+        }
+        NavigationBarProtection(Modifier.align(BottomCenter))
         StarredListToolbar(
             modifier = Modifier
                 .align(if (useVerticalToolbar) CenterEnd else BottomCenter),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -27,6 +28,7 @@ import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
@@ -164,6 +166,8 @@ private fun StarredSessionsList(
         enabled = !useVerticalToolbar,
     )
     val hasStarredSessions = sessions.isNotEmpty()
+    val density = LocalDensity.current
+    val statusBarHeight = if (showInSidePane) 0 else WindowInsets.statusBars.getTop(density)
 
     LaunchedEffect(sessions, hasAutoScrolled, listState) {
         if (sessions.isEmpty()) return@LaunchedEffect
@@ -171,7 +175,7 @@ private fun StarredSessionsList(
             val firstFutureIndex = firstFutureItemIndex(sessions)
             if (firstFutureIndex in 1 until sessions.size) {
                 // Lazy list item 0 is the top bar; session rows start at index 1.
-                listState.scrollToItem(firstFutureIndex + 1)
+                listState.scrollToItem(firstFutureIndex + 1, scrollOffset = -statusBarHeight)
             }
             hasAutoScrolled = true
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedulestatistic/ScheduleStatisticComposables.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContent
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -28,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import info.metadude.android.eventfahrplan.database.models.ColumnStatistic
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.bars.TopBar
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
 import nerd.tuxmobil.fahrplan.congress.designsystem.graphs.StackedHorizontalBar
@@ -61,6 +64,7 @@ fun ScheduleStatisticContent(
         content = { contentPadding ->
             Box(
                 Modifier
+                    .fillMaxSize()
                     .padding(top = contentPadding.calculateTopPadding())
             ) {
                 when (state) {
@@ -74,6 +78,7 @@ fun ScheduleStatisticContent(
                         }
                     }
                 }
+                NavigationBarProtection(Modifier.align(BottomCenter))
             }
         }
     )

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -25,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -49,6 +51,7 @@ import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.MultiDevicePreview
 import nerd.tuxmobil.fahrplan.congress.commons.ScreenMetrics
 import nerd.tuxmobil.fahrplan.congress.commons.createSearchResultPreviewData
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonIcon
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonOutlined
 import nerd.tuxmobil.fahrplan.congress.designsystem.chips.FilterChip
@@ -190,7 +193,7 @@ private fun SearchBarContent(
     onViewEvent: (SearchViewEvent) -> Unit,
 ) {
     Crossfade(targetState = state) { state ->
-        Column {
+        Column(Modifier.fillMaxSize()) {
             when (state) {
                 is Loading -> Loading()
                 is NoSearchResults -> NoSearchResult(onBack = { onViewEvent(state.backEvent) })
@@ -293,35 +296,38 @@ private fun SearchResultList(
     parameters: ImmutableList<SearchResultParameter>,
     onViewEvent: (SearchViewEvent) -> Unit,
 ) {
-    LazyColumn(
-        state = rememberLazyListState(),
-        contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
-    ) {
-        itemsIndexed(
-            items = parameters,
-            key = { _, parameter -> parameter.hashCode() },
-        ) { index, parameter ->
-            when (parameter) {
-                is Separator -> HeaderDayDate(
-                    modifier = Modifier.animateItem(),
-                    text = parameter.daySeparator.value,
-                    contentDescription = parameter.daySeparator.contentDescription,
-                )
-
-                is SearchResult -> {
-                    val next = parameters.getOrNull(index + 1)
-                    val showDivider = index < parameters.size - 1 && next is SearchResult
-                    SearchResultItem(
-                        searchResult = parameter,
-                        modifier = Modifier
-                            .animateItem()
-                            .clickable { onViewEvent(OnSearchResultItemClick(parameter.id)) }
-                            .safeContentHorizontalPadding(),
-                        showDivider = showDivider,
+    Box(Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = rememberLazyListState(),
+            contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
+        ) {
+            itemsIndexed(
+                items = parameters,
+                key = { _, parameter -> parameter.hashCode() },
+            ) { index, parameter ->
+                when (parameter) {
+                    is Separator -> HeaderDayDate(
+                        modifier = Modifier.animateItem(),
+                        text = parameter.daySeparator.value,
+                        contentDescription = parameter.daySeparator.contentDescription,
                     )
+
+                    is SearchResult -> {
+                        val next = parameters.getOrNull(index + 1)
+                        val showDivider = index < parameters.size - 1 && next is SearchResult
+                        SearchResultItem(
+                            searchResult = parameter,
+                            modifier = Modifier
+                                .animateItem()
+                                .clickable { onViewEvent(OnSearchResultItemClick(parameter.id)) }
+                                .safeContentHorizontalPadding(),
+                            showDivider = showDivider,
+                        )
+                    }
                 }
             }
         }
+        NavigationBarProtection(Modifier.align(BottomCenter))
     }
     BackHandler {
         onViewEvent(OnSearchSubScreenBackPress)
@@ -460,43 +466,49 @@ private fun SearchHistoryList(
     searchQueries: ImmutableList<String>,
     onViewEvent: (SearchViewEvent) -> Unit,
 ) {
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .safeContentHorizontalPadding(),
-        verticalAlignment = CenterVertically,
-    ) {
-        Text(
-            text = stringResource(R.string.search_history_title),
-            fontWeight = Bold,
-            modifier = Modifier.weight(1f),
-        )
-        ButtonOutlined(
-            border = BorderStroke(1.dp, EventFahrplanTheme.colorScheme.primary),
-            onClick = { onViewEvent(OnSearchHistoryClear) }
-        ) {
-            Text(
-                stringResource(R.string.search_history_clear),
-            )
-        }
-    }
-    LazyColumn(
-        state = rememberLazyListState(),
-        contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
-    ) {
-        itemsIndexed(searchQueries) { index, searchQuery ->
-            SearchHistoryItem(
-                searchQuery = searchQuery,
-                modifier = Modifier
-                    .clickable { onViewEvent(OnSearchHistoryItemClick(searchQuery)) }
-                    .safeContentHorizontalPadding()
-            )
-            val next = searchQueries.getOrNull(index + 1)
-            if (index < searchQueries.size - 1 && (next != null)) {
-                DividerHorizontal(Modifier.padding(horizontal = 12.dp))
+    Box(Modifier.fillMaxSize()) {
+        Column {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .safeContentHorizontalPadding(),
+                verticalAlignment = CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.search_history_title),
+                    fontWeight = Bold,
+                    modifier = Modifier.weight(1f),
+                )
+                ButtonOutlined(
+                    border = BorderStroke(1.dp, EventFahrplanTheme.colorScheme.primary),
+                    onClick = { onViewEvent(OnSearchHistoryClear) }
+                ) {
+                    Text(
+                        stringResource(R.string.search_history_clear),
+                    )
+                }
+            }
+            LazyColumn(
+                modifier = Modifier.weight(1f),
+                state = rememberLazyListState(),
+                contentPadding = WindowInsets.navigationBarsImeBottomPaddingValues(),
+            ) {
+                itemsIndexed(searchQueries) { index, searchQuery ->
+                    SearchHistoryItem(
+                        searchQuery = searchQuery,
+                        modifier = Modifier
+                            .clickable { onViewEvent(OnSearchHistoryItemClick(searchQuery)) }
+                            .safeContentHorizontalPadding()
+                    )
+                    val next = searchQueries.getOrNull(index + 1)
+                    if (index < searchQueries.size - 1 && (next != null)) {
+                        DividerHorizontal(Modifier.padding(horizontal = 12.dp))
+                    }
+                }
             }
         }
+        NavigationBarProtection(Modifier.align(BottomCenter))
     }
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -1,13 +1,16 @@
 package nerd.tuxmobil.fahrplan.congress.settings
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
@@ -15,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.commons.alarmTimeToUiString
+import nerd.tuxmobil.fahrplan.congress.designsystem.bars.NavigationBarProtection
 import nerd.tuxmobil.fahrplan.congress.designsystem.bars.TopBar
 import nerd.tuxmobil.fahrplan.congress.designsystem.templates.Scaffold
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
@@ -53,23 +57,26 @@ internal fun SettingsListScreen(
         },
         contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-                .padding(contentPadding)
-        ) {
-            val showDivider = LocalWindowInfo.current.containerDpSize.width > 1000.dp
-            if (state.isDevelopmentCategoryVisible) {
-                CategoryDevelopment(state, showDivider, onViewEvent)
-            }
+        Box(Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(contentPadding)
+            ) {
+                val showDivider = LocalWindowInfo.current.containerDpSize.width > 1000.dp
+                if (state.isDevelopmentCategoryVisible) {
+                    CategoryDevelopment(state, showDivider, onViewEvent)
+                }
 
-            CategoryGeneral(state, showDivider, onViewEvent)
-            CategoryAlarms(state, showDivider, onViewEvent)
+                CategoryGeneral(state, showDivider, onViewEvent)
+                CategoryAlarms(state, showDivider, onViewEvent)
 
-            if (state.isEngelsystemCategoryVisible) {
-                CategoryEngelsystem(state, onViewEvent)
+                if (state.isEngelsystemCategoryVisible) {
+                    CategoryEngelsystem(state, onViewEvent)
+                }
             }
+            NavigationBarProtection(Modifier.align(BottomCenter))
         }
     }
 }


### PR DESCRIPTION
# Description

## Protect system bars with translucent gradient to improve readability.
+ The custom composable overlaps the main content and draws a gradient in the area covered by insets.
+ Top and bottom overlays are selectively applied to screens which reach the device edges.
+ It is intentionally not applied to the schedule screen which has enough contrast through session cards' background colors.
+ The bottom overlay is not applied if 3 buttons navigation is active. There the system already draws a scrim.
+ https://developer.android.com/design/ui/mobile/guides/layout-and-content/edge-to-edge
+ https://developer.android.com/design/ui/mobile/guides/foundations/system-bars
+ https://developer.android.com/develop/ui/compose/system/system-bars

## Fix readability of first scrollable item on favorites screen.
+ Stop item from being scrolled under the system status bar.
+ Applies to phone layouts.

# Details screen before & after
Top and bottom bars with translucent gradient.
<img width="270" height="600" alt="bars-details-before" src="https://github.com/user-attachments/assets/1b1a1481-1185-4f86-ad08-ef1c0430f136" /> <img width="270" height="600" alt="bars-details-after" src="https://github.com/user-attachments/assets/afb2f033-aed2-469a-aaa5-9e8c6e2b63b5" />


# Favorites screen before & after
First item no longer scrolling under top bar.
<img width="270" height="600" alt="bars-favs-before" src="https://github.com/user-attachments/assets/db40e46d-5ab5-46fb-aea3-7a423d993885" /> <img width="270" height="600" alt="bars-favs-after" src="https://github.com/user-attachments/assets/05707253-8eed-49bc-b4e4-06524a653d5c" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)