### PR TITLE
Improve layout of empty screens: text readability, visibility of graphic.

### DIFF
--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
@@ -10,12 +10,14 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
 import androidx.compose.ui.unit.dp
@@ -29,35 +31,42 @@ fun NoData(
     @DrawableRes emptyContent: Int,
     title: String,
     subtitle: String,
+    modifier: Modifier = Modifier,
+    onContentSizeChanged: (IntSize) -> Unit = {},
 ) {
     Column(
-        Modifier
+        modifier
             .fillMaxSize()
             .padding(dimensionResource(R.dimen.empty_screen_padding)),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Image(
-            modifier = Modifier.padding(dimensionResource(R.dimen.empty_screen_drawable_padding)),
-            painter = painterResource(emptyContent),
-            contentDescription = null,
-        )
-        Text(
-            text = title,
-            textAlign = TextAlign.Center,
-            fontWeight = FontWeight.Bold,
-            fontSize = dimensionResource(R.dimen.empty_screen_text).toTextUnit(),
-            lineHeight = TextUnit(1.5f, TextUnitType.Em),
-        )
-        Text(
-            modifier = Modifier
-                .widthIn(max = dimensionResource(R.dimen.empty_screen_subtitle_max_width))
-                .padding(top = dimensionResource(R.dimen.empty_screen_subtitle_padding_top)),
-            text = subtitle,
-            textAlign = TextAlign.Center,
-            fontSize = dimensionResource(R.dimen.empty_screen_text).toTextUnit(),
-            lineHeight = TextUnit(1.5f, TextUnitType.Em),
-        )
+        Column(
+            modifier = Modifier.onSizeChanged(onContentSizeChanged),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Image(
+                modifier = Modifier.padding(dimensionResource(R.dimen.empty_screen_drawable_padding)),
+                painter = painterResource(emptyContent),
+                contentDescription = null,
+            )
+            Text(
+                text = title,
+                textAlign = TextAlign.Center,
+                fontWeight = FontWeight.Bold,
+                fontSize = dimensionResource(R.dimen.empty_screen_text).toTextUnit(),
+                lineHeight = TextUnit(1.5f, TextUnitType.Em),
+            )
+            Text(
+                modifier = Modifier
+                    .widthIn(max = dimensionResource(R.dimen.empty_screen_subtitle_max_width))
+                    .padding(top = dimensionResource(R.dimen.empty_screen_subtitle_padding_top)),
+                text = subtitle,
+                textAlign = TextAlign.Center,
+                fontSize = dimensionResource(R.dimen.empty_screen_text).toTextUnit(),
+                lineHeight = TextUnit(1.5f, TextUnitType.Em),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/designsystem/screenstates/NoData.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -17,6 +18,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
 import nerd.tuxmobil.fahrplan.congress.R
 import nerd.tuxmobil.fahrplan.congress.designsystem.texts.Text
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
@@ -48,7 +50,9 @@ fun NoData(
             lineHeight = TextUnit(1.5f, TextUnitType.Em),
         )
         Text(
-            modifier = Modifier.padding(top = dimensionResource(R.dimen.empty_screen_subtitle_padding_top)),
+            modifier = Modifier
+                .widthIn(max = dimensionResource(R.dimen.empty_screen_subtitle_max_width))
+                .padding(top = dimensionResource(R.dimen.empty_screen_subtitle_padding_top)),
             text = subtitle,
             textAlign = TextAlign.Center,
             fontSize = dimensionResource(R.dimen.empty_screen_text).toTextUnit(),

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/extensions/ViewExtensions.kt
@@ -11,6 +11,7 @@ import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 
 /**
  * See [ViewCompat.requireViewById].
@@ -22,10 +23,17 @@ fun View.applyEdgeToEdgeInsets(
     typeMask: Int = systemBars() or displayCutout() or ime(),
 ) {
     ViewCompat.setOnApplyWindowInsetsListener(this) { _, windowInsets ->
-        val insets = windowInsets.getInsets(typeMask)
-        WindowInsetsCompat.Builder()
-            .setInsets(typeMask, insets)
-            .build()
+        val builder = WindowInsetsCompat.Builder()
+        // Insets must be queried and set per individual type: WindowInsetsCompat#getInsets()
+        // returns the union of all types in the given mask, so building the result with the
+        // combined mask would make every type in it report that same union instead of its own
+        // value (e.g. ime() would report max(systemBars, displayCutout, ime) instead of ime).
+        for (type in listOf(systemBars(), displayCutout(), ime())) {
+            if (typeMask and type != 0) {
+                builder.setInsets(type, windowInsets.getInsets(type))
+            }
+        }
+        builder.build()
     }
 }
 
@@ -50,6 +58,20 @@ fun View.applyRightInsets(
         view.updateLayoutParams<MarginLayoutParams> {
             rightMargin = insets.right
         }
+        windowInsets
+    }
+}
+
+/**
+ * Grows the view's bottom padding by the IME height so vertically centered content
+ * (e.g. via `android:layout_centerInParent`) re-centers above the keyboard instead of
+ * staying centered behind it.
+ */
+fun View.applyImeBottomPadding() {
+    val initialPaddingBottom = paddingBottom
+    ViewCompat.setOnApplyWindowInsetsListener(this) { view, windowInsets ->
+        val imeBottomInset = windowInsets.getInsets(ime()).bottom
+        view.updatePadding(bottom = initialPaddingBottom + imeBottomInset)
         windowInsets
     }
 }

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/FahrplanFragment.kt
@@ -66,6 +66,7 @@ import nerd.tuxmobil.fahrplan.congress.commons.ResourceResolver
 import nerd.tuxmobil.fahrplan.congress.contract.BundleKeys
 import nerd.tuxmobil.fahrplan.congress.designsystem.themes.EventFahrplanTheme
 import nerd.tuxmobil.fahrplan.congress.extensions.applyHorizontalInsets
+import nerd.tuxmobil.fahrplan.congress.extensions.applyImeBottomPadding
 import nerd.tuxmobil.fahrplan.congress.extensions.applyRightInsets
 import nerd.tuxmobil.fahrplan.congress.extensions.getLayoutInflater
 import nerd.tuxmobil.fahrplan.congress.extensions.isLandscape
@@ -245,6 +246,8 @@ class FahrplanFragment : Fragment(), MenuProvider {
 
         val timeTextColumn = view.requireViewByIdCompat<LinearLayout>(R.id.times_layout)
         timeTextColumnEdgeToEdge.applyInsets(view, timeTextColumn)
+
+        view.requireViewByIdCompat<View>(R.id.schedule_no_content_view).applyImeBottomPadding()
 
         view.requireViewByIdCompat<ComposeView>(R.id.alarm_time_picker_view)
             .setContent {

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/search/SearchComposables.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -25,13 +27,16 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment.Companion.BottomCenter
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -40,6 +45,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -281,7 +287,23 @@ private fun ClearSearchQueryIcon() {
 
 @Composable
 private fun NoSearchResult(onBack: () -> Unit) {
+    val imeWindowInsets = WindowInsets.ime
+    var containerHeightPx by remember { mutableIntStateOf(0) }
+    var contentHeightPx by remember { mutableIntStateOf(0) }
     NoData(
+        // Shifts the whole illustration + text block up together as one unit, instead of
+        // shrinking the surrounding box (which re-centers image and text independently and
+        // can visibly separate them as the keyboard height changes). The shift is capped to
+        // the room available above the centered content, so it never moves up past the top
+        // of this area into the SearchQueryInputField and SearchFilters above it.
+        modifier = Modifier
+            .onSizeChanged { containerHeightPx = it.height }
+            .offset {
+                val wantedShift = imeWindowInsets.getBottom(this) / 2
+                val maxShift = ((containerHeightPx - contentHeightPx) / 2).coerceAtLeast(0)
+                IntOffset(x = 0, y = -wantedShift.coerceIn(0, maxShift))
+            },
+        onContentSizeChanged = { contentHeightPx = it.height },
         emptyContent = R.drawable.no_search_results,
         title = stringResource(R.string.search_no_search_result_title),
         subtitle = stringResource(R.string.search_no_search_result_subtitle),

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -84,6 +84,7 @@
     <dimen name="empty_screen_text">16sp</dimen>
     <dimen name="empty_screen_line_spacing_extra">6sp</dimen>
     <dimen name="empty_screen_subtitle_padding_top">16dp</dimen>
+    <dimen name="empty_screen_subtitle_max_width">250dp</dimen>
     <dimen name="empty_screen_drawable_padding">16dp</dimen>
     <dimen name="empty_screen_padding">16dp</dimen>
 


### PR DESCRIPTION
# Description
+ Improve readability of empty screen text by limiting its width.
+ Move empty screen illustration up when keyboard is open. 
  + Affects search screen on tablets in landscape mode and phones.
  + Affects schedule screen on tablets when search screen is open.
  + Avoid covering the search input field and search filter buttons.

# No data screens: before & after 
<img width="270" height="600" alt="no-favorites-before" src="https://github.com/user-attachments/assets/7e88c66d-5b48-4f89-b08c-90b6ae86dc4f" /> <img width="270" height="600" alt="no-favorites-after" src="https://github.com/user-attachments/assets/417f002e-d1d3-4929-b289-de745cb2f213" />
<img width="270" height="600" alt="no-alarms-before" src="https://github.com/user-attachments/assets/50f04ca3-eb3c-462f-9350-2dcebfecff64" /> <img width="270" height="600" alt="no-alarms-after" src="https://github.com/user-attachments/assets/48ec6ffd-f643-4d06-996a-69450c432708" />
<img width="270" height="600" alt="no-search-before" src="https://github.com/user-attachments/assets/7f61170d-7216-458d-93c2-58f7738a87f5" /> <img width="270" height="600" alt="no-search-after" src="https://github.com/user-attachments/assets/83533837-2232-48b9-aaa2-8ec37dedae81" />

# No data search screens: before & after

https://github.com/user-attachments/assets/84e337a7-6383-430d-aa15-8f63112d8981 

https://github.com/user-attachments/assets/83f6937e-97bb-4703-8db5-12704ce7cdf8


https://github.com/user-attachments/assets/9afd5a33-ee59-467a-8772-616d86beec59

https://github.com/user-attachments/assets/0ad8d18a-0a88-47e3-b07e-4de372aacb14


# Successfully tested
with `ccc39c3` flavor, `debug` build
- :heavy_check_mark: Google Pixel 6, Android 16 (API 36)
- :heavy_check_mark: Samsung Galaxy Tab S7 FE, SM-T733 (tablet), Android 14 (API 34)