### PR TITLE
Add "Wafer" and "Openki" as supported server backend types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Android 6.0 (Marshmallow) and newer versions are supported.
 
 * The app is designed to consume event data published in a specific [XML format][frab-schedule-xml-spec]
 or [JSON format][frab-schedule-json-spec]. Depending on the supported backend system ([Frab][frab-website],
-[Pretalx][pretalx-website], [Wafer][wafer-website]) one or both are provided.
+[Pretalx][pretalx-website], [Wafer][wafer-website], [OpenKi][openki-website]) one or both are provided.
 * The file format produced by the predecessor backend software, [Pentabarf][pentabarf-github],
 cannot be consumed out of the box.
 * In general, it is possible to re-deploy the app for other events which
@@ -196,6 +196,7 @@ limitations under the License.
 [issues-github]: https://github.com/EventFahrplan/EventFahrplan/issues
 [johnjohndoe-github]: https://github.com/johnjohndoe
 [limitations]: docs/LIMITATIONS.md
+[openki-website]: https://openki.net
 [pentabarf-github]: https://github.com/nevs/pentabarf
 [pretalx-website]: https://pretalx.com
 [tuxmobil-github]: https://github.com/tuxmobil

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendType.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendType.kt
@@ -12,7 +12,8 @@ enum class ServerBackendType(
 
     PENTABARF("pentabarf", Html),
     FRAB("frab", Markdown),
-    PRETALX("pretalx", Markdown);
+    PRETALX("pretalx", Markdown),
+    WAFER("wafer", Markdown);
 
     companion object {
         fun of(name: String) = entries.firstOrNull { it.value == name }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendType.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendType.kt
@@ -13,7 +13,8 @@ enum class ServerBackendType(
     PENTABARF("pentabarf", Html),
     FRAB("frab", Markdown),
     PRETALX("pretalx", Markdown),
-    WAFER("wafer", Markdown);
+    WAFER("wafer", Markdown),
+    OPENKI("openki", Markdown);
 
     companion object {
         fun of(name: String) = entries.firstOrNull { it.value == name }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
@@ -4,43 +4,49 @@ import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.FRAB
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PRETALX
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class ServerBackendTypeTest {
 
-    @Test
-    fun `of returns PENTABARF for pentabarf`() {
-        val type = ServerBackendType.of("pentabarf")
-        assertThat(type).isEqualTo(PENTABARF)
-    }
+    @Nested
+    inner class Of {
 
-    @Test
-    fun `of returns FRAB for frab`() {
-        val type = ServerBackendType.of("frab")
-        assertThat(type).isEqualTo(FRAB)
-    }
-
-    @Test
-    fun `of returns PRETALX for pretalx`() {
-        val type = ServerBackendType.of("pretalx")
-        assertThat(type).isEqualTo(PRETALX)
-    }
-
-    @Test
-    fun `of throws error for unknown server backend type string`() {
-        val exception = assertThrows<UnknownServerBackendTypeException> {
-            ServerBackendType.of("unknown")
+        @Test
+        fun `of returns PENTABARF for pentabarf`() {
+            val type = ServerBackendType.of("pentabarf")
+            assertThat(type).isEqualTo(PENTABARF)
         }
-        assertThat(exception).hasMessageThat().isEqualTo("""Unknown server backend type: "unknown".""")
-    }
 
-    @Test
-    fun `of throws error for empty server backend type string`() {
-        val exception = assertThrows<UnknownServerBackendTypeException> {
-            ServerBackendType.of("")
+        @Test
+        fun `of returns FRAB for frab`() {
+            val type = ServerBackendType.of("frab")
+            assertThat(type).isEqualTo(FRAB)
         }
-        assertThat(exception).hasMessageThat().isEqualTo("""Unknown server backend type: "".""")
+
+        @Test
+        fun `of returns PRETALX for pretalx`() {
+            val type = ServerBackendType.of("pretalx")
+            assertThat(type).isEqualTo(PRETALX)
+        }
+
+        @Test
+        fun `of throws error for unknown server backend type string`() {
+            val exception = assertThrows<UnknownServerBackendTypeException> {
+                ServerBackendType.of("unknown")
+            }
+            assertThat(exception).hasMessageThat().isEqualTo("""Unknown server backend type: "unknown".""")
+        }
+
+        @Test
+        fun `of throws error for empty server backend type string`() {
+            val exception = assertThrows<UnknownServerBackendTypeException> {
+                ServerBackendType.of("")
+            }
+            assertThat(exception).hasMessageThat().isEqualTo("""Unknown server backend type: "".""")
+        }
+
     }
 
 }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import nerd.tuxmobil.fahrplan.congress.models.MarkupLanguage.Html
 import nerd.tuxmobil.fahrplan.congress.models.MarkupLanguage.Markdown
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.FRAB
+import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.OPENKI
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PRETALX
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.WAFER
@@ -38,6 +39,12 @@ class ServerBackendTypeTest {
         fun `of returns WAFER for wafer`() {
             val type = ServerBackendType.of("wafer")
             assertThat(type).isEqualTo(WAFER)
+        }
+
+        @Test
+        fun `of returns OPENKI for openki`() {
+            val type = ServerBackendType.of("openki")
+            assertThat(type).isEqualTo(OPENKI)
         }
 
         @Test
@@ -79,6 +86,11 @@ class ServerBackendTypeTest {
         @Test
         fun `WAFER supports Markdown markup`() {
             assertThat(WAFER.markupLanguage).isEqualTo(Markdown)
+        }
+
+        @Test
+        fun `OPENKI supports Markdown markup`() {
+            assertThat(OPENKI.markupLanguage).isEqualTo(Markdown)
         }
 
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
@@ -1,6 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.utils
 
 import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.MarkupLanguage.Html
+import nerd.tuxmobil.fahrplan.congress.models.MarkupLanguage.Markdown
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.FRAB
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PRETALX
@@ -45,6 +47,26 @@ class ServerBackendTypeTest {
                 ServerBackendType.of("")
             }
             assertThat(exception).hasMessageThat().isEqualTo("""Unknown server backend type: "".""")
+        }
+
+    }
+
+    @Nested
+    inner class MarkupLanguage {
+
+        @Test
+        fun `PENTABARF supports HTML markup`() {
+            assertThat(PENTABARF.markupLanguage).isEqualTo(Html)
+        }
+
+        @Test
+        fun `FRAB supports Markdown markup`() {
+            assertThat(FRAB.markupLanguage).isEqualTo(Markdown)
+        }
+
+        @Test
+        fun `PRETALX supports Markdown markup`() {
+            assertThat(PRETALX.markupLanguage).isEqualTo(Markdown)
         }
 
     }

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/utils/ServerBackendTypeTest.kt
@@ -6,6 +6,7 @@ import nerd.tuxmobil.fahrplan.congress.models.MarkupLanguage.Markdown
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.FRAB
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PENTABARF
 import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.PRETALX
+import nerd.tuxmobil.fahrplan.congress.utils.ServerBackendType.WAFER
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -31,6 +32,12 @@ class ServerBackendTypeTest {
         fun `of returns PRETALX for pretalx`() {
             val type = ServerBackendType.of("pretalx")
             assertThat(type).isEqualTo(PRETALX)
+        }
+
+        @Test
+        fun `of returns WAFER for wafer`() {
+            val type = ServerBackendType.of("wafer")
+            assertThat(type).isEqualTo(WAFER)
         }
 
         @Test
@@ -67,6 +74,11 @@ class ServerBackendTypeTest {
         @Test
         fun `PRETALX supports Markdown markup`() {
             assertThat(PRETALX.markupLanguage).isEqualTo(Markdown)
+        }
+
+        @Test
+        fun `WAFER supports Markdown markup`() {
+            assertThat(WAFER.markupLanguage).isEqualTo(Markdown)
         }
 
     }

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -9,7 +9,7 @@ This list is for your preparation. Step 3 guides you through where to enter the 
 
 - Schedule URL which provides Frab compatible XML or JSON
 - Session URL template, e.g. `https://awesome-event.com/2021/events/%1$s.html`
-- Server backend type, one of: `pentabarf`, `frab`, `pretalx`
+- Server backend type, one of: `pentabarf`, `frab`, `pretalx`, `wafer`
 - Google Play URL, e.g. `https://play.google.com/store/apps/details?id=com.awesome.event.schedule`
 - F-Droid URL, e.g. `https://f-droid.org/packages/com.awesome.event.schedule`
 - Event URL, e.g. `https://awesome-event.com/2021`

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -9,7 +9,7 @@ This list is for your preparation. Step 3 guides you through where to enter the 
 
 - Schedule URL which provides Frab compatible XML or JSON
 - Session URL template, e.g. `https://awesome-event.com/2021/events/%1$s.html`
-- Server backend type, one of: `pentabarf`, `frab`, `pretalx`, `wafer`
+- Server backend type, one of: `pentabarf`, `frab`, `pretalx`, `wafer`, `openki`
 - Google Play URL, e.g. `https://play.google.com/store/apps/details?id=com.awesome.event.schedule`
 - F-Droid URL, e.g. `https://f-droid.org/packages/com.awesome.event.schedule`
 - Event URL, e.g. `https://awesome-event.com/2021`


### PR DESCRIPTION
# Description
+ Add "Openki" https://openki.net as a supported server backend type.  Define `Markdown` as the supported markup language.
+ Add "Wafer" https://wafer.readthedocs.io as a supported server backend type. Define `Markdown` as the supported markup language.
+ Unit test markup language per server backend type.
+ Restructure `ServerBackendTypeTest` to be extensible.

# Successfully tested
with `ccc39c3` flavor, `debug` build, with URLs pointing to these backends
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)