### PR TITLE
Allow to configure video recordings URL to be included in share action.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,6 +61,7 @@ android {
         buildConfigField("boolean", "ENABLE_FOSDEM_ROOM_STATES", "false")
         buildConfigField("String", "FOSDEM_ROOM_STATES_URL", """""""")
         buildConfigField("String", "LIVE_STREAMS_URL", """""""")
+        buildConfigField("String", "VIDEO_RECORDINGS_URL", """""""")
     }
 
     buildFeatures {
@@ -121,6 +122,7 @@ android {
             buildConfigField("String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", """"#camp23 #CCCamp23 #fahrplan"""")
             buildConfigField("String", "TRACE_DROID_EMAIL_ADDRESS", """"tobias.preuss+camp2023@googlemail.com"""")
             buildConfigField("String", "SCHEDULE_FEEDBACK_URL", """"https://frab.cccv.de/en/camp2023/public/events/%s/feedback/new"""")
+            buildConfigField("String", "VIDEO_RECORDINGS_URL", """"📼 https://media.ccc.de/c/camp2023"""")
         }
         create("ccc39c3") {
             dimension = defaultDimension
@@ -143,6 +145,7 @@ android {
             buildConfigField("String", "SOCIAL_MEDIA_HASHTAGS_HANDLES", """"#39c3 #fahrplan"""")
             buildConfigField("String", "TRACE_DROID_EMAIL_ADDRESS", """"tobias.preuss+39c3@googlemail.com"""")
             buildConfigField("String", "SCHEDULE_FEEDBACK_URL", """""""")
+            buildConfigField("String", "VIDEO_RECORDINGS_URL", """"📼 https://media.ccc.de/c/39c3"""")
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormat.kt
@@ -22,11 +22,15 @@ class SimpleSessionFormat {
         timeZoneId: ZoneId?,
         socialMediaHashtagsHandles: String = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES,
         liveStreamsUrl: String = BuildConfig.LIVE_STREAMS_URL,
+        videoRecordingsUrl: String = BuildConfig.VIDEO_RECORDINGS_URL,
     ): String {
         val builder = StringBuilder()
         builder.appendSession(session, timeZoneId)
         if (liveStreamsUrl.isNotEmpty() && !session.links.containsWikiLink()) {
             builder.appendLiveStreamsUrl(liveStreamsUrl)
+        }
+        if (videoRecordingsUrl.isNotEmpty() && !session.links.containsWikiLink()) {
+            builder.appendVideoRecordingsUrl(videoRecordingsUrl)
         }
         if (socialMediaHashtagsHandles.isNotEmpty()) {
             builder.append(LINE_BREAK)
@@ -75,6 +79,11 @@ class SimpleSessionFormat {
     private fun StringBuilder.appendLiveStreamsUrl(liveStreamsUrl: String) {
         append(LINE_BREAK)
         append(liveStreamsUrl)
+    }
+
+    private fun StringBuilder.appendVideoRecordingsUrl(videoRecordingsUrl: String) {
+        append(LINE_BREAK)
+        append(videoRecordingsUrl)
     }
 
     private fun StringBuilder.appendDivider() {

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -173,7 +173,7 @@ class SessionDetailsViewModelTest {
         fun `OnShareClick emits ShareSimple effect with formatted session`() = runTest {
             val repository = createRepository()
             val fakeSessionFormat = mock<SimpleSessionFormat> {
-                on { format(any(), anyOrNull(), any(), any()) } doReturn "An example session"
+                on { format(any(), anyOrNull(), any(), any(), any()) } doReturn "An example session"
             }
             val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
             viewModel.onViewEvent(OnShareClick)

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -605,7 +605,7 @@ class FahrplanViewModelTest {
         fun `share posts to shareSimple property`() = runTest {
             val repository = createRepository()
             val fakeSessionFormat = mock<SimpleSessionFormat> {
-                on { format(any(), anyOrNull(), any(), any()) } doReturn "session-61"
+                on { format(any(), anyOrNull(), any(), any(), any()) } doReturn "session-61"
             }
             val viewModel = createViewModel(repository, simpleSessionFormat = fakeSessionFormat)
             viewModel.share(Session("61"))

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/sharing/SimpleSessionFormatTest.kt
@@ -24,6 +24,8 @@ class SimpleSessionFormatTest {
         const val SOCIAL_MEDIA_HASHTAGS_HANDLES = "#fahrplan #36c3"
         const val NO_LIVE_STREAMS_URL = ""
         const val LIVE_STREAMS_URL = "https://streaming.media.ccc.de/36c3"
+        const val NO_VIDEO_RECORDINGS_URL = ""
+        const val VIDEO_RECORDINGS_URL = "https://media.ccc.de/c/36c3"
     }
 
     private val systemTimezone = TimeZone.getDefault()
@@ -90,6 +92,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -109,6 +112,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -128,6 +132,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -147,6 +152,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -168,6 +174,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -185,6 +192,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -205,6 +213,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = NO_TIME_ZONE_ID,
                 socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -227,6 +236,91 @@ class SimpleSessionFormatTest {
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
+            )
+        ).isEqualTo(
+            """
+            Angel shifts planning
+            Sonntag, 29. Dezember 2019, 09:00 MEZ (Europe/Berlin), Main hall
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with video recordings URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = VIDEO_RECORDINGS_URL,
+            )
+        ).isEqualTo(
+            """
+            A talk which changes your life
+            Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+            $expectedSession1Url
+            $VIDEO_RECORDINGS_URL
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with social media hashtags and video recordings URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = VIDEO_RECORDINGS_URL,
+            )
+        ).isEqualTo(
+            """
+            A talk which changes your life
+            Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+            $expectedSession1Url
+            $VIDEO_RECORDINGS_URL
+
+            #fahrplan #36c3
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a session with live stream URL and video recordings URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session1,
+                timeZoneId = NO_TIME_ZONE_ID,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = LIVE_STREAMS_URL,
+                videoRecordingsUrl = VIDEO_RECORDINGS_URL,
+            )
+        ).isEqualTo(
+            """
+            A talk which changes your life
+            Freitag, 27. Dezember 2019, 11:00 GMT+01:00, Yellow pavilion
+
+            $expectedSession1Url
+            $LIVE_STREAMS_URL
+            $VIDEO_RECORDINGS_URL
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `format returns formatted multiline text for a wiki session omitting the video recordings URL`() {
+        assertThat(
+            SimpleSessionFormat().format(
+                session = session3,
+                timeZoneId = TIME_ZONE_EUROPE_BERLIN,
+                socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
+                liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -254,7 +348,7 @@ class SimpleSessionFormatTest {
             Freitag, 27. Dezember 2019, 11:00 MEZ (Europe/Berlin), Yellow pavilion
 
             $expectedSession1Url
-            """.trimIndent() + expectedLiveStreamsUrlSuffix
+            """.trimIndent() + expectedLiveStreamsUrlSuffix + expectedVideoRecordingsUrlSuffix
         )
     }
 
@@ -290,6 +384,7 @@ class SimpleSessionFormatTest {
                 timeZoneId = TIME_ZONE_EUROPE_BERLIN,
                 socialMediaHashtagsHandles = NO_SOCIAL_MEDIA_HASHTAGS_HANDLES,
                 liveStreamsUrl = NO_LIVE_STREAMS_URL,
+                videoRecordingsUrl = NO_VIDEO_RECORDINGS_URL,
             )
         ).isEqualTo(
             """
@@ -316,6 +411,9 @@ class SimpleSessionFormatTest {
 
     private val expectedLiveStreamsUrlSuffix =
         if (BuildConfig.LIVE_STREAMS_URL.isEmpty()) "" else "\n${BuildConfig.LIVE_STREAMS_URL}"
+
+    private val expectedVideoRecordingsUrlSuffix =
+        if (BuildConfig.VIDEO_RECORDINGS_URL.isEmpty()) "" else "\n${BuildConfig.VIDEO_RECORDINGS_URL}"
 
     private fun createSessionUrl(slug: String, url: String) =
         if (isPentabarfConfigured()) createPentabarfUrl(slug) else url

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -101,6 +101,7 @@ The following options can be enabled via a `buildConfigField` and configured in 
 - Feedback system via `SCHEDULE_FEEDBACK_URL`
 - FOSDEM room status via `ENABLE_FOSDEM_ROOM_STATUS`, `FOSDEM_ROOM_STATES_URL`
 - Live streams URL via `LIVE_STREAMS_URL`, inserted when sharing a single session
+- Video recording URL via `VIDEO_RECORDINGS_URL`, inserted when sharing a single session
 
 ## 5. Optional engagements
 


### PR DESCRIPTION
# Description
+ Add the official video recordings link to the app so attendees can easily find and watch past talks after the event. When sharing an individual session, the shared message now includes the video recordings link alongside the session details.
+ Sessions that link to a wiki page continue to use their existing sharing format, without the video recordings link.
+ Add video recordings URLs for `cccamp2023` and `ccc39c3` flavors.

# Sharing a session / Before & after screenshots
<img width="270" height="600" alt="sharing-recordings-before" src="https://github.com/user-attachments/assets/08abf23b-0156-4817-b9a4-bc864d7859a8" /> <img width="270" height="600" alt="sharing-recordings-after" src="https://github.com/user-attachments/assets/41868a51-5ab5-4f74-a3d2-2c493db747c3" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)

# Related
- https://github.com/EventFahrplan/EventFahrplan/pull/928