### PR TITLE
Allow customizing social media tags and handles for sharing sessions.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -58,7 +58,7 @@ import nerd.tuxmobil.fahrplan.congress.utils.FeedbackUrlComposition
 internal class SessionDetailsViewModel(
 
     private val repository: AppRepository,
-    settingsRepository: SettingsRepository,
+    private val settingsRepository: SettingsRepository,
     private val executionContext: ExecutionContext,
     private val logging: Logging,
     private val buildConfigProvision: BuildConfigProvision,
@@ -177,7 +177,12 @@ internal class SessionDetailsViewModel(
     private fun share() {
         loadSelectedSession { session ->
             val timeZoneId = repository.readMeta().timeZoneId
-            sendEffect(ShareSimple(simpleSessionFormat.format(session, timeZoneId)))
+            val socialMediaHashtagsHandles = settingsRepository.getSocialMediaHashtagsHandles()
+            sendEffect(ShareSimple(simpleSessionFormat.format(
+                session = session,
+                timeZoneId = timeZoneId,
+                socialMediaHashtagsHandles = socialMediaHashtagsHandles,
+            )))
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/DefaultSettingsRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
 import nerd.tuxmobil.fahrplan.congress.utils.AlarmToneConversion
 
 internal class DefaultSettingsRepository(
@@ -27,6 +28,7 @@ internal class DefaultSettingsRepository(
         private const val INSISTENT_ALARMS_ENABLED_KEY = "insistent"
         private const val SHOW_SCHEDULE_UPDATE_DIALOG_ENABLED_KEY = "show_schedule_update_dialog"
         private const val SHOW_ON_LOCKSCREEN_ENABLED_KEY = "show_on_lockscreen"
+        private const val SOCIAL_MEDIA_HASHTAGS_HANDLES_KEY = "social_media_hashtags_handles"
         private const val ENGELSYSTEM_URL_KEY = "preference_key_engelsystem_json_export_url"
 
         private val settingsDefaults = Settings()
@@ -123,6 +125,18 @@ internal class DefaultSettingsRepository(
         }
     }
 
+    override fun setSocialMediaHashtagsHandles(handles: String) {
+        preferences.edit {
+            putString(SOCIAL_MEDIA_HASHTAGS_HANDLES_KEY, handles)
+        }
+    }
+
+    override fun resetSocialMediaHashtagsHandles() {
+        preferences.edit {
+            remove(SOCIAL_MEDIA_HASHTAGS_HANDLES_KEY)
+        }
+    }
+
     override fun setEngelsystemShiftsUrl(url: String) {
         preferences.edit {
             putString(ENGELSYSTEM_URL_KEY, url)
@@ -142,6 +156,7 @@ internal class DefaultSettingsRepository(
             scheduleRefreshInterval = getScheduleRefreshInterval(),
             isAutoUpdateEnabled = isAutoUpdateEnabled(),
             alternativeScheduleUrl = getAlternativeScheduleUrl(),
+            socialMediaHashtagsHandles = getSocialMediaHashtagsHandles(),
             engelsystemShiftsUrl = getEngelsystemShiftsUrl(),
         )
     }
@@ -206,6 +221,11 @@ internal class DefaultSettingsRepository(
     override fun getAlternativeScheduleUrl(): String {
         val defaultValue = settingsDefaults.alternativeScheduleUrl
         return preferences.getString(ALTERNATIVE_SCHEDULE_URL_KEY, defaultValue)!!
+    }
+
+    override fun getSocialMediaHashtagsHandles(): String {
+        val defaultValue = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES
+        return preferences.getString(SOCIAL_MEDIA_HASHTAGS_HANDLES_KEY, defaultValue)!!
     }
 
     override fun getEngelsystemShiftsUrl(): String {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/Settings.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/Settings.kt
@@ -13,6 +13,7 @@ data class Settings(
     val alarmTime: Int = 10,
     val isShowScheduleUpdateDialogEnabled: Boolean = true,
     val isShowOnLockscreenEnabled: Boolean = true,
+    val socialMediaHashtagsHandles: String = "",
 
     // Backend preferences
     val scheduleRefreshInterval: Int = -1,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/preferences/SettingsRepository.kt
@@ -26,6 +26,9 @@ interface SettingsRepository {
     fun setInsistentAlarms(enable: Boolean)
     fun getAlarmTime(): Int
     fun setAlarmTime(alarmTime: Int)
+    fun getSocialMediaHashtagsHandles(): String
+    fun setSocialMediaHashtagsHandles(handles: String)
+    fun resetSocialMediaHashtagsHandles()
 
     fun getScheduleRefreshInterval(): Int
     fun getScheduleRefreshIntervalDefaultValue(): Int

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -79,6 +79,7 @@ import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage.TitledMessage
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessageScreen
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.schedule.SessionInteractionType.ADD_TO_CALENDAR
 import nerd.tuxmobil.fahrplan.congress.schedule.SessionInteractionType.SHARE
@@ -153,6 +154,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
         val customEngelsystemRoomName = getString(R.string.engelsystem_alias)
         val viewModelFactory = FahrplanViewModelFactory(
             repository = appRepository,
+            settingsRepository = SettingsRepository.getInstance(context),
             alarmServices = alarmServices,
             errorMessageFactory = ErrorMessage.Factory(context),
             notificationHelper = notificationHelper,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModel.kt
@@ -30,6 +30,7 @@ import nerd.tuxmobil.fahrplan.congress.models.Session
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage.TitledMessage
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.ExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
@@ -50,6 +51,7 @@ import kotlin.time.Duration.Companion.milliseconds
 internal class FahrplanViewModel(
 
     private val repository: AppRepository,
+    private val settingsRepository: SettingsRepository,
     private val executionContext: ExecutionContext,
     private val logging: Logging,
     private val errorMessageFactory: ErrorMessage.Factory,
@@ -331,7 +333,12 @@ internal class FahrplanViewModel(
     fun share(session: Session) {
         launch {
             val timeZoneId = repository.readMeta().timeZoneId
-            simpleSessionFormat.format(session, timeZoneId).let { formattedSession ->
+            val socialMediaHashtagsHandles = settingsRepository.getSocialMediaHashtagsHandles()
+            simpleSessionFormat.format(
+                session = session,
+                timeZoneId = timeZoneId,
+                socialMediaHashtagsHandles = socialMediaHashtagsHandles,
+            ).let { formattedSession ->
                 mutableShareSimple.sendOneTimeEvent(formattedSession)
             }
         }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelFactory.kt
@@ -6,6 +6,7 @@ import info.metadude.android.eventfahrplan.commons.logging.Logging
 import nerd.tuxmobil.fahrplan.congress.alarms.AlarmServices
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppExecutionContext
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.sharing.JsonSessionFormat
@@ -14,6 +15,7 @@ import nerd.tuxmobil.fahrplan.congress.sharing.SimpleSessionFormat
 internal class FahrplanViewModelFactory(
 
     private val repository: AppRepository,
+    private val settingsRepository: SettingsRepository,
     private val errorMessageFactory: ErrorMessage.Factory,
     private val alarmServices: AlarmServices,
     private val navigationMenuEntriesGenerator: NavigationMenuEntriesGenerator,
@@ -28,6 +30,7 @@ internal class FahrplanViewModelFactory(
         val logging = Logging.get()
         return FahrplanViewModel(
             repository = repository,
+            settingsRepository = settingsRepository,
             executionContext = AppExecutionContext,
             logging = logging,
             errorMessageFactory = errorMessageFactory,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsEvent.kt
@@ -23,6 +23,10 @@ internal sealed interface SettingsEvent {
     data object AlarmTimeClicked : SettingsEvent
     data class SetAlarmTime(val alarmTime: Int) : SettingsEvent
 
+    data object SocialMediaHashtagsHandlesClicked : SettingsEvent
+    data object ResetSocialMediaHashtagsHandles : SettingsEvent
+    data class SetSocialMediaHashtagsHandles(val handles: String) : SettingsEvent
+
     data object EngelsystemUrlClicked : SettingsEvent
     data class SetEngelsystemShiftsUrl(val url: String) : SettingsEvent
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsListScreen.kt
@@ -40,6 +40,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.widgets.EnableAutomaticUpdatesPr
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.EngelsystemShiftsUrlPreference
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.ExternalClickPreference
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.PreferenceCategory
+import nerd.tuxmobil.fahrplan.congress.settings.widgets.SocialMediaHashtagsHandlesPreference
 import nerd.tuxmobil.fahrplan.congress.settings.widgets.SwitchPreference
 
 @Composable
@@ -71,6 +72,7 @@ internal fun SettingsListScreen(
 
                 CategoryGeneral(state, showDivider, onViewEvent)
                 CategoryAlarms(state, showDivider, onViewEvent)
+                CategorySharing(state, onViewEvent)
 
                 if (state.isEngelsystemCategoryVisible) {
                     CategoryEngelsystem(state, onViewEvent)
@@ -201,6 +203,19 @@ private fun CategoryAlarms(
             title = stringResource(R.string.preference_title_alarm_time),
             subtitle = state.settings.alarmTimeToUiString(),
             onClick = { onViewEvent(AlarmTimeClicked) },
+        )
+    }
+}
+
+@Composable
+private fun CategorySharing(
+    state: SettingsUiState,
+    onViewEvent: (SettingsEvent) -> Unit,
+) {
+    PreferenceCategory(stringResource(R.string.preference_sharing_category_title)) {
+        SocialMediaHashtagsHandlesPreference(
+            socialMediaHashtagsHandles = state.settings.socialMediaHashtagsHandles,
+            onViewEvent = onViewEvent,
         )
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsNavigationDestination.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsNavigationDestination.kt
@@ -6,5 +6,6 @@ internal sealed class SettingsNavigationDestination(val route: String) {
     data object ScheduleStatistic : SettingsNavigationDestination("schedule_statistic")
     data object AlternativeScheduleUrl : SettingsNavigationDestination("alternative_schedule_url")
     data object AlarmTime : SettingsNavigationDestination("alarm_time")
+    data object SocialMediaHashtagsHandles : SettingsNavigationDestination("social_media_hashtags_handles")
     data object EngelSystemUrl : SettingsNavigationDestination("engelsystem_url")
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsScreen.kt
@@ -30,17 +30,20 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateBack
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.NavigateTo
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.PickAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEffect.SetActivityResult
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ResetSocialMediaHashtagsHandles
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetEngelsystemShiftsUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetScheduleRefreshInterval
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetSocialMediaHashtagsHandles
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.EngelSystemUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleStatistic
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.SettingsList
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.SocialMediaHashtagsHandles
 
 @Composable
 internal fun SettingsScreen(
@@ -105,6 +108,14 @@ internal fun SettingsScreen(
                 currentValue = state.settings.alarmTime,
                 onOptionSelected = { viewModel.onViewEvent(SetAlarmTime(it)) },
                 onDismiss = { navController.popBackStack() },
+            )
+        }
+        dialog(route = SocialMediaHashtagsHandles.route) {
+            SocialMediaHashtagsHandlesDialog(
+                currentValue = state.settings.socialMediaHashtagsHandles,
+                onValueChanged = { viewModel.onViewEvent(SetSocialMediaHashtagsHandles(it)) },
+                onReset = { viewModel.onViewEvent(ResetSocialMediaHashtagsHandles) },
+                onDismiss = { navController.popBackStack() }
             )
         }
         dialog(route = EngelSystemUrl.route) {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SettingsViewModel.kt
@@ -33,6 +33,7 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.DeviceTimezoneClic
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.EngelsystemUrlClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.FastSwipingClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.InsistentAlarmClicked
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ResetSocialMediaHashtagsHandles
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ShowOnLockscreenClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleRefreshIntervalClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.ScheduleStatisticClicked
@@ -42,11 +43,14 @@ import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlarmTone
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetAlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetEngelsystemShiftsUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetScheduleRefreshInterval
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SetSocialMediaHashtagsHandles
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SocialMediaHashtagsHandlesClicked
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlarmTime
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.AlternativeScheduleUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.EngelSystemUrl
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleRefreshInterval
 import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.ScheduleStatistic
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsNavigationDestination.SocialMediaHashtagsHandles
 
 internal class SettingsViewModel(
     appRepository: AppRepository,
@@ -89,6 +93,9 @@ internal class SettingsViewModel(
         InsistentAlarmClicked -> toggleInsistentAlarmsEnabled()
         AlarmTimeClicked -> navigateTo(AlarmTime)
         is SetAlarmTime -> updateAlarmTime(event.alarmTime)
+        SocialMediaHashtagsHandlesClicked -> navigateTo(SocialMediaHashtagsHandles)
+        is SetSocialMediaHashtagsHandles -> updateSocialMediaHashtagsHandles(event.handles)
+        ResetSocialMediaHashtagsHandles -> resetSocialMediaHashtagsHandles()
         EngelsystemUrlClicked -> navigateTo(EngelSystemUrl)
         is SetEngelsystemShiftsUrl -> updateEngelsystemShiftsUrl(event.url)
     }
@@ -166,6 +173,16 @@ internal class SettingsViewModel(
     private fun updateEngelsystemShiftsUrl(url: String) {
         settingsRepository.setEngelsystemShiftsUrl(url)
         updateActivityResult(ENGELSYSTEM_SHIFTS_URL_UPDATED)
+        navigateBack()
+    }
+
+    private fun updateSocialMediaHashtagsHandles(handles: String) {
+        settingsRepository.setSocialMediaHashtagsHandles(handles)
+        navigateBack()
+    }
+
+    private fun resetSocialMediaHashtagsHandles() {
+        settingsRepository.resetSocialMediaHashtagsHandles()
         navigateBack()
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SocialMediaHashtagsHandlesDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/SocialMediaHashtagsHandlesDialog.kt
@@ -1,0 +1,47 @@
+package nerd.tuxmobil.fahrplan.congress.settings
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import nerd.tuxmobil.fahrplan.congress.BuildConfig
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
+import nerd.tuxmobil.fahrplan.congress.settings.widgets.PreferenceTextInputDialog
+import nerd.tuxmobil.fahrplan.congress.utils.Validation
+import nerd.tuxmobil.fahrplan.congress.utils.Validation.ValidationResult
+
+@Composable
+internal fun SocialMediaHashtagsHandlesDialog(
+    currentValue: String,
+    onValueChanged: (String) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    PreferenceTextInputDialog(
+        title = stringResource(R.string.preference_title_social_media_hashtags_handles),
+        value = currentValue,
+        placeholder = stringResource(R.string.preference_hint_social_media_hashtags_handles),
+        validator = NoOpValidator,
+        resetValue = BuildConfig.SOCIAL_MEDIA_HASHTAGS_HANDLES,
+        onValueChanged = onValueChanged,
+        onReset = onReset,
+        onDismiss = onDismiss,
+    )
+}
+
+private object NoOpValidator : Validation {
+    override fun validate(input: String) = ValidationResult.Success
+}
+
+@PreviewLightDark
+@Composable
+internal fun SocialMediaHashtagsHandlesDialogPreview() {
+    EventFahrplanTheme {
+        SocialMediaHashtagsHandlesDialog(
+            currentValue = "",
+            onValueChanged = {},
+            onReset = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/PreferenceTextInputDialog.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/PreferenceTextInputDialog.kt
@@ -1,6 +1,8 @@
 package nerd.tuxmobil.fahrplan.congress.settings.widgets
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeContentPadding
@@ -17,29 +19,35 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.buttons.ButtonText
 import nerd.tuxmobil.fahrplan.congress.designsystem.dialogs.AlertDialog
 import nerd.tuxmobil.fahrplan.congress.designsystem.inputs.TextFieldOutlined
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.utils.Validation
-import nerd.tuxmobil.fahrplan.congress.utils.Validation.ValidationResult
+import nerd.tuxmobil.fahrplan.congress.utils.Validation.ValidationResult.Error
+import nerd.tuxmobil.fahrplan.congress.utils.Validation.ValidationResult.Success
 import nerd.tuxmobil.fahrplan.congress.utils.compose.RequestFocusOnLaunch
 
 @Composable
 internal fun PreferenceTextInputDialog(
     title: String,
     value: String,
+    resetValue: String? = null,
     placeholder: String,
     validator: Validation,
     onValueChanged: (String) -> Unit,
+    onReset: (() -> Unit)? = null,
     onDismiss: () -> Unit,
 ) {
     var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(value))
     }
+    var isReset by rememberSaveable { mutableStateOf(false) }
     var errorText by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
+    val trimmedText = textFieldValue.text.trim()
 
     AlertDialog(
         title = { Text(title) },
@@ -47,20 +55,22 @@ internal fun PreferenceTextInputDialog(
             RequestFocusOnLaunch(focusRequester)
 
             Column {
-                val text = textFieldValue.text
-                errorText = if (text.isBlank()) {
+                errorText = if (trimmedText.isBlank()) {
                     null
                 } else {
-                    when (val validationResult = validator.validate(text)) {
-                        ValidationResult.Success -> null
-                        is ValidationResult.Error -> validationResult.errorMessage
+                    when (val validationResult = validator.validate(trimmedText)) {
+                        Success -> null
+                        is Error -> validationResult.errorMessage
                     }
                 }
 
                 TextFieldOutlined(
                     value = textFieldValue,
                     placeholder = { Text(text = placeholder, maxLines = 1) },
-                    onValueChange = { textFieldValue = it },
+                    onValueChange = {
+                        textFieldValue = it
+                        isReset = false
+                    },
                     singleLine = true,
                     isError = errorText != null,
                     modifier = Modifier
@@ -78,16 +88,33 @@ internal fun PreferenceTextInputDialog(
             }
         },
         confirmButton = {
-            ButtonText(
-                enabled = errorText == null,
-                onClick = { onValueChanged(textFieldValue.text) },
-            ) {
-                Text(stringResource(android.R.string.ok))
-            }
-        },
-        dismissButton = {
-            ButtonText(onClick = onDismiss) {
-                Text(stringResource(android.R.string.cancel))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                if (resetValue != null && onReset != null) {
+                    ButtonText(
+                        onClick = {
+                            textFieldValue = TextFieldValue(resetValue)
+                            isReset = true
+                        }
+                    ) {
+                        Text(stringResource(R.string.preference_dialog_action_reset))
+                    }
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                ButtonText(onClick = onDismiss) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                ButtonText(
+                    enabled = errorText == null,
+                    onClick = {
+                        if (isReset || trimmedText == resetValue) {
+                            onReset?.invoke()
+                        } else {
+                            onValueChanged(trimmedText)
+                        }
+                    },
+                ) {
+                    Text(stringResource(android.R.string.ok))
+                }
             }
         },
         onDismissRequest = onDismiss,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/SocialMediaHashtagsHandlesPreference.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/settings/widgets/SocialMediaHashtagsHandlesPreference.kt
@@ -1,0 +1,25 @@
+package nerd.tuxmobil.fahrplan.congress.settings.widgets
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import nerd.tuxmobil.fahrplan.congress.R
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent
+import nerd.tuxmobil.fahrplan.congress.settings.SettingsEvent.SocialMediaHashtagsHandlesClicked
+
+@Composable
+internal fun SocialMediaHashtagsHandlesPreference(
+    socialMediaHashtagsHandles: String,
+    showDivider: Boolean = false,
+    onViewEvent: (SettingsEvent) -> Unit,
+) {
+    val subtitle = socialMediaHashtagsHandles.ifEmpty {
+        stringResource(R.string.preference_summary_social_media_hashtags_handles)
+    }
+
+    ClickPreference(
+        title = stringResource(R.string.preference_title_social_media_hashtags_handles),
+        subtitle = subtitle,
+        showDivider = showDivider,
+        onClick = { onViewEvent(SocialMediaHashtagsHandlesClicked) },
+    )
+}

--- a/app/src/main/res/values-de/preferences.xml
+++ b/app/src/main/res/values-de/preferences.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+    <!-- Preference dialog actions -->
+    <string name="preference_dialog_action_reset">Zurücksetzen</string>
+
     <!-- App notification settings -->
     <string name="preference_title_app_notification_settings">Benachrichtigungen anpassen</string>
     <string name="preference_summary_app_notification_settings">Öffne den dazugehörigen System-Einstellungen-Bildschirm von hier.</string>
@@ -64,6 +67,12 @@
     <!-- Insistent session alarms -->
     <string name="preference_title_insistent_alarms_enabled">Dauerhaften Alarm anschalten</string>
     <string name="preference_summary_insistent_alarms_enabled">Lässt einen Alarm unendlich lange klingeln.</string>
+
+    <!-- Category Sharing -->
+
+    <string name="preference_sharing_category_title">Teilen</string>
+    <string name="preference_title_social_media_hashtags_handles">Hashtags &amp; Social Media Handles konfigurieren</string>
+    <string name="preference_summary_social_media_hashtags_handles">Wird beim Teilen einer Sitzung angehängt. Leer lassen, um keine hinzuzufügen.</string>
 
     <!-- Category Engelsystem -->
 

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
 
+    <!-- Preference dialog actions -->
+    <string name="preference_dialog_action_reset">Reset</string>
+
     <!-- Category development -->
 
     <!-- Schedule refresh interval -->
@@ -84,6 +87,13 @@
     <!-- Insistent session alarms -->
     <string name="preference_title_insistent_alarms_enabled">Enable insistent alarm</string>
     <string name="preference_summary_insistent_alarms_enabled">Keeps an alarm on infinitely.</string>
+
+    <!-- Category Sharing -->
+
+    <string name="preference_sharing_category_title">Sharing</string>
+    <string name="preference_title_social_media_hashtags_handles">Configure hashtags &amp; social media handles</string>
+    <string name="preference_summary_social_media_hashtags_handles">Appended when sharing a session. Leave empty to not include any.</string>
+    <string name="preference_hint_social_media_hashtags_handles" translatable="false">#event #hashtag @handle</string>
 
     <!-- Category Engelsystem -->
 

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModelTest.kt
@@ -642,6 +642,7 @@ class SessionDetailsViewModelTest {
         settingsStream: Flow<Settings> = emptyFlow(),
     ) = mock<SettingsRepository> {
         on { this.settingsStream } doReturn settingsStream
+        on { getSocialMediaHashtagsHandles() } doReturn ""
     }
 
     private fun createViewModel(

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanViewModelTest.kt
@@ -29,6 +29,7 @@ import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage.SimpleMessage
 import nerd.tuxmobil.fahrplan.congress.net.errors.ErrorMessage.TitledMessage
 import nerd.tuxmobil.fahrplan.congress.notifications.NotificationHelper
+import nerd.tuxmobil.fahrplan.congress.preferences.SettingsRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.AppRepository
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState
 import nerd.tuxmobil.fahrplan.congress.repositories.LoadScheduleState.FetchFailure
@@ -580,7 +581,7 @@ class FahrplanViewModelTest {
         fun `addAlarm invokes alarmService function`() {
             val repository = createRepository()
             val alarmServices = mock<AlarmServices>()
-            val viewModel = createViewModel(repository, alarmServices)
+            val viewModel = createViewModel(repository, alarmServices = alarmServices)
             val session = Session("session-97")
             viewModel.addAlarm(session, alarmTime = 0)
             verifyInvokedOnce(alarmServices).addSessionAlarm(session, alarmTimeOffset = 0)
@@ -590,7 +591,7 @@ class FahrplanViewModelTest {
         fun `deleteAlarm invokes alarmService function`() {
             val repository = createRepository()
             val alarmServices = mock<AlarmServices>()
-            val viewModel = createViewModel(repository, alarmServices)
+            val viewModel = createViewModel(repository, alarmServices = alarmServices)
             val session = Session("session-97")
             viewModel.deleteAlarm(session)
             verifyInvokedOnce(alarmServices).deleteSessionAlarm(session)
@@ -796,8 +797,13 @@ class FahrplanViewModelTest {
         on { getMessageForParsingResult(any()) } doReturn SimpleMessage("fake message")
     }
 
+    private fun createSettingsRepository() = mock<SettingsRepository> {
+        on { getSocialMediaHashtagsHandles() } doReturn ""
+    }
+
     private fun createViewModel(
         repository: AppRepository,
+        settingsRepository: SettingsRepository = createSettingsRepository(),
         alarmServices: AlarmServices = mock(),
         errorMessageFactory: ErrorMessage.Factory = createFakeErrorMessageFactory(),
         notificationHelper: NotificationHelper = mock(),
@@ -807,6 +813,7 @@ class FahrplanViewModelTest {
         runsAtLeastOnAndroidTiramisu: Boolean = false
     ) = FahrplanViewModel(
         repository = repository,
+        settingsRepository = settingsRepository,
         executionContext = TestExecutionContext,
         logging = NoLogging,
         errorMessageFactory = errorMessageFactory,

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -90,7 +90,7 @@ associated [README](../assets/empty-states/README.md).
 The following options can be enabled via a `buildConfigField` and configured in *app/build.gradle.kts* as needed.
 
 - Event postal address for easy map navigation via `EVENT_POSTAL_ADDRESS`
-- Social media hashtags/handles for the event via `SOCIAL_MEDIA_HASHTAGS_HANDLES`
+- Social media hashtags/handles for the event via `SOCIAL_MEDIA_HASHTAGS_HANDLES`, users can override this value in the app's settings
 - Alternative schedule URL via `ENABLE_ALTERNATIVE_SCHEDULE_URL`
 - c3nav integration via `C3NAV_URL`
 - Chaosflix export via `ENABLE_CHAOSFLIX_EXPORT`


### PR DESCRIPTION
# Description
+ Add a `Sharing` preference that lets users override the event's configured social media hashtags and handles. Persist the custom value and provide a reset action that restores the preconfigured default.
+ Apply the configured value when sharing a single session from both the schedule and session details screens. Keep multi-session sharing unchanged.

# New "Sharing" category in settings screen
<img width="270" height="600" alt="settings-screen" src="https://github.com/user-attachments/assets/fa332169-ff20-4435-a8eb-9bebd9853d56" />

# Configure hashtags & social media handles dialog
<img width="270" height="600" alt="settings-screen-dialog" src="https://github.com/user-attachments/assets/2e9fc66e-e719-41e3-b8ba-b411500ab299" />

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)