### PR TITLE
Shake alarm icon when being added to session card.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopAppBar.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/bars/TopAppBar.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.designsystem.bars
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
@@ -10,7 +9,6 @@ import nerd.tuxmobil.fahrplan.congress.extensions.safeDrawingHorizontalAndTop
 import androidx.compose.material3.TopAppBar as Material3TopAppBar
 import androidx.compose.material3.TopAppBarDefaults as Material3TopAppBarDefaults
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopAppBar(
     title: @Composable () -> Unit,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/favorites/StarredListComposables.kt
@@ -2,7 +2,6 @@ package nerd.tuxmobil.fahrplan.congress.favorites
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -295,7 +294,6 @@ private fun LazyListScope.searchResultItems(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun CheckableItem(
     checked: Boolean,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -141,6 +141,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
      * Used to redraw only the rooms that visually change (e.g. because a session is favored)
      */
     private val renderedRoomHashByRoomName = mutableMapOf<String, Int>()
+    private val renderedAlarmState = RenderedAlarmState()
 
     private var currentDayIndex = -1
 
@@ -475,9 +476,12 @@ class FahrplanFragment : Fragment(), MenuProvider {
         if (currentDayIndex != scheduleData.dayIndex || columnsLayout.childCount != roomDataList.size) {
             columnsLayout.removeAllViews()
             renderedRoomHashByRoomName.clear()
+            renderedAlarmState.clear()
         }
 
         currentDayIndex = scheduleData.dayIndex
+
+        val newlyAddedAlarmSessionIds = renderedAlarmState.findNewlyAddedAlarmSessionIds(roomDataList)
 
         var skippedCount = 0
         var renderedCount = 0
@@ -509,6 +513,7 @@ class FahrplanFragment : Fragment(), MenuProvider {
                 setContent {
                     RoomColumn(
                         columnData = roomColumnData,
+                        newlyAddedAlarmSessionIds = newlyAddedAlarmSessionIds,
                         onSessionClick = { sessionId ->
                             val session = roomData.sessions.first { it.sessionId == sessionId }
                             logging.d(LOG_TAG, """Click on: "${session.title}"""")
@@ -540,6 +545,8 @@ class FahrplanFragment : Fragment(), MenuProvider {
             columnsLayout.addView(roomColumnView, roomIndex)
             renderedRoomHashByRoomName[roomData.roomName] = roomData.hashCode()
         }
+
+        renderedAlarmState.remember(roomDataList)
 
         logging.report(LOG_TAG, buildString {
             append("addRoomColumns.complete: ")

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/RenderedAlarmState.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/RenderedAlarmState.kt
@@ -1,0 +1,32 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import nerd.tuxmobil.fahrplan.congress.models.RoomData
+
+class RenderedAlarmState {
+
+    private val hasAlarmBySessionId = mutableMapOf<String, Boolean>()
+
+    fun clear() = hasAlarmBySessionId.clear()
+
+    fun findNewlyAddedAlarmSessionIds(roomDataList: List<RoomData>) =
+        roomDataList
+            .asSequence()
+            .flatMap { it.sessions }
+            .filter { session ->
+                val hadNoAlarmWhenLastRendered = hasAlarmBySessionId[session.sessionId] == false
+                hadNoAlarmWhenLastRendered && session.hasAlarm
+            }
+            .map { it.sessionId }
+            .toSet()
+
+    fun remember(roomDataList: List<RoomData>) {
+        hasAlarmBySessionId.clear()
+        roomDataList
+            .asSequence()
+            .flatMap { it.sessions }
+            .forEach { session ->
+                hasAlarmBySessionId[session.sessionId] = session.hasAlarm
+            }
+    }
+
+}

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -1,5 +1,7 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
@@ -21,6 +23,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,6 +33,8 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
@@ -71,6 +76,7 @@ import nerd.tuxmobil.fahrplan.congress.schedule.SessionInteractionType.TOGGLE_FA
 @Composable
 fun RoomColumn(
     columnData: RoomColumnData,
+    newlyAddedAlarmSessionIds: Set<String> = emptySet(),
     onSessionClick: (String) -> Unit,
     onSessionInteraction: (String, SessionInteractionType) -> Unit
 ) {
@@ -88,7 +94,12 @@ fun RoomColumn(
 
                 SessionCard(
                     data = sessionData,
-                    sessionCardLayout = { SessionCardLayout(sessionData) },
+                    sessionCardLayout = {
+                        SessionCardLayout(
+                            data = sessionData,
+                            shakeAlarmIconOnEnter = sessionData.sessionId in newlyAddedAlarmSessionIds,
+                        )
+                    },
                     onClick = { onSessionClick(sessionData.sessionId) },
                     onMenuItemClick = { onSessionInteraction(sessionData.sessionId, it) },
                 )
@@ -175,7 +186,10 @@ fun SessionCard(
 
 @Suppress("kotlin:S107")
 @Composable
-private fun SessionCardLayout(data: SessionCardData) {
+private fun SessionCardLayout(
+    data: SessionCardData,
+    shakeAlarmIconOnEnter: Boolean = false,
+) {
     Column(
         modifier = Modifier
             .padding(horizontal = dimensionResource(R.dimen.session_drawable_inner_padding))
@@ -212,6 +226,7 @@ private fun SessionCardLayout(data: SessionCardData) {
                         if (data.hasAlarm) {
                             AlarmIcon(
                                 modifier = Modifier.padding(start = 4.dp),
+                                shakeOnEnter = shakeAlarmIconOnEnter,
                             )
                         }
                     }
@@ -448,12 +463,30 @@ private fun TrackName(
     }
 }
 
+private val ALARM_ICON_ROTATION_VALUES = listOf(-20f, 20f, -14f, 14f, -8f, 8f, 0f)
+private val ALARM_ICON_ANIMATION_SPEC = tween<Float>(durationMillis = 80)
+private val ALARM_ICON_TRANSFORM_ORIGIN = TransformOrigin(0.5f, 0.15f)
+
 @Composable
 private fun AlarmIcon(
     modifier: Modifier = Modifier,
+    shakeOnEnter: Boolean = false,
 ) {
+    val shaking = remember { Animatable(0f) }
+    LaunchedEffect(shakeOnEnter) {
+        if (shakeOnEnter) {
+            ALARM_ICON_ROTATION_VALUES.forEach { targetRotation ->
+                shaking.animateTo(targetRotation, ALARM_ICON_ANIMATION_SPEC)
+            }
+        }
+    }
+
     IconDecorative(
         modifier = modifier
+            .graphicsLayer {
+                rotationZ = shaking.value
+                transformOrigin = ALARM_ICON_TRANSFORM_ORIGIN
+            }
             .size(dimensionResource(R.dimen.session_drawable_icon_size))
             .padding(dimensionResource(R.dimen.session_drawable_icon_padding)),
         icon = R.drawable.ic_bell_on_session,

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/ScheduleComposables.kt
@@ -1,7 +1,6 @@
 package nerd.tuxmobil.fahrplan.congress.schedule
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -28,7 +27,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterVertically
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -100,7 +98,6 @@ fun RoomColumn(
 }
 
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
 fun SessionCard(
     data: SessionCardData,

--- a/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/RenderedAlarmStateTest.kt
+++ b/app/src/test/java/nerd/tuxmobil/fahrplan/congress/schedule/RenderedAlarmStateTest.kt
@@ -1,0 +1,67 @@
+package nerd.tuxmobil.fahrplan.congress.schedule
+
+import com.google.common.truth.Truth.assertThat
+import nerd.tuxmobil.fahrplan.congress.models.RoomData
+import nerd.tuxmobil.fahrplan.congress.models.Session
+import org.junit.jupiter.api.Test
+
+class RenderedAlarmStateTest {
+
+    private val renderedAlarmState = RenderedAlarmState()
+
+    @Test
+    fun `findNewlyAddedAlarmSessionIds returns empty set for sessions without previous rendered state`() {
+        val roomDataList = listOf(
+            createRoomData(
+                Session(sessionId = "session-1", hasAlarm = true)
+            )
+        )
+        val sessionIds = renderedAlarmState.findNewlyAddedAlarmSessionIds(roomDataList)
+        assertThat(sessionIds).isEmpty()
+    }
+
+    @Test
+    fun `findNewlyAddedAlarmSessionIds returns session ids for alarms added since previous render`() {
+        renderedAlarmState.remember(
+            listOf(
+                createRoomData(
+                    Session(sessionId = "session-1", hasAlarm = false),
+                    Session(sessionId = "session-2", hasAlarm = true),
+                )
+            )
+        )
+        val roomDataList = listOf(
+            createRoomData(
+                Session(sessionId = "session-1", hasAlarm = true),
+                Session(sessionId = "session-2", hasAlarm = true),
+            )
+        )
+        val sessionIds = renderedAlarmState.findNewlyAddedAlarmSessionIds(roomDataList)
+        assertThat(sessionIds).containsExactly("session-1")
+    }
+
+    @Test
+    fun `findNewlyAddedAlarmSessionIds returns empty set after clear`() {
+        renderedAlarmState.remember(
+            listOf(
+                createRoomData(
+                    Session(sessionId = "session-1", hasAlarm = false)
+                )
+            )
+        )
+        renderedAlarmState.clear()
+        val roomDataList = listOf(
+            createRoomData(
+                Session(sessionId = "session-1", hasAlarm = true)
+            )
+        )
+        val sessionIds = renderedAlarmState.findNewlyAddedAlarmSessionIds(roomDataList)
+        assertThat(sessionIds).isEmpty()
+    }
+
+    private fun createRoomData(vararg sessions: Session) = RoomData(
+        roomName = "room",
+        sessions = sessions.toList(),
+    )
+
+}


### PR DESCRIPTION
# Description
+ Give visual feedback when an alarm is added to a session by briefly shaking the bell icon on that session's card.
+ `FahrplanFragment` now records the alarm state per session that was last rendered (`renderedAlarmState`). On the next update, a session whose state transitions from "no alarm" to "has alarm" is collected (`hasAlarmBySessionId`) and its icon is animated. Sessions that were never rendered before do not animate, so nothing shakes on initial load.
+ The set is forwarded through `RoomColumn` and `SessionCardLayout` to `AlarmIcon` via `shakeOnEnter`.
+ The icon rotates through a short keyframe sequence driven by an `Animatable` and applied with a `graphicsLayer` whose transform origin sits near the top of the bell.
+ Unrelated: Remove no longer needed opt-in annotation.

# Alarm bell icon shakes when alarm is scheduled

https://github.com/user-attachments/assets/efc98381-825d-48ec-b8b6-a4d618cae866

# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)