### PR TITLE
Allow to configure live streams URL to be included in share action.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ android {
         buildConfigField("boolean", "ENGAGE_LANDSCAPE_ORIENTATION", "true")
         buildConfigField("boolean", "ENABLE_FOSDEM_ROOM_STATES", "false")
         buildConfigField("String", "FOSDEM_ROOM_STATES_URL", """""""")
+        buildConfigField("String", "LIVE_STREAMS_URL", """""""")
     }
 
     buildFeatures {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -20,7 +20,7 @@ class SimpleSessionFormat {
     fun format(
         session: Session,
         timeZoneId: ZoneId?,
-        socialMediaHashtagsHandles: String = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES
+        socialMediaHashtagsHandles: String = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES,
     ): String {
         val builder = StringBuilder()
         builder.appendSession(session, timeZoneId)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -21,9 +21,13 @@ class SimpleSessionFormat {
         session: Session,
         timeZoneId: ZoneId?,
         socialMediaHashtagsHandles: String = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES,
+        liveStreamsUrl: String = BuildConfig.LIVE_STREAMS_URL,
     ): String {
         val builder = StringBuilder()
         builder.appendSession(session, timeZoneId)
+        if (liveStreamsUrl.isNotEmpty() && !session.links.containsWikiLink()) {
+            builder.appendLiveStreamsUrl(liveStreamsUrl)
+        }
         if (socialMediaHashtagsHandles.isNotEmpty()) {
             builder.append(LINE_BREAK)
             builder.append(LINE_BREAK)
@@ -66,6 +70,11 @@ class SimpleSessionFormat {
             val sessionUrl = SessionUrlComposer().getSessionUrl(session)
             append(sessionUrl)
         }
+    }
+
+    private fun StringBuilder.appendLiveStreamsUrl(liveStreamsUrl: String) {
+        append(LINE_BREAK)
+        append(liveStreamsUrl)
     }
 
     private fun StringBuilder.appendDivider() {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/utils/SessionUrlComposer.kt
@@ -25,7 +25,7 @@ class SessionUrlComposer(
      * The URL composition depends on the backend system being used for the conference.
      *
      * Special handling is applied to sessions with a [room name][Session.roomName] which is part
-     * of the collection of [special room names][specialRoomNames]. If there an URL defined then
+     * of the collection of [special room names][specialRoomNames]. If there is an URL defined then
      * it is returned. If there is no URL defined then no composition is tried but instead
      * an empty string is returned.
      */

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -173,7 +173,7 @@ class SessionDetailsViewModelTest {
         fun `OnShareClick emits ShareSimple effect with formatted session`() = runTest {
             val repository = createRepository()
             val fakeSessionFormat = mock<SimpleSessionFormat> {
-                on { format(any(), anyOrNull(), any()) } doReturn "An example session"
+                on { format(any(), anyOrNull(), any(), any()) } doReturn "An example session"
             }
             val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
             viewModel.onViewEvent(OnShareClick)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -605,7 +605,7 @@ class FahrplanViewModelTest {
         fun `share posts to shareSimple property`() = runTest {
             val repository = createRepository()
             val fakeSessionFormat = mock<SimpleSessionFormat> {
-                on { format(any(), anyOrNull(), any()) } doReturn "session-61"
+                on { format(any(), anyOrNull(), any(), any()) } doReturn "session-61"
             }
             val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
             viewModel.share(Session("61"))

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -84,9 +84,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a session without time zone name`() {
         assertThat(
             SimpleSessionFormat().format(
-                session1,
-                NO_TIME_ZONE_ID,
-                NO_SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """
@@ -102,9 +102,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a session with time zone name`() {
         assertThat(
             SimpleSessionFormat().format(
-                session1,
-                TIME_ZONE_EUROPE_BERLIN,
-                NO_SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session1,
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """
@@ -120,9 +120,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a session without social media hashtags`() {
         assertThat(
             SimpleSessionFormat().format(
-                session1,
-                NO_TIME_ZONE_ID,
-                NO_SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """
@@ -138,9 +138,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a session with social media hashtags`() {
         assertThat(
             SimpleSessionFormat().format(
-                session1,
-                NO_TIME_ZONE_ID,
-                SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """
@@ -158,9 +158,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a wiki session`() {
         assertThat(
             SimpleSessionFormat().format(
-                session3,
-                TIME_ZONE_EUROPE_BERLIN,
-                NO_SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session3,
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """
@@ -179,8 +179,8 @@ class SimpleSessionFormatTest {
     fun `format returns separated multiline text for a single session`() {
         assertThat(
             SimpleSessionFormat().format(
-                listOf(session1),
-                TIME_ZONE_EUROPE_BERLIN
+                sessions = listOf(session1),
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
             )
         ).isEqualTo(
             """
@@ -196,8 +196,8 @@ class SimpleSessionFormatTest {
     fun `format returns separated multiline text for multiple sessions`() {
         assertThat(
             SimpleSessionFormat().format(
-                listOf(session1, session2),
-                TIME_ZONE_EUROPE_BERLIN
+                sessions = listOf(session1, session2),
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
             )
         ).isEqualTo(
             """
@@ -220,9 +220,9 @@ class SimpleSessionFormatTest {
     fun `format returns formatted multiline text for a session in central european summer time`() {
         assertThat(
             SimpleSessionFormat().format(
-                session4,
-                TIME_ZONE_EUROPE_BERLIN,
-                NO_SOCIAL_MEDIA_HASHTAGS_HANDLES
+                session = session4,
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
             )
         ).isEqualTo(
             """

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -22,6 +22,8 @@ class SimpleSessionFormatTest {
         val TIME_ZONE_EUROPE_BERLIN: ZoneId = ZoneId.of("Europe/Berlin")
         const val NO_SOCIAL_MEDIA_HASHTAGS_HANDLES = ""
         const val SOCIAL_MEDIA_HASHTAGS_HANDLES = "#fahrplan #36c3"
+        const val NO_LIVE_STREAMS_URL = ""
+        const val LIVE_STREAMS_URL = "https://streaming.media.ccc.de/36c3"
     }
 
     private val systemTimezone = TimeZone.getDefault()
@@ -87,6 +89,7 @@ class SimpleSessionFormatTest {
                 session = session1,
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -105,6 +108,7 @@ class SimpleSessionFormatTest {
                 session = session1,
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -123,6 +127,7 @@ class SimpleSessionFormatTest {
                 session = session1,
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -141,6 +146,7 @@ class SimpleSessionFormatTest {
                 session = session1,
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -161,6 +167,66 @@ class SimpleSessionFormatTest {
                 session = session3,
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
+            )
+        ).isEqualTo(
+            """
+            Angel shifts planning
+            Sonntag, 29. Dezember 2019, 09:00 MEZ (Europe/Berlin), Main hall
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with live streams URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = LIVE_STREAMS_URL,
+            )
+        ).isEqualTo(
+            """
+            A talk which changes your life
+            Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+            $expectedSession1Url
+            $LIVE_STREAMS_URL
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with social media hashtags and live streams URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = LIVE_STREAMS_URL,
+            )
+        ).isEqualTo(
+            """
+            A talk which changes your life
+            Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+            $expectedSession1Url
+            $LIVE_STREAMS_URL
+
+            #fahrplan #36c3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a wiki session omitting the live streams URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session3,
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -188,7 +254,7 @@ class SimpleSessionFormatTest {
             Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
 
             $expectedSession1Url
-            """.trimIndent()
+            """.trimIndent() + expectedLiveStreamsUrlSuffix
         )
     }
 
@@ -223,6 +289,7 @@ class SimpleSessionFormatTest {
                 session = session4,
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
             )
         ).isEqualTo(
             """
@@ -246,6 +313,9 @@ class SimpleSessionFormatTest {
         slug = "U9SD23",
         url = "https://example.com/2019/U9SD23.html"
     )
+
+    private val expectedLiveStreamsUrlSuffix =
+        if (BuildConfig.LIVE_STREAMS_URL.isEmpty()) "" else "\n${BuildConfig.LIVE_STREAMS_URL}"
 
     private fun createSessionUrl(slug: String, url: String) =
         if (isPentabarfConfigured()) createPentabarfUrl(slug) else url

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -100,6 +100,7 @@ The following options can be enabled via a `buildConfigField` and configured in 
   - Customize Engelsystem shifts JSON export URL hint via `preference_hint_engelsystem_json_export_url`
 - Feedback system via `SCHEDULE_FEEDBACK_URL`
 - FOSDEM room status via `ENABLE_FOSDEM_ROOM_STATUS`, `FOSDEM_ROOM_STATES_URL`
+- Live streams URL via `LIVE_STREAMS_URL`, inserted when sharing a single session
 
 ## 5. Optional engagements
 


### PR DESCRIPTION
# Description
+ Add the official live streams link to the app so attendees can easily find and open the event broadcast. When sharing an individual session, the shared message now includes the live streams link alongside the session details.
+ Sessions that link to a wiki page continue to use their existing sharing format, without the live streams link.

# Sharing a session / Before & after screenshots
<img width="270" height="600" alt="sharing-live-streams-before" src="https://github.com/user-attachments/assets/3f7338fb-92aa-4678-bb83-b8a0f539d1a7" /> <img width="270" height="600" alt="sharing-live-streams-after" src="https://github.com/user-attachments/assets/5326604d-de68-4621-8c01-feaee8f10015" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)